### PR TITLE
tests: don't use wait without pid

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -x
 set -e
+PIDS=""
 GNOCCHI_TEST_STORAGE_DRIVERS=${GNOCCHI_TEST_STORAGE_DRIVERS:-file}
 GNOCCHI_TEST_INDEXER_DRIVERS=${GNOCCHI_TEST_INDEXER_DRIVERS:-postgresql}
 for storage in ${GNOCCHI_TEST_STORAGE_DRIVERS}
@@ -7,7 +8,7 @@ do
     export GNOCCHI_TEST_STORAGE_DRIVER=$storage
     for indexer in ${GNOCCHI_TEST_INDEXER_DRIVERS}
     do
-        (
+        {
         case $GNOCCHI_TEST_STORAGE_DRIVER in
             ceph|redis)
                 pifpaf run $GNOCCHI_TEST_STORAGE_DRIVER -- pifpaf -g GNOCCHI_INDEXER_URL run $indexer -- ./tools/pretty_tox.sh $*
@@ -29,10 +30,15 @@ do
                 ;;
         esac
         # NOTE(sileht): Start all storage tests at once
-        ) &
+        } &
+        PIDS="$PIDS $!"
     done
-    # NOTE(sileht): Wait all storage tests
-    wait
+    # NOTE(sileht): Wait all storage tests, we tracks pid
+    # because wait without pid always return 0
+    for pid in $PIDS; do
+        wait $pid
+    done
+    PIDS=""
     # TODO(sileht): the output can be a mess with this
     # Create a less verbose testrun output (with dot like nose ?)
     # merge all subunit output and print it in after_script in travis


### PR DESCRIPTION
Without pid, wait always return 0.

This change tracks pids to ensure we have the return code
of the background jobs.