### PR TITLE
rest: return 404 when granularity does not exist

### DIFF
--- a/gnocchi/rest/__init__.py
+++ b/gnocchi/rest/__init__.py
@@ -1663,9 +1663,9 @@ class AggregationController(rest.RestController):
         except storage.MetricUnaggregatable as e:
             abort(400, ("One of the metrics being aggregated doesn't have "
                         "matching granularity: %s") % str(e))
-        except storage.MetricDoesNotExist as e:
-            abort(404, e)
-        except storage.AggregationDoesNotExist as e:
+        except (storage.MetricDoesNotExist,
+                storage.GranularityDoesNotExist,
+                storage.AggregationDoesNotExist) as e:
             abort(404, e)
 
     @pecan.expose('json')

--- a/gnocchi/tests/functional/gabbits/aggregation.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregation.yaml
@@ -139,6 +139,12 @@ tests:
       GET: /v1/aggregation/metric?metric=$HISTORY['get metric list'].$RESPONSE['$[0].id']&metric=$HISTORY['get metric list'].$RESPONSE['$[1].id']&granularity=1&fill=asdf
       status: 400
 
+    - name: get measure aggregates non existing granularity
+      desc: https://github.com/gnocchixyz/gnocchi/issues/148
+      GET: /v1/aggregation/metric?metric=$HISTORY['get metric list'].$RESPONSE['$[0].id']&granularity=42
+      status: 404
+      response_strings:
+        - Granularity '42.0' for metric
 
 # Aggregation by resource and metric_name
 


### PR DESCRIPTION
The exception is not caught currently, making the REST API return a 500 error.

Fixes #148 

(cherry picked from commit 85c08b4f90d9b9ce0906ae4fe20867526d6c207f)