### PR TITLE
Make gnocchi-api wrap uWSGI

### DIFF
--- a/doc/source/operating.rst
+++ b/doc/source/operating.rst
@@ -13,14 +13,15 @@ To run Gnocchi, simply run the HTTP server and metric daemon:
 Running API As A WSGI Application
 =================================
 
-The Gnocchi API tier runs using WSGI. This means it can be run using `Apache
-httpd`_ and `mod_wsgi`_, or other HTTP daemon such as `uwsgi`_. You should
-configure the number of process and threads according to the number of CPU you
-have, usually around 1.5 × number of CPU. If one server is not enough, you can
-spawn any number of new API server to scale Gnocchi out, even on different
-machines.
+To run Gnocchi API, you can use the provided `gnocchi-api`. It wraps around
+`uwsgi` – makes sure that `uwsgi`_ is installed. If one Gnocchi API server is
+not enough, you can spawn any number of new API server to scale Gnocchi out,
+even on different machines.
 
-The following uwsgi configuration file can be used::
+Since Gnocchi API tier runs using WSGI, it can alternatively be run using
+`Apache httpd`_ and `mod_wsgi`_, or any other HTTP daemon. If you want to
+deploy using `uwsgi`_ yourself, the following uwsgi configuration file can be
+used as a base::
 
   [uwsgi]
   http = localhost:8041
@@ -36,6 +37,10 @@ The following uwsgi configuration file can be used::
   plugins = python
   buffer-size = 65535
   lazy-apps = true
+  add-header = Connection: close
+
+You should configure the number of processes according to the number of CPU you
+have, usually around 1.5 × number of CPU.
 
 Once written to `/etc/gnocchi/uwsgi.ini`, it can be launched this way::
 

--- a/gnocchi/cli.py
+++ b/gnocchi/cli.py
@@ -13,6 +13,10 @@
 # implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
+from distutils import spawn
+import math
+import os
 import sys
 import threading
 import time
@@ -29,6 +33,7 @@ import tooz
 from gnocchi import archive_policy
 from gnocchi import genconfig
 from gnocchi import indexer
+from gnocchi.rest import app
 from gnocchi import service
 from gnocchi import statsd as statsd_service
 from gnocchi import storage
@@ -307,6 +312,57 @@ def metricd_tester(conf):
             break
     s.process_new_measures(
         index, list(metrics)[:conf.stop_after_processing_metrics], True)
+
+
+def api():
+    # Compat with previous pbr script
+    try:
+        double_dash = sys.argv.index("--")
+    except ValueError:
+        double_dash = None
+    else:
+        sys.argv.pop(double_dash)
+
+    conf = cfg.ConfigOpts()
+    for opt in app.API_OPTS:
+        # NOTE(jd) Register the API options without a default, so they are only
+        # used to override the one in the config file
+        c = copy.copy(opt)
+        c.default = None
+        conf.register_cli_opt(c)
+    conf = service.prepare_service(conf=conf)
+
+    if double_dash is not None:
+        # NOTE(jd) Wait to this stage to log so we're sure the logging system
+        # is in place
+        LOG.warning(
+            "No need to pass `--' in gnocchi-api command line anymore, "
+            "please remove")
+
+    uwsgi = spawn.find_executable("uwsgi")
+    if not uwsgi:
+        LOG.error("Unable to find `uwsgi'.\n"
+                  "Be sure it is installed and in $PATH.")
+        return 1
+
+    workers = utils.get_default_workers()
+
+    return os.execl(
+        uwsgi, uwsgi,
+        "--http", "%s:%d" % (conf.host or conf.api.host,
+                             conf.port or conf.api.port),
+        "--master",
+        "--enable-threads",
+        "--die-on-term",
+        # NOTE(jd) See https://github.com/gnocchixyz/gnocchi/issues/156
+        "--add-header", "Connection: close",
+        "--processes", str(math.floor(workers * 1.5)),
+        "--threads", str(workers),
+        "--lazy-apps",
+        "--chdir", "/",
+        "--wsgi", "gnocchi.rest.wsgi",
+        "--pyargv", " ".join(sys.argv[1:]),
+    )
 
 
 def metricd():

