### PR TITLE
Pull request for sileht/ceph-log-hide

### DIFF
--- a/gnocchi/tests/base.py
+++ b/gnocchi/tests/base.py
@@ -336,8 +336,10 @@ class TestCase(BaseTestCase):
                                    'storage')
         elif self.conf.storage.driver == 'ceph':
             pool_name = uuid.uuid4().hex
-            subprocess.call("rados -c %s mkpool %s" % (
-                os.getenv("CEPH_CONF"), pool_name), shell=True)
+            with open(os.devnull, 'w') as f:
+                subprocess.call("rados -c %s mkpool %s" % (
+                    os.getenv("CEPH_CONF"), pool_name), shell=True,
+                    stdout=f, stderr=subprocess.STDOUT)
             self.conf.set_override('ceph_pool', pool_name, 'storage')
 
         # Override the bucket prefix to be unique to avoid concurrent access

--- a/gnocchi/tests/test_bin.py
+++ b/gnocchi/tests/test_bin.py
@@ -13,6 +13,7 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+import os
 import subprocess
 
 from gnocchi.tests import base
@@ -20,5 +21,6 @@ from gnocchi.tests import base
 
 class BinTestCase(base.BaseTestCase):
     def test_gnocchi_config_generator_run(self):
-        subp = subprocess.Popen(['gnocchi-config-generator'])
+        with open(os.devnull, 'w') as f:
+            subp = subprocess.Popen(['gnocchi-config-generator'], stdout=f)
         self.assertEqual(0, subp.wait())


### PR DESCRIPTION
test: don't print the whole config file
tests: hide useless rados output