### PR TITLE
travis: fetch all refs for docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,13 @@ before_script:
   # Travis We need to fetch all tags/branches for documentation target
   - case $TARGET in
       docs*)
-        git config --add remote.origin.fetch +refs/heads/stable/*:refs/remotes/origin/stable/*;
+        git config --get-all remote.origin.fetch;
+        git config --unset-all remote.origin.fetch;
+        git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/*;
+        git config --get-all remote.origin.fetch;
         git fetch --unshallow --tags;
         ;;
     esac
-  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then git pull --rebase ; fi'
   - docker build --tag gnocchi-ci --file=tools/travis-ci-setup.dockerfile .
 script:
   - docker run -v ~/.cache/pip:/home/tester/.cache/pip -v $(pwd):/home/tester/src gnocchi-ci tox -e ${TARGET}


### PR DESCRIPTION
Since 464cfc9f8469fc7cea4d6987603775009f6cab16 we change the fetcher
configuration to build the doc of stable branch from master.

But that doesn't work when we build the doc from stable branch.

This change should fix that by fetching all refs.