### PR TITLE
storage: introduce add_measures_batch for Ceph

### DIFF
--- a/gnocchi/rest/__init__.py
+++ b/gnocchi/rest/__init__.py
@@ -18,7 +18,6 @@ import functools
 import itertools
 import uuid
 
-from concurrent import futures
 import jsonpatch
 from oslo_utils import dictutils
 from oslo_utils import strutils
@@ -162,8 +161,6 @@ RESOURCE_DEFAULT_PAGINATION = ['revision_start:asc',
                                'started_at:asc']
 
 METRIC_DEFAULT_PAGINATION = ['id:asc']
-
-THREADS = utils.get_default_workers()
 
 
 def get_pagination_options(params, default):
@@ -1422,12 +1419,10 @@ class ResourcesMetricsMeasuresBatchController(rest.RestController):
         for metric in known_metrics:
             enforce("post measures", metric)
 
-        storage = pecan.request.storage.incoming
-        with futures.ThreadPoolExecutor(max_workers=THREADS) as executor:
-            list(executor.map(lambda x: storage.add_measures(*x),
-                              ((metric,
-                                body_by_rid[metric.resource_id][metric.name])
-                               for metric in known_metrics)))
+        pecan.request.storage.incoming.add_measures_batch(
+            dict((metric,
+                 body_by_rid[metric.resource_id][metric.name])
+                 for metric in known_metrics))
 
         pecan.response.status = 202
 
@@ -1456,11 +1451,9 @@ class MetricsMeasuresBatchController(rest.RestController):
         for metric in metrics:
             enforce("post measures", metric)
 
-        storage = pecan.request.storage.incoming
-        with futures.ThreadPoolExecutor(max_workers=THREADS) as executor:
-            list(executor.map(lambda x: storage.add_measures(*x),
-                              ((metric, body[metric.id]) for metric in
-                               metrics)))
+        pecan.request.storage.incoming.add_measures_batch(
+            dict((metric, body[metric.id]) for metric in
+                 metrics))
 
         pecan.response.status = 202
 

--- a/gnocchi/storage/incoming/__init__.py
+++ b/gnocchi/storage/incoming/__init__.py
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 #
+# Copyright © 2017 Red Hat, Inc.
 # Copyright © 2014-2015 eNovance
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -33,16 +34,23 @@ class StorageDriver(object):
     def upgrade(indexer):
         pass
 
-    @staticmethod
-    def add_measures(metric, measures):
+    def add_measures(self, metric, measures):
         """Add a measure to a metric.
 
         :param metric: The metric measured.
         :param measures: The actual measures.
         """
-        raise exceptions.NotImplementedError
+        self.add_measures_batch({metric: measures})
 
     @staticmethod
+    def add_measures_batch(metrics_and_measures):
+        """Add a batch of measures for some metrics.
+
+        :param metrics_and_measures: A dict where keys
+        are metrics and value are measure.
+        """
+        raise exceptions.NotImplementedError
+
     def measures_report(details=True):
         """Return a report of pending to process measures.
 

--- a/gnocchi/storage/incoming/_carbonara.py
+++ b/gnocchi/storage/incoming/_carbonara.py
@@ -14,17 +14,21 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+from concurrent import futures
 import itertools
 import struct
 
 from oslo_log import log
 from oslo_serialization import msgpackutils
 import pandas
-import six.moves
+import six
 
 from gnocchi.storage import incoming
+from gnocchi import utils
 
 LOG = log.getLogger(__name__)
+
+_NUM_WORKERS = utils.get_default_workers()
 
 
 class CarbonaraBasedStorage(incoming.StorageDriver):
@@ -50,12 +54,19 @@ class CarbonaraBasedStorage(incoming.StorageDriver):
             pandas.to_datetime(measures[::2], unit='ns'),
             itertools.islice(measures, 1, len(measures), 2))
 
-    def add_measures(self, metric, measures):
+    def _encode_measures(self, measures):
         measures = list(measures)
-        data = struct.pack(
+        return struct.pack(
             "<" + self._MEASURE_SERIAL_FORMAT * len(measures),
             *list(itertools.chain.from_iterable(measures)))
-        self._store_new_measures(metric, data)
+
+    def add_measures_batch(self, metrics_and_measures):
+        with futures.ThreadPoolExecutor(max_workers=_NUM_WORKERS) as executor:
+            list(executor.map(
+                lambda args: self._store_new_measures(*args),
+                ((metric, self._encode_measures(measures))
+                 for metric, measures
+                 in six.iteritems(metrics_and_measures))))
 
     @staticmethod
     def _store_new_measures(metric, data):

--- a/gnocchi/storage/incoming/ceph.py
+++ b/gnocchi/storage/incoming/ceph.py
@@ -19,6 +19,7 @@ import functools
 import itertools
 import uuid
 
+import six
 
 from gnocchi.storage.common import ceph
 from gnocchi.storage.incoming import _carbonara
@@ -72,23 +73,26 @@ class CephStorage(_carbonara.CarbonaraBasedStorage):
         for xattr in xattrs:
             self.ioctx.rm_xattr(self.MEASURE_PREFIX, xattr)
 
-    def _store_new_measures(self, metric, data):
-        # NOTE(sileht): list all objects in a pool is too slow with
-        # many objects (2min for 20000 objects in 50osds cluster),
-        # and enforce us to iterrate over all objects
-        # So we create an object MEASURE_PREFIX, that have as
-        # omap the list of objects to process (not xattr because
-        # it doesn't allow to configure the locking behavior)
-        name = "_".join((
-            self.MEASURE_PREFIX,
-            str(metric.id),
-            str(uuid.uuid4()),
-            datetime.datetime.utcnow().strftime("%Y%m%d_%H:%M:%S")))
-
-        self.ioctx.write_full(name, data)
+    def add_measures_batch(self, metrics_and_measures):
+        names = []
+        for metric, measures in six.iteritems(metrics_and_measures):
+            name = "_".join((
+                self.MEASURE_PREFIX,
+                str(metric.id),
+                str(uuid.uuid4()),
+                datetime.datetime.utcnow().strftime("%Y%m%d_%H:%M:%S")))
+            names.append(name)
+            data = self._encode_measures(measures)
+            self.ioctx.write_full(name, data)
 
         with rados.WriteOpCtx() as op:
-            self.ioctx.set_omap(op, (name,), (b"",))
+            # NOTE(sileht): list all objects in a pool is too slow with
+            # many objects (2min for 20000 objects in 50osds cluster),
+            # and enforce us to iterrate over all objects
+            # So we create an object MEASURE_PREFIX, that have as
+            # omap the list of objects to process (not xattr because
+            # it doesn't # allow to configure the locking behavior)
+            self.ioctx.set_omap(op, tuple(names), (b"",) * len(names))
             self.ioctx.operate_write_op(op, self.MEASURE_PREFIX,
                                         flags=self.OMAP_WRITE_FLAGS)
 


### PR DESCRIPTION
This replaces the thread based approach with a faster write operation for the
driver that will support it.
This seems to improve performance by a large magnitude.

(cherry picked from commit d9d472ed70e327f8affeefbd26135e1db2df376c)