### PR TITLE
Remove gnocchi-config-generator from tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,6 @@ deps = .[test,redis,{env:GNOCCHI_STORAGE_DEPS:},{env:GNOCCHI_INDEXER_DEPS:}]
    {env:GNOCCHI_TEST_TARBALLS:}
 commands =
     doc8 --ignore-path doc/source/rest.rst doc/source
-    gnocchi-config-generator
     {toxinidir}/run-tests.sh {posargs}
     {toxinidir}/run-func-tests.sh {posargs}
 


### PR DESCRIPTION
It's already launched and tested by gnocchi.tests.test_bin, and the current
runs output the logfile to stdout which pollutes test output.