### PR TITLE
don't load indexer in reporting process

### DIFF
--- a/gnocchi/cli.py
+++ b/gnocchi/cli.py
@@ -146,6 +146,9 @@ class MetricReporting(MetricProcessBase):
         super(MetricReporting, self).__init__(
             worker_id, conf, conf.metricd.metric_reporting_delay)
 
+    def _configure(self):
+        self.store = storage.get_driver(self.conf)
+
     def _run_job(self):
         try:
             report = self.store.incoming.measures_report(details=False)


### PR DESCRIPTION
we don't need access to indexer to build report. skip loading
indexer to save memory and connection.