### PR TITLE
tox: add missing redis dep for functional tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,10 @@ setenv =
     s3: GNOCCHI_TEST_TARBALLS=
     redis: GNOCCHI_TEST_TARBALLS=
     file: GNOCCHI_TEST_TARBALLS=
-deps = .[test]
+# NOTE(jd) Install redis as a test dependency since it is used as a
+# coordination driver in functional tests (--coordination-driver is passed to
+# pifpaf)
+deps = .[test,redis]
    postgresql: .[postgresql,{env:GNOCCHI_STORAGE_DEPS}]
    mysql: .[mysql,{env:GNOCCHI_STORAGE_DEPS}]
    {env:GNOCCHI_TEST_TARBALLS:}


### PR DESCRIPTION
Install redis as a test dependency since it is used as a coordination driver in
functional tests (--coordination-driver is passed to pifpaf).