### PR TITLE
Metrics: Allow to copy a metric with a different archive policy

### DIFF
--- a/gnocchi/indexer/__init__.py
+++ b/gnocchi/indexer/__init__.py
@@ -335,6 +335,10 @@ class IndexerDriver(object):
         raise exceptions.NotImplementedError
 
     @staticmethod
+    def copy_metric(id, creator, archive_policy_name, source_metric):
+        raise exceptions.NotImplementedError
+
+    @staticmethod
     def list_metrics(names=None, ids=None, details=False, status='active',
                      limit=None, marker=None, sorts=None, **kwargs):
         raise exceptions.NotImplementedError


### PR DESCRIPTION
Fixes #4

**_Still a work in progress._** 

The current approach I am using to copy a metric is to do a POST request like the following:

```http
POST v1/metric?source=67d95308-8034-4489-b9de-24b717c69c71
Content-Type: application/json

{
  "archive_policy_name": "high"
}
```

Where `source` stands for the UUID of the metric we want to copy. The request body will contain the archive policy that the metric copy will have.

Pending stuff:
- [ ] Add/update unit tests
- [ ] Add/update Gabbi tests
- [ ] Validate source and new archive policy definitions.