### PR TITLE
travis: remove install step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ before_script:
         ;;
     esac
   - docker build --tag gnocchi-ci --file=tools/travis-ci-setup.dockerfile .
+install:
 script:
   - docker run -v ~/.cache/pip:/home/tester/.cache/pip -v $(pwd):/home/tester/src gnocchi-ci tox -e ${TARGET}
 


### PR DESCRIPTION
The standard Travis procedure installs what's in requirements.txt whereas we
don't care. Let's win a few seconds by doing… nothing instead.