### PR TITLE
utils: use ASCII bytes as member id

### DIFF
--- a/gnocchi/utils.py
+++ b/gnocchi/utils.py
@@ -90,7 +90,7 @@ def _enable_coordination(coord):
 
 
 def get_coordinator_and_start(url):
-    my_id = uuid.uuid4().bytes
+    my_id = str(uuid.uuid4()).encode()
     coord = coordination.get_coordinator(url, my_id)
     _enable_coordination(coord)
     return coord, my_id


### PR DESCRIPTION
Tooz actually wants ASCII bytes and not random bytes.

Fixes #130

(cherry picked from commit e749b60f49a4a3b48cc5da67a797f717dd8cd01d)