### PR TITLE
Install pifpaf with ceph extra

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ doc =
     Jinja2
     reno>=1.6.2
 test =
-    pifpaf>=1.0.1
+    pifpaf[ceph]>=1.0.1
     gabbi>=1.30.0
     coverage>=3.6
     fixtures

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ setenv = GNOCCHI_VARIANT=test,mysql,ceph,ceph_recommended_lib
 deps = gnocchi[{env:GNOCCHI_VARIANT}]>=3.1,<3.2
   alembic<0.9.0
   gnocchiclient>=2.8.0
-  pifpaf>=0.13
+  pifpaf[ceph]>=0.13
 commands = pifpaf --env-prefix INDEXER run mysql -- pifpaf --env-prefix STORAGE run ceph {toxinidir}/run-upgrade-tests.sh {posargs}
 
 [testenv:bashate]


### PR DESCRIPTION
Some extra dependency in pifpaf are now set as flavors, such as ceph.