### PR TITLE
retry to get block on error

### DIFF
--- a/gnocchi/cli.py
+++ b/gnocchi/cli.py
@@ -153,9 +153,11 @@ class MetricScheduler(MetricProcessBase):
         self.block_index = 0
         self.block_size_default = self.workers * self.TASKS_PER_WORKER
         self.block_size = self.block_size_default
+        self.block_synced = False
         self.periodic = None
 
     def set_block(self, event):
+        self.block_synced = False
         get_members_req = self._coord.get_members(self.GROUP_ID)
         try:
             members = sorted(get_members_req.get())
@@ -166,11 +168,13 @@ class MetricScheduler(MetricProcessBase):
                 cap = msgpack.loads(req.get(), encoding='utf-8')
                 max_workers = max(cap['workers'], self.workers)
             self.block_size = max_workers * self.TASKS_PER_WORKER
+            self.block_synced = True
             LOG.info('New set of agents detected. Now working on block: %s, '
                      'with up to %s metrics', self.block_index,
                      self.block_size)
         except Exception:
-            LOG.warning('Error getting block to work on, defaulting to first')
+            LOG.error('Error getting block to work on (%s), '
+                      'defaulting to first', exc_info=True)
             self.block_index = 0
             self.block_size = self.block_size_default
 
@@ -186,7 +190,9 @@ class MetricScheduler(MetricProcessBase):
 
             @periodics.periodic(spacing=self.SYNC_RATE, run_immediately=True)
             def run_watchers():
-                self._coord.run_watchers()
+                done = self._coord.run_watchers()
+                if not done and not self.block_synced:
+                    self.set_block(None)
 
             self.periodic = periodics.PeriodicWorker.create([])
             self.periodic.add(run_watchers)


### PR DESCRIPTION
When something wrong occurs in coordinator callback we just print a
warning for deployer.But we should also print the root cause and
retry later to get the correct block_size. Otherwise the worker
will never work on its block and an entire will never been processed.

This change tracks the correctness of the block_size and retries if
this one not synced.

This change can't be backported, because on master this code is gone.

Change-Id: Id3fc343cb1556b94af501344a8b016618cbebce3