### PR TITLE
Install pifpaf with ceph extra

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ doc =
     Jinja2
     reno>=1.6.2
 test =
-    pifpaf>=0.12.0
+    pifpaf[ceph]>=0.12.0
     gabbi>=1.21.0
     coverage>=3.6
     fixtures

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ usedevelop = False
 setenv = GNOCCHI_VARIANT=test,mysql,ceph,ceph_recommended_lib
 deps = gnocchi[{env:GNOCCHI_VARIANT}]>=3.0,<3.1
   gnocchiclient>=2.8.0
-  pifpaf>=0.13
+  pifpaf[ceph]>=0.13
 commands = pifpaf --env-prefix INDEXER run mysql -- pifpaf --env-prefix STORAGE run ceph {toxinidir}/run-upgrade-tests.sh {posargs}
 
 [testenv:py35-postgresql-file-upgrade-from-2.2]
@@ -81,7 +81,7 @@ usedevelop = False
 setenv = GNOCCHI_VARIANT=test,mysql,ceph,ceph_recommended_lib
 deps = gnocchi[{env:GNOCCHI_VARIANT}]>=2.2,<2.3
   gnocchiclient>=2.8.0
-  pifpaf>=0.13
+  pifpaf[ceph]>=0.13
   cradox
 # cradox is required because 2.2 extra names are incorrect
 commands = pifpaf --env-prefix INDEXER run mysql -- pifpaf --env-prefix STORAGE run ceph {toxinidir}/run-upgrade-tests.sh {posargs}


### PR DESCRIPTION
Some extra dependency in pifpaf are now set as flavors, such as ceph.

(cherry picked from commit 4e8089eb77216695d69080b9e148f18d1210c7a8)