### PR TITLE
rest: move _carbonara.SackLockTimeoutError to storage

### DIFF
--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -32,6 +32,10 @@ OPTS = [
 LOG = daiquiri.getLogger(__name__)
 
 
+class SackLockTimeoutError(Exception):
+        pass
+
+
 class Measure(object):
     def __init__(self, timestamp, value):
         self.timestamp = timestamp

--- a/gnocchi/storage/_carbonara.py
+++ b/gnocchi/storage/_carbonara.py
@@ -53,10 +53,6 @@ class CorruptionError(ValueError):
         super(CorruptionError, self).__init__(message)
 
 
-class SackLockTimeoutError(Exception):
-        pass
-
-
 class CarbonaraBasedStorage(storage.StorageDriver):
 
     def __init__(self, conf, incoming, coord=None):
@@ -361,7 +357,7 @@ class CarbonaraBasedStorage(storage.StorageDriver):
         s = self.incoming.sack_for_metric(metric.id)
         lock = self.incoming.get_sack_lock(self.coord, s)
         if not lock.acquire(blocking=timeout):
-            raise SackLockTimeoutError(
+            raise storage.SackLockTimeoutError(
                 'Unable to refresh metric: %s. Metric is locked. '
                 'Please try again.' % metric.id)
         try:


### PR DESCRIPTION
gnocchi.rest actually expects storage.SackLockTimeoutError so it currently is
not caught.