### PR TITLE
Make command line tools log to stderr

### DIFF
--- a/gnocchi/cli.py
+++ b/gnocchi/cli.py
@@ -56,7 +56,7 @@ def upgrade():
                    help="Number of storage sacks to create."),
 
     ])
-    conf = service.prepare_service(conf=conf)
+    conf = service.prepare_service(conf=conf, log_to_std=True)
     if not conf.skip_index:
         index = indexer.get_driver(conf)
         index.connect()
@@ -84,7 +84,7 @@ def change_sack_size():
         cfg.IntOpt("sacks-number", required=True, min=1,
                    help="Number of storage sacks."),
     ])
-    conf = service.prepare_service(conf=conf)
+    conf = service.prepare_service(conf=conf, log_to_std=True)
     s = storage.get_incoming_driver(conf.incoming)
     try:
         report = s.measures_report(details=False)

--- a/gnocchi/service.py
+++ b/gnocchi/service.py
@@ -32,7 +32,8 @@ LOG = daiquiri.getLogger(__name__)
 
 
 def prepare_service(args=None, conf=None,
-                    default_config_files=None):
+                    default_config_files=None,
+                    log_to_std=False):
     if conf is None:
         conf = cfg.ConfigOpts()
     opts.set_defaults()
@@ -53,7 +54,7 @@ def prepare_service(args=None, conf=None,
          default_config_files=default_config_files,
          version=pbr.version.VersionInfo('gnocchi').version_string())
 
-    if conf.log_dir or conf.log_file:
+    if not log_to_std and (conf.log_dir or conf.log_file):
         outputs = [daiquiri.output.File(filename=conf.log_file,
                                         directory=conf.log_dir)]
     else:


### PR DESCRIPTION
`gnocchi-upgrade' and `gnocchi-change-sack-size' are both command line tools
and not daemons. That means they should always log to stderr, and not use the
configuration file instructions as where to log.

Fixes #16