### PR TITLE
reduce memory for slim report

### DIFF
--- a/gnocchi/storage/incoming/s3.py
+++ b/gnocchi/storage/incoming/s3.py
@@ -98,7 +98,6 @@ class S3Storage(_carbonara.CarbonaraBasedStorage):
             response = self.s3.list_objects_v2(
                 Bucket=self._bucket_name_measures,
                 **kwargs)
-            # FIXME(gordc): this can be streamlined if not details
             for c in response.get('Contents', ()):
                 if c['Key'] != self.CFG_PREFIX:
                     __, metric, metric_file = c['Key'].split("/", 2)


### PR DESCRIPTION
- don't store all metrics and counts in memory if not building detailed
report.
- leverage pipelines in redis
- remove s3 FIXME since i don't think it's true.