### PR TITLE
sqlalchemy: be explicit about the PostgreSQL driver

### DIFF
--- a/gnocchi/indexer/sqlalchemy.py
+++ b/gnocchi/indexer/sqlalchemy.py
@@ -275,6 +275,10 @@ class SQLAlchemyIndexer(indexer.IndexerDriver):
             url = sqlalchemy_url.make_url(url)
             url.drivername = "mysql+pymysql"
             return str(url)
+        if url.startswith("postgresql://"):
+            url = sqlalchemy_url.make_url(url)
+            url.drivername = "postgresql+psycopg2"
+            return str(url)
         return url
 
     def __init__(self, conf):

--- a/setup.cfg
+++ b/setup.cfg
@@ -120,6 +120,7 @@ gnocchi.indexer =
     mysql = gnocchi.indexer.sqlalchemy:SQLAlchemyIndexer
     mysql+pymysql = gnocchi.indexer.sqlalchemy:SQLAlchemyIndexer
     postgresql = gnocchi.indexer.sqlalchemy:SQLAlchemyIndexer
+    postgresql+psycopg2 = gnocchi.indexer.sqlalchemy:SQLAlchemyIndexer
 
 gnocchi.aggregates =
     moving-average = gnocchi.aggregates.moving_stats:MovingAverage


### PR DESCRIPTION
SQLAlchemy now logs a warning if the driver is not correctly set in the URL.

Fixes #56