### PR TITLE
storage: fix resample on empty metric

### DIFF
--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -159,7 +159,7 @@ class TimeSerie(object):
         # NOTE(jd) Our whole serialization system is based on Epoch, and we
         # store unsigned integer, so we can't store anything before Epoch.
         # Sorry!
-        if self.ts.index[0].value < 0:
+        if not self.ts.empty and self.ts.index[0].value < 0:
             raise BeforeEpochError(self.ts.index[0])
         return self.ts[start:].groupby(functools.partial(
             round_timestamp, freq=granularity * 10e8))


### PR DESCRIPTION
If a metric is empty, carbonara raises an IndexError when checking for the data
on grouping since the Pandas timeseries is empty.

Fixes #69

(cherry picked from commit 5fb48769440cc405d375d7721fecf82e0dd5610f)