### PR TITLE
append rather than combine_first

### DIFF
--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -551,9 +551,11 @@ class AggregatedTimeSerie(TimeSerie):
     @classmethod
     def from_timeseries(cls, timeseries, sampling, aggregation_method,
                         max_size=None):
-        ts = pandas.Series()
-        for t in timeseries:
-            ts = ts.combine_first(t.ts)
+        # NOTE(gordc): Indices must be unique across all timeseries. Also,
+        # timeseries should be a list that is ordered within list and series.
+        ts = (timeseries[0].ts.append([t.ts for t in timeseries[1:]])
+              if timeseries else None)
+
         return cls(sampling=sampling,
                    aggregation_method=aggregation_method,
                    ts=ts, max_size=max_size)

--- a/gnocchi/storage/_carbonara.py
+++ b/gnocchi/storage/_carbonara.py
@@ -200,15 +200,15 @@ class CarbonaraBasedStorage(storage.StorageDriver):
                 carbonara.SplitKey.from_timestamp_and_sampling(
                     to_timestamp, granularity))
 
-        timeseries = filter(
+        timeseries = list(filter(
             lambda x: x is not None,
             self._map_in_thread(
                 self._get_measures_and_unserialize,
                 ((metric, key, aggregation, granularity)
-                 for key in all_keys
+                 for key in sorted(all_keys)
                  if ((not from_timestamp or key >= from_timestamp)
                      and (not to_timestamp or key <= to_timestamp))))
-        )
+        ))
 
         return carbonara.AggregatedTimeSerie.from_timeseries(
             sampling=granularity,


### PR DESCRIPTION
when getting measures spanning multiple object, we currently use
combine_first. we shouldn't need to use combine_first since there
should not be any overlap in indices across measures in object.
because of that we should be able to use append which is faster
because it doesn't need to verify as much.

benchmark combining 5K points is ~7x faster:

timeit.timeit("asdf=ts.combine_first(ts2);asdf=asdf.combine_first(ts3)",
              number=1000)
1.601928949356079

timeit.timeit("asdf=ts.append([ts3,ts2])", number=1000)
0.2242450714111328

i'm not not initialising a new Series to work on because it adds
significant overhead

timeit.timeit("asdf=pd.Series();asdf=asdf.combine_first(ts);
              asdf=asdf.combine_first(ts2);asdf=asdf.combine_first(ts3)",
              number=1000)
5.4795918464660645