### PR TITLE
metricd: use a better number of partitions for the hashring

### DIFF
--- a/gnocchi/cli.py
+++ b/gnocchi/cli.py
@@ -194,7 +194,7 @@ class MetricProcessor(MetricProcessBase):
             six.moves.range(self.store.incoming.NUM_SACKS))
         try:
             self.partitioner = self.coord.join_partitioned_group(
-                self.GROUP_ID, partitions=200)
+                self.GROUP_ID, partitions=self.store.incoming.NUM_SACKS)
             LOG.info('Joined coordination group: %s', self.GROUP_ID)
 
             @periodics.periodic(spacing=self.conf.metricd.worker_sync_rate,


### PR DESCRIPTION
The current hashring distributing the sacks across the metricd workers is 200.
That means the the smallest number of sacks that a worker can have is
(number_of_sacks/200), being 0.64 on a default installation.

That's weird ratio.

If the number of sacks created is 4096 and the number of workers is 4096, then
each worker manages at least 4096/200=20,48 sacks. There's no good reason for
that, each worker should be responsible for one sack (+ replicas) in such a
setup.

Let's use the number of sacks as the partition number so the minimum amount of
sack that a worker will always be able to manage is 1 (+ replicas).