### PR TITLE
batch GET metric interface

### DIFF
--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -138,6 +138,10 @@ try to create them as long as an archive policy rule matches:
 
 {{ scenarios['post-measures-batch-named-create']['doc'] }}
 
+Multiple metrics can be retrieved in a single request and returned as
+independent series:
+
+{{ scenarios['get-measures-batch']['doc'] }}
 
 Archive Policy
 ==============

--- a/doc/source/rest.yaml
+++ b/doc/source/rest.yaml
@@ -195,6 +195,10 @@
       ]
     }
 
+- name: get-measures-batch
+  request: |
+    GET /v1/batch/metrics/measures?metric={{ scenarios['create-metric']['response'].json['id'] }}&metric={{ scenarios['create-metric-2']['response'].json['id'] }} HTTP/1.1
+
 - name: search-value-in-metric
   request: |
     POST /v1/search/metric?metric_id={{ scenarios['create-metric']['response'].json['id'] }} HTTP/1.1

--- a/gnocchi/rest/__init__.py
+++ b/gnocchi/rest/__init__.py
@@ -1497,6 +1497,65 @@ class MetricsMeasuresBatchController(rest.RestController):
 
         pecan.response.status = 202
 
+    @staticmethod
+    @pecan.expose('json')
+    def get_all(**kwargs):
+        # Check RBAC policy
+        metric_ids = arg_to_list(kwargs.get('metric', []))
+        metrics = pecan.request.indexer.list_metrics(ids=metric_ids)
+        missing_metric_ids = (set(metric_ids)
+                              - set(six.text_type(m.id) for m in metrics))
+        if missing_metric_ids:
+            abort(400, {"cause": "Unknown metrics",
+                        "detail": list(missing_metric_ids)})
+
+        for metric in metrics:
+            enforce("get metric", metric)
+
+        start = kwargs.get('start')
+        if start is not None:
+            try:
+                start = utils.to_datetime(start)
+            except Exception:
+                abort(400, "Invalid value for start")
+
+        stop = kwargs.get('stop')
+        if stop is not None:
+            try:
+                stop = utils.to_datetime(stop)
+            except Exception:
+                abort(400, "Invalid value for stop")
+
+        aggregation = kwargs.get('aggregation', 'mean')
+        if (aggregation
+           not in archive_policy.ArchivePolicy.VALID_AGGREGATION_METHODS):
+            abort(
+                400,
+                'Invalid aggregation value %s, must be one of %s'
+                % (aggregation,
+                   archive_policy.ArchivePolicy.VALID_AGGREGATION_METHODS))
+
+        granularity = kwargs.get('granularity')
+        if granularity is not None:
+            try:
+                granularity = Timespan(granularity)
+            except ValueError as e:
+                abort(400, e)
+
+        metric_batch = {}
+        try:
+            for metric in metrics:
+                measures = pecan.request.storage.get_measures(
+                    metric, start, stop, aggregation, granularity)
+                metric_batch[str(metric.id)] = [
+                    (timestamp.isoformat(), offset, v)
+                    for timestamp, offset, v in measures]
+        except (storage.GranularityDoesNotExist,
+                storage.AggregationDoesNotExist) as e:
+            abort(404, e)
+
+        return metric_batch
+
 
 class SearchController(object):
     resource = SearchResourceController()

--- a/gnocchi/tests/functional/gabbits/batch-measures.yaml
+++ b/gnocchi/tests/functional/gabbits/batch-measures.yaml
@@ -181,6 +181,100 @@ tests:
         $:
           - ["2015-03-06T14:34:12+00:00", 1.0, 12.0]
 
