### PR TITLE
drop unused clean

### DIFF
--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -188,12 +188,8 @@ class TimeSerie(object):
         return ts
 
     @classmethod
-    def from_data(cls, timestamps=None, values=None, clean=False):
-        ts = pandas.Series(values, timestamps)
-        if clean:
-            # For format v2
-            ts = cls.clean_ts(ts)
-        return cls(ts)
+    def from_data(cls, timestamps=None, values=None):
+        return cls(pandas.Series(values, timestamps))
 
     @classmethod
     def from_tuples(cls, timestamps_values):


### PR DESCRIPTION
we only needed to clean v2 objects because it was msgpack serialised
dict.

see commit: 5596bdea4848d0594990a5adde74045637e69431