### PR TITLE
Remove catching of non existent ArchivePolicyInUse exception

### DIFF
--- a/gnocchi/rest/__init__.py
+++ b/gnocchi/rest/__init__.py
@@ -355,8 +355,6 @@ class ArchivePolicyRulesController(rest.RestController):
             pecan.request.indexer.delete_archive_policy_rule(name)
         except indexer.NoSuchArchivePolicyRule as e:
             abort(404, e)
-        except indexer.ArchivePolicyRuleInUse as e:
-            abort(400, e)
 
 
 def MeasuresListSchema(measures):


### PR DESCRIPTION
A non existent `ArchivePolicyRuleInUse` exception is catched when deleting an archive policy rule in the `ArchivePolicyRulesController` controller:

```python
    @pecan.expose()
    def delete(self, name):
        # NOTE(jd) I don't think there's any point in fetching and passing the
        # archive policy rule here, as the rule is probably checking the actual
        # role of the user, not the content of the AP rule.
        enforce("delete archive policy rule", {})
        try:
            pecan.request.indexer.delete_archive_policy_rule(name)
        except indexer.NoSuchArchivePolicyRule as e:
            abort(404, e)
        except indexer.ArchivePolicyRuleInUse as e:
            abort(400, e)
```

This PR adds this missing exception.