### PR TITLE
tox: don't specify envdir

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,6 @@ commands =
 [testenv:py35-postgresql-file-upgrade-from-3.1]
 # We should always recreate since the script upgrade
 # Gnocchi we can't reuse the virtualenv
-envdir = upgrade
 recreate = True
 skip_install = True
 usedevelop = False
@@ -63,7 +62,6 @@ commands = pifpaf --env-prefix INDEXER run postgresql {toxinidir}/run-upgrade-te
 [testenv:py27-mysql-ceph-upgrade-from-3.1]
 # We should always recreate since the script upgrade
 # Gnocchi we can't reuse the virtualenv
-envdir = upgrade
 recreate = True
 skip_install = True
 usedevelop = False
@@ -76,7 +74,6 @@ commands = pifpaf --env-prefix INDEXER run mysql -- pifpaf --env-prefix STORAGE 
 [testenv:py35-postgresql-file-upgrade-from-4.0]
 # We should always recreate since the script upgrade
 # Gnocchi we can't reuse the virtualenv
-envdir = upgrade
 recreate = True
 skip_install = True
 usedevelop = False
@@ -89,7 +86,6 @@ commands = pifpaf --env-prefix INDEXER run postgresql {toxinidir}/run-upgrade-te
 [testenv:py27-mysql-ceph-upgrade-from-4.0]
 # We should always recreate since the script upgrade
 # Gnocchi we can't reuse the virtualenv
-envdir = upgrade
 recreate = True
 skip_install = True
 usedevelop = False


### PR DESCRIPTION
Putting `envdir = upgrade` makes tox create an upgrade in the middle of the
source directory, which is not convenient/standard and gets scanned by e.g.
flake8. Let's each job use its own default directory.