### PR TITLE
ceph: simplify reporting

### DIFF
--- a/gnocchi/storage/incoming/ceph.py
+++ b/gnocchi/storage/incoming/ceph.py
@@ -107,6 +107,10 @@ class CephStorage(_carbonara.CarbonaraBasedStorage):
             op.wait_for_complete()
 
     def _build_report(self, details):
+        def inc_details(details, metric):
+            details[metric] += 1
+
+        build_metric_details = inc_details if details else lambda x, y: None
         metrics = set()
         count = 0
         metric_details = defaultdict(int)
@@ -122,8 +126,7 @@ class CephStorage(_carbonara.CarbonaraBasedStorage):
                     count += 1
                     metric = name.split("_")[1]
                     metrics.add(metric)
-                    if details:
-                        metric_details[metric] += 1
+                    build_metric_details(metric_details, metric)
                 if len(names) < self.Q_LIMIT:
                     break
                 else:


### PR DESCRIPTION
backlog is not grouped by common metric keys so it can have hundreds
of thousands to millions of keys to loop through. we shouldn't waste
time by checking details millions of times.