--- a/gnocchi/opts.py
+++ b/gnocchi/opts.py
@@ -22,6 +22,7 @@ from oslo_middleware import cors
 
 import gnocchi.archive_policy
 import gnocchi.indexer
+import gnocchi.rest.app
 import gnocchi.storage
 import gnocchi.storage.ceph
 import gnocchi.storage.file
@@ -161,7 +162,8 @@ def list_opts():
                        default=10, min=0,
                        help='Number of seconds before timeout when attempting '
                             'to force refresh of metric.'),
-        )),
+        ) + gnocchi.rest.app.API_OPTS,
+        ),
         ("storage", (_STORAGE_OPTS + gnocchi.storage._carbonara.OPTS)),
         ("incoming", _INCOMING_OPTS),
         ("statsd", (

--- a/gnocchi/rest/app.py
+++ b/gnocchi/rest/app.py
@@ -18,6 +18,7 @@ import pkg_resources
 import uuid
 
 import daiquiri
+from oslo_config import cfg
 from oslo_middleware import cors
 from oslo_policy import policy
 from paste import deploy
@@ -34,6 +35,16 @@ from gnocchi import storage as gnocchi_storage
 
 
 LOG = daiquiri.getLogger(__name__)
+
+
+API_OPTS = (
+    cfg.HostAddressOpt('host',
+                       default="0.0.0.0",
+                       help="Host to listen on"),
+    cfg.PortOpt('port',
+                default=8041,
+                help="Port to listen on"),
+)
 
 
 # Register our encoder by default for everything

--- a/gnocchi/rest/gnocchi-api
+++ b/gnocchi/rest/gnocchi-api
@@ -1,0 +1,19 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+if __name__ == '__main__':
+    import sys
+    from gnocchi import cli
+    sys.exit(cli.api())
+else:
+    from gnocchi.rest import app
+    application = app.build_wsgi_app()

--- a/gnocchi/rest/wsgi.py
+++ b/gnocchi/rest/wsgi.py
@@ -1,0 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This file is loaded by gnocchi-api when executing uwsgi"""
+from gnocchi.rest import app
+application = app.build_wsgi_app()

--- a/releasenotes/notes/gnocchi-api-uwsgi-f16d958cb26ad90e.yaml
+++ b/releasenotes/notes/gnocchi-api-uwsgi-f16d958cb26ad90e.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    The `gnocchi-api` script is now a wrapper around uWSGI. Using a
+    WSGI-compliant HTTP server always have been recommended, but since most
+    users want to just run gnocchi-api, it'll now be fast and efficient by
+    default.

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,6 +94,9 @@ pre-hook.build_config = gnocchi.genconfig.prehook
 packages =
     gnocchi
 
+scripts =
+    gnocchi/rest/gnocchi-api
+
 [entry_points]
 gnocchi.indexer.sqlalchemy.resource_type_attribute =
     string = gnocchi.indexer.sqlalchemy_extension:StringSchema
@@ -135,9 +138,6 @@ console_scripts =
     gnocchi-change-sack-size = gnocchi.cli:change_sack_size
     gnocchi-statsd = gnocchi.cli:statsd
     gnocchi-metricd = gnocchi.cli:metricd
-
-wsgi_scripts =
-    gnocchi-api = gnocchi.rest.app:build_wsgi_app
 
 oslo.config.opts =
     gnocchi = gnocchi.opts:list_opts


### PR DESCRIPTION
As the wise Mehdi once said: "nobody reads documentation".
Everybody wants to run a daemon for the API server and everybody wants to run
`gnocchi-api'. Then let's provide it as a wrapper around uwsgi, so it's a fast
and performant HTTP by default.