### PR TITLE
archive_policy: Raise Error if calculated points is < 0

### DIFF
--- a/gnocchi/archive_policy.py
+++ b/gnocchi/archive_policy.py
@@ -176,6 +176,8 @@ class ArchivePolicyItem(dict):
                 self['timespan'] = None
             else:
                 points = int(timespan / granularity)
+                if points <= 0:
+                    raise ValueError("Calculated number of points is < 0")
                 self['timespan'] = granularity * points
         else:
             points = int(points)

--- a/gnocchi/tests/gabbi/gabbits/archive.yaml
+++ b/gnocchi/tests/gabbi/gabbits/archive.yaml
@@ -480,6 +480,18 @@ tests:
                 timespan: "1 shenanigan"
       status: 400
 
+    - name: create policy when granularity is larger than timespan
+      POST: /v1/archive_policy
+      request_headers:
+          content-type: application/json
+          x-roles: admin
+      data:
+          name: should-have-failed
+          definition:
+              - granularity: 2 hour
+                timespan: 1 hour
+      status: 400
+
 # Non admin user attempt
 
     - name: fail to create policy non-admin

--- a/gnocchi/tests/test_archive_policy.py
+++ b/gnocchi/tests/test_archive_policy.py
@@ -96,3 +96,6 @@ class TestArchivePolicyItem(base.BaseTestCase):
         self.assertRaises(ValueError,
                           archive_policy.ArchivePolicyItem,
                           1, -1)
+        self.assertRaises(ValueError,
+                          archive_policy.ArchivePolicyItem,
+                          2, None, 1)


### PR DESCRIPTION
Backport of archive_policy: Raise Error if calculated points is < 0 for stable/3.0