### PR TITLE
Add upgrade directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ releasenotes/build
 cover
 .coverage
 dist
+upgrade/


### PR DESCRIPTION
This directory is created by tox when running one of the upgrade test.