### PR TITLE
Remove oslotest dependency

### DIFF
--- a/.testr.conf
+++ b/.testr.conf
@@ -1,5 +1,5 @@
 [DEFAULT]
-test_command=OS_STDOUT_CAPTURE=${OS_STDOUT_CAPTURE:-1} OS_STDERR_CAPTURE=${OS_STDERR_CAPTURE:-1} OS_TEST_TIMEOUT=${OS_TEST_TIMEOUT:-60} ${PYTHON:-python} -m subunit.run discover -t . ${OS_TEST_PATH:-gnocchi/tests} $LISTOPT $IDOPTION
+test_command=${PYTHON:-python} -m subunit.run discover -t .  ${GNOCCHI_TEST_PATH:-gnocchi/tests} $LISTOPT $IDOPTION
 test_id_option=--load-list $IDFILE
 test_list_option=--list
 group_regex=(gabbi\.suitemaker\.test_gabbi((_live_|_)([^_]+)))_

--- a/gnocchi/tests/indexer/sqlalchemy/test_migrations.py
+++ b/gnocchi/tests/indexer/sqlalchemy/test_migrations.py
@@ -37,11 +37,9 @@ class ModelsMigrationsSync(
                            base.TestCase,
                            test_migrations.ModelsMigrationsSync)):
 
-    def _set_timeout(self):
-        self.useFixture(fixtures.Timeout(120, gentle=True))
-
     def setUp(self):
         super(ModelsMigrationsSync, self).setUp()
+        self.useFixture(fixtures.Timeout(120, gentle=True))
         self.db = mock.Mock()
         self.conf.set_override(
             'url',

--- a/gnocchi/tests/test_archive_policy.py
+++ b/gnocchi/tests/test_archive_policy.py
@@ -11,10 +11,9 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from oslotest import base
-
 from gnocchi import archive_policy
 from gnocchi import service
+from gnocchi.tests import base
 
 
 class TestArchivePolicy(base.BaseTestCase):

--- a/gnocchi/tests/test_bin.py
+++ b/gnocchi/tests/test_bin.py
@@ -15,7 +15,7 @@
 # under the License.
 import subprocess
 
-from oslotest import base
+from gnocchi.tests import base
 
 
 class BinTestCase(base.BaseTestCase):

--- a/gnocchi/tests/test_carbonara.py
+++ b/gnocchi/tests/test_carbonara.py
@@ -19,11 +19,11 @@ import math
 
 import fixtures
 import iso8601
-from oslotest import base
 import pandas
 import six
 
 from gnocchi import carbonara
+from gnocchi.tests import base
 
 
 class TestBoundTimeSerie(base.BaseTestCase):

--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -18,7 +18,6 @@ import uuid
 
 import iso8601
 import mock
-from oslotest import base
 import six.moves
 
 from gnocchi import archive_policy
@@ -971,7 +970,7 @@ class TestStorageDriver(tests_base.TestCase):
                              resample=3600))
 
 
-class TestMeasureQuery(base.BaseTestCase):
+class TestMeasureQuery(tests_base.TestCase):
     def test_equal(self):
         q = storage.MeasureQuery({"=": 4})
         self.assertTrue(q(4))

--- a/run-func-tests.sh
+++ b/run-func-tests.sh
@@ -44,7 +44,7 @@ for storage in ${GNOCCHI_TEST_STORAGE_DRIVERS}; do
 
         export GNOCCHI_SERVICE_TOKEN="" # Just make gabbi happy
         export GNOCCHI_AUTHORIZATION="basic YWRtaW46" # admin in base64
-        export OS_TEST_PATH=gnocchi/tests/functional_live
+        export GNOCCHI_TEST_PATH=gnocchi/tests/functional_live
         pifpaf -e GNOCCHI run gnocchi --indexer-url $INDEXER_URL --storage-url $STORAGE_URL --coordination-driver redis -- ./tools/pretty_tox.sh $*
 
         cleanup

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,6 @@ test =
     coverage>=3.6
     fixtures
     mock
-    oslotest
     python-subunit>=0.0.18
     os-testr
     testrepository

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py{35,27}-{postgresql,mysql}{,-file,-swift,-ceph,-s3},pep8
 [testenv]
 usedevelop = True
 sitepackages = False
-passenv = LANG OS_DEBUG OS_TEST_TIMEOUT OS_STDOUT_CAPTURE OS_STDERR_CAPTURE OS_LOG_CAPTURE GNOCCHI_TEST_* AWS_*
+passenv = LANG GNOCCHI_TEST_* AWS_*
 setenv =
     GNOCCHI_TEST_STORAGE_DRIVER=file
     GNOCCHI_TEST_INDEXER_DRIVER=postgresql
@@ -85,7 +85,7 @@ commands = flake8
            bashate -v devstack/plugin.sh
 
 [testenv:py27-gate]
-setenv = OS_TEST_PATH=gnocchi/tests/functional_live
+setenv = GNOCCHI_TEST_PATH=gnocchi/tests/functional_live
          GABBI_LIVE=1
 passenv = {[testenv]passenv} GNOCCHI_SERVICE* GNOCCHI_AUTHORIZATION
 sitepackages = True
@@ -95,7 +95,7 @@ commands = {toxinidir}/tools/pretty_tox.sh '{posargs}'
 # This target provides a shortcut to running just the gabbi tests.
 [testenv:py27-gabbi]
 deps = .[test,postgresql,file]
-setenv = OS_TEST_PATH=gnocchi/tests/functional
+setenv = GNOCCHI_TEST_PATH=gnocchi/tests/functional
 basepython = python2.7
 commands = pifpaf -g GNOCCHI_INDEXER_URL run postgresql -- {toxinidir}/tools/pretty_tox.sh '{posargs}'
 


### PR DESCRIPTION
Oslotest is OpenStack specific and we actually don't use any of its feature
except stdout redirection and log silencing, which is really provided by
`fixtures' and `daiquiri'.
Remove it and use testtools directly. This avoids having OS_* variables used
everywhere and makes sure we don't pull dependencies we don't need (mox3,
os-client-config, etc).