### PR TITLE
Remove genconfig target

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -130,10 +130,6 @@ exclude = .tox,.eggs,doc
 show-source = true
 enable-extensions = H904
 
-[testenv:genconfig]
-deps = .[mysql,postgresql,test,file,ceph,swift,s3]
-commands = gnocchi-config-generator
-
 [testenv:docs]
 basepython = python2.7
 ## This does not work, see: https://github.com/tox-dev/tox/issues/509


### PR DESCRIPTION
We have a dedicated tool that can be run in any standard installation of
Gnocchi, not need for a hackish tox target anymore.