### PR TITLE
doc: add where to find source code

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -27,6 +27,7 @@ Community
 ---------
 You can join Gnocchi's community via the following channels:
 
+- Source code: https://github.com/gnocchixyz/gnocchi
 - Bug tracker: https://github.com/gnocchixyz/gnocchi/issues
 - IRC: #gnocchi on `Freenode <https://freenode.net>`_
 


### PR DESCRIPTION
This seems obvious but we never wrote it anywhere.