### PR TITLE
Improve indexer and storage INFO logs

### DIFF
--- a/gnocchi/indexer/sqlalchemy.py
+++ b/gnocchi/indexer/sqlalchemy.py
@@ -288,6 +288,9 @@ class SQLAlchemyIndexer(indexer.IndexerDriver):
         self.conf = conf
         self.facade = PerInstanceFacade(conf)
 
+    def __str__(self):
+        return "%s: %s" % (self.__class__.__name__, self.conf.indexer.url)
+
     def disconnect(self):
         self.facade.dispose()
 

--- a/gnocchi/storage/ceph.py
+++ b/gnocchi/storage/ceph.py
@@ -47,6 +47,10 @@ class CephStorage(_carbonara.CarbonaraBasedStorage):
         super(CephStorage, self).__init__(conf, incoming, coord)
         self.rados, self.ioctx = ceph.create_rados_connection(conf)
 
+    def __str__(self):
+        # Use cluster ID for now
+        return "%s: %s" % (self.__class__.__name__, self.rados.get_fsid())
+
     def stop(self):
         ceph.close_rados_connection(self.rados, self.ioctx)
         super(CephStorage, self).stop()

--- a/gnocchi/storage/file.py
+++ b/gnocchi/storage/file.py
@@ -42,6 +42,9 @@ class FileStorage(_carbonara.CarbonaraBasedStorage):
         self.basepath_tmp = os.path.join(self.basepath, 'tmp')
         utils.ensure_paths([self.basepath_tmp])
 
+    def __str__(self):
+        return "%s: %s" % (self.__class__.__name__, str(self.basepath))
+
     def _atomic_file_store(self, dest, data):
         tmpfile = tempfile.NamedTemporaryFile(
             prefix='gnocchi', dir=self.basepath_tmp,

--- a/gnocchi/storage/redis.py
+++ b/gnocchi/storage/redis.py
@@ -37,6 +37,9 @@ class RedisStorage(_carbonara.CarbonaraBasedStorage):
         super(RedisStorage, self).__init__(conf, incoming, coord)
         self._client = redis.get_client(conf)
 
+    def __str__(self):
+        return "%s: %s" % (self.__class__.__name__, self._client)
+
     def _metric_key(self, metric):
         return redis.SEP.join([self.STORAGE_PREFIX, str(metric.id)])
 

--- a/gnocchi/storage/s3.py
+++ b/gnocchi/storage/s3.py
@@ -75,6 +75,9 @@ class S3Storage(_carbonara.CarbonaraBasedStorage):
         else:
             self._consistency_stop = None
 
+    def __str__(self):
+        return "%s: %s" % (self.__class__.__name__, self._bucket_name)
+
     def upgrade(self, num_sacks):
         super(S3Storage, self).upgrade(num_sacks)
         try:

--- a/gnocchi/storage/swift.py
+++ b/gnocchi/storage/swift.py
@@ -73,6 +73,9 @@ class SwiftStorage(_carbonara.CarbonaraBasedStorage):
         self.swift = swift.get_connection(conf)
         self._container_prefix = conf.swift_container_prefix
 
+    def __str__(self):
+        return "%s: %s" % (self.__class__.__name__, self._container_prefix)
+
     def _container_name(self, metric):
         return '%s.%s' % (self._container_prefix, str(metric.id))
 

--- a/gnocchi/tests/test_indexer.py
+++ b/gnocchi/tests/test_indexer.py
@@ -37,6 +37,10 @@ class TestIndexer(tests_base.TestCase):
 
 class TestIndexerDriver(tests_base.TestCase):
 
+    def test_str(self):
+        self.assertEqual("%s: %s" % (self.index.__class__.__name__,
+                         self.conf.indexer.url), str(self.index))
+
     def test_create_archive_policy_already_exists(self):
         # NOTE(jd) This archive policy
         # is created by gnocchi.tests on setUp() :)

--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -25,6 +25,11 @@ from gnocchi import carbonara
 from gnocchi import indexer
 from gnocchi import storage
 from gnocchi.storage import _carbonara
+from gnocchi.storage import ceph
+from gnocchi.storage import file
+from gnocchi.storage import redis
+from gnocchi.storage import s3
+from gnocchi.storage import swift
 from gnocchi.tests import base as tests_base
 from gnocchi.tests import utils as tests_utils
 from gnocchi import utils
@@ -42,6 +47,23 @@ class TestStorageDriver(tests_base.TestCase):
         m_sql = self.index.create_metric(m.id, str(uuid.uuid4()),
                                          archive_policy_name)
         return m, m_sql
+
+    def test_driver_str(self):
+        driver = storage.get_driver(self.conf)
+
+        if isinstance(driver, file.FileStorage):
+            s = driver.basepath
+        elif isinstance(driver, ceph.CephStorage):
+            s = driver.rados.get_fsid()
+        elif isinstance(driver, redis.RedisStorage):
+            s = driver._client
+        elif isinstance(driver, s3.S3Storage):
+            s = driver._bucket_name
+        elif isinstance(driver, swift.SwiftStorage):
+            s = driver._container_prefix
+
+        self.assertEqual(str(driver), "%s: %s" % (
+                         driver.__class__.__name__, s))
 
     def trigger_processing(self, metrics=None):
         if metrics is None:


### PR DESCRIPTION
Closes #119 

For some storage drivers I am not really sure what information would be suitable to display in the logs, since I haven't really started using them.

For the indexer and file storage I now get this message:

```
2017-06-16 09:40:05,734 [7284] INFO gnocchi.cli: Upgrading indexer SQLAlchemyIndexer: postgresql://gnocchi:gnocchi@127.0.0.1/gnocchi
2017-06-16 09:40:05,881 [7284] INFO gnocchi.cli: Upgrading storage FileStorage: /home/ubuntu/gn
```