### PR TITLE
cli: fix close_services() order

### DIFF
--- a/gnocchi/cli.py
+++ b/gnocchi/cli.py
@@ -133,9 +133,9 @@ class MetricProcessBase(cotyledon.Service):
 
     def terminate(self):
         self._shutdown.set()
-        self.close_services()
         LOG.info("Waiting ongoing metric processing to finish")
         self._shutdown_done.wait()
+        self.close_services()
 
     @staticmethod
     def close_services():


### PR DESCRIPTION
close_services() closes e.g. the coordinator in the MetricProcessor. But
currently it is close before the shutdown is complete, and it's possible that
the processing of metrics requires the coordinator. On shutdown, this can lead
to a backtrace such as:

Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/cotyledon/_utils.py", line 84, in exit_on_exception
    yield
  File "/usr/local/lib/python2.7/site-packages/cotyledon/_service.py", line 139, in _run
    self.run()
  File "/Users/jd/Source/gnocchi/gnocchi/cli.py", line 134, in run
    self._run_job()
  File "/Users/jd/Source/gnocchi/gnocchi/cli.py", line 242, in _run_job
    lock = in_store.get_sack_lock(self.coord, s)
  File "/Users/jd/Source/gnocchi/gnocchi/storage/incoming/_carbonara.py", line 77, in get_sack_lock
    return coord.get_lock(lock_name)
  File "/Users/jd/Source/tooz/tooz/drivers/redis.py", line 377, in get_lock
    return RedisLock(self, self._client, name, self.lock_timeout)
  File "/Users/jd/Source/tooz/tooz/drivers/redis.py", line 65, in __init__
    self._lock = client.lock(name,
AttributeError: 'NoneType' object has no attribute 'lock'

In order to fix it, make sure we close the coordinator when the MetricProcessor
has shut down.