+    - name: get multiple metrics
+      GET: /v1/batch/metrics/measures
+      query_parameters:
+        metric:
+          - $HISTORY['list metrics'].$RESPONSE['$[0].id']
+          - $HISTORY['list metrics'].$RESPONSE['$[1].id']
+      response_json_paths:
+        $.`len`: 2
+      response_strings:
+        - "\"$HISTORY['list metrics'].$RESPONSE['$[0].id']\": [[\"2015-03-06T14:33:57+00:00\", 1.0, 43.1"
+        - "\"$HISTORY['list metrics'].$RESPONSE['$[1].id']\": [[\"2015-03-06T14:33:57+00:00\", 1.0, 43.1"
+
+    - name: get multiple metrics with start and stop
+      GET: /v1/batch/metrics/measures
+      query_parameters:
+        metric:
+          - $HISTORY['list metrics'].$RESPONSE['$[0].id']
+          - $HISTORY['list metrics'].$RESPONSE['$[1].id']
+        start: "2015-03-06T14:34:00"
+        stop: "2015-03-06T14:35:57"
+      response_json_paths:
+        $.`len`: 2
+      response_strings:
+        - "\"$HISTORY['list metrics'].$RESPONSE['$[0].id']\": [[\"2015-03-06T14:34:12+00:00\", 1.0, 12.0]]"
+        - "\"$HISTORY['list metrics'].$RESPONSE['$[1].id']\": [[\"2015-03-06T14:34:12+00:00\", 1.0, 12.0]]"
+
+    - name: get multiple metrics with granularity
+      GET: /v1/batch/metrics/measures
+      query_parameters:
+        metric:
+          - $HISTORY['list metrics'].$RESPONSE['$[0].id']
+          - $HISTORY['list metrics'].$RESPONSE['$[1].id']
+        granularity: 1.0
+      response_json_paths:
+        $.`len`: 2
+      response_strings:
+        - "\"$HISTORY['list metrics'].$RESPONSE['$[0].id']\": [[\"2015-03-06T14:33:57+00:00\", 1.0, 43.1"
+        - "\"$HISTORY['list metrics'].$RESPONSE['$[1].id']\": [[\"2015-03-06T14:33:57+00:00\", 1.0, 43.1"
+
+    - name: get multiple metrics with aggregation
+      GET: /v1/batch/metrics/measures
+      query_parameters:
+        metric:
+          - $HISTORY['list metrics'].$RESPONSE['$[0].id']
+          - $HISTORY['list metrics'].$RESPONSE['$[1].id']
+        aggregation: 'count'
+      response_json_paths:
+        $.`len`: 2
+      response_strings:
+        - "\"$HISTORY['list metrics'].$RESPONSE['$[0].id']\": [[\"2015-03-06T14:33:57+00:00\", 1.0, 1.0"
+        - "\"$HISTORY['list metrics'].$RESPONSE['$[1].id']\": [[\"2015-03-06T14:33:57+00:00\", 1.0, 1.0"
+
+    - name: get multiple metrics with no metrics
+      GET: /v1/batch/metrics/measures
+      response_json_paths:
+        {}
+
+    - name: get multiple metrics with unknown metric
+      GET: /v1/batch/metrics/measures
+      request_headers:
+        accept: application/json
+      query_parameters:
+        metric: 
+          - $HISTORY['list metrics'].$RESPONSE['$[0].id']
+          - badbadba-d63b-4cdd-be89-111111111111
+      status: 400
+      response_json_paths:
+        $.description.cause: "Unknown metrics"
+        $.description.detail[0]: "badbadba-d63b-4cdd-be89-111111111111"
+
+    - name: get multiple metrics with irrelevant aggregation
+      GET: /v1/batch/metrics/measures
+      query_parameters:
+        metric:
+          - $HISTORY['list metrics'].$RESPONSE['$[0].id']
+          - $HISTORY['list metrics'].$RESPONSE['$[1].id']
+        aggregation: 'last'
+      status: 404
+      response_strings:
+        - "Aggregation method 'last' for metric"
+        - "does not exist"
+
+    - name: get multiple metrics with irrelevant granularity
+      GET: /v1/batch/metrics/measures
+      query_parameters:
+        metric:
+          - $HISTORY['list metrics'].$RESPONSE['$[0].id']
+          - $HISTORY['list metrics'].$RESPONSE['$[1].id']
+        granularity: 12.0
+      status: 404
+      response_strings:
+        - "Granularity '12.0' for metric"
+        - "does not exist"
+
     - name: push measurements to unknown named metrics and resource with create_metrics with uuid resource id
       POST: /v1/batch/resources/metrics/measures?create_metrics=true
       request_headers:
@@ -198,7 +292,6 @@ tests:
               value: 43.1
             - timestamp: "2015-03-06T14:34:12"
               value: 12
-
       status: 400
       response_json_paths:
           $.description.cause: "Unknown resources"
@@ -230,7 +323,6 @@ tests:
               value: 43.1
             - timestamp: "2015-03-06T14:34:12"
               value: 12
-
       status: 400
       response_json_paths:
           $.description.cause: "Unknown resources"
@@ -251,7 +343,6 @@ tests:
               value: 43.1
             - timestamp: "2015-03-06T14:34:12"
               value: 12
-
       status: 400
       response_json_paths:
           $.description.cause: "Unknown resources"

--- a/releasenotes/notes/bulk-metric-get-e2b298478b679087.yaml
+++ b/releasenotes/notes/bulk-metric-get-e2b298478b679087.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Support added to accept GET requests to /v1/batch/metrics/measures to
+    retrieve multiple metrics in a single request. Metric ids should be passed
+    in as query parameters in the format
+    /v1/batch/metrics/measures?metric=uuid1&metric=uuid2. Additionally,
+    ``start``, ``stop``, ``granularity`` and ``aggregation`` parameters may be
+    passed in for additional filtering. All metrics must support the same
+    granularity and aggregation if filtering on those attributes.


### PR DESCRIPTION
support ability to get multiple metrics based on id. returns result
with format matching:

{'id1': [(timestamp, granularity, value)],
 'id2': [(timestamp, granularity, value)]}

Fixes: #87 