### PR TITLE
Remove useless debug message

### DIFF
--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -176,7 +176,6 @@ class StorageDriver(object):
                      on error
         :type sync: bool
         """
-        LOG.debug("Processing new measures")
         try:
             self.process_new_measures(index, metrics, sync)
         except Exception:


### PR DESCRIPTION
This is always printed even if nothing have to done:

http://logs.openstack.org/44/468844/17/gate/gate-telemetry-dsvm-integration-ceilometer-ubuntu-xenial/8f54c0e/logs/screen-gnocchi-metricd.txt.gz#_Jun_06_09_09_09_101487

Also we have something to do, we already print another more usefull
message:

"Processing measures for b03bed59-d1da-4db0-b9bf-adff3766d2a9"