### PR TITLE
storage: fix resample on empty metric

### DIFF
--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -246,7 +246,7 @@ class TimeSerie(object):
         # NOTE(jd) Our whole serialization system is based on Epoch, and we
         # store unsigned integer, so we can't store anything before Epoch.
         # Sorry!
-        if self.ts.index[0].value < 0:
+        if not self.ts.empty and self.ts.index[0].value < 0:
             raise BeforeEpochError(self.ts.index[0])
 
         return GroupedTimeSeries(self.ts[start:], granularity)

--- a/gnocchi/tests/functional/gabbits/resource-aggregation.yaml
+++ b/gnocchi/tests/functional/gabbits/resource-aggregation.yaml
@@ -43,6 +43,22 @@ tests:
           value: 12
       status: 202
 
+    - name: get aggregation with no data
+      desc: https://github.com/gnocchixyz/gnocchi/issues/69
+      POST: /v1/aggregation/resource/generic/metric/cpu.util?stop=2012-03-06T00:00:00&fill=0&granularity=300&resample=3600
+      request_headers:
+        x-user-id: 6c865dd0-7945-4e08-8b27-d0d7f1c2b667
+        x-project-id: c7f32f1f-c5ef-427a-8ecd-915b219c66e8
+        content-type: application/json
+      data:
+        =:
+          id: 4ed9c196-4c9f-4ba8-a5be-c9a71a82aac4
+      poll:
+        count: 10
+        delay: 1
+      response_json_paths:
+        $: []
+
     - name: create resource 2
       POST: /v1/resource/generic
       request_headers:

--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -960,6 +960,16 @@ class TestStorageDriver(tests_base.TestCase):
             (utils.datetime_utc(2014, 1, 1, 12, 0, 15), 5.0, 1.0),
         ], self.storage.get_measures(m))
 
+    def test_resample_no_metric(self):
+        """https://github.com/gnocchixyz/gnocchi/issues/69"""
+        self.assertEqual([],
+                         self.storage.get_measures(
+                             self.metric,
+                             utils.datetime_utc(2014, 1, 1),
+                             utils.datetime_utc(2015, 1, 1),
+                             granularity=300,
+                             resample=3600))
+
 
 class TestMeasureQuery(base.BaseTestCase):
     def test_equal(self):


### PR DESCRIPTION
If a metric is empty, carbonara raises an IndexError when checking for the data
on grouping since the Pandas timeseries is empty.

Fixes #69