### PR TITLE
swift: we must use the number of default sack

### DIFF
--- a/gnocchi/storage/incoming/swift.py
+++ b/gnocchi/storage/incoming/swift.py
@@ -43,7 +43,7 @@ class SwiftStorage(_carbonara.CarbonaraBasedStorage):
         self.swift.put_container(self.CFG_PREFIX)
         self.swift.put_object(self.CFG_PREFIX, self.CFG_PREFIX,
                               json.dumps({self.CFG_SACKS: num_sacks}))
-        for i in six.moves.range(self.NUM_SACKS):
+        for i in six.moves.range(num_sacks):
             self.swift.put_container(self.get_sack_name(i))
 
     def remove_sack_group(self, num_sacks):

--- a/run-func-tests.sh
+++ b/run-func-tests.sh
@@ -15,9 +15,15 @@ check_empty_var() {
     fi
 }
 
+PYTHON_VERSION_MAJOR=$(python -c 'import sys; print(sys.version_info.major)')
+
 GNOCCHI_TEST_STORAGE_DRIVERS=${GNOCCHI_TEST_STORAGE_DRIVERS:-file}
 GNOCCHI_TEST_INDEXER_DRIVERS=${GNOCCHI_TEST_INDEXER_DRIVERS:-postgresql}
 for storage in ${GNOCCHI_TEST_STORAGE_DRIVERS}; do
+    if [ "$storage" == "swift" ] && [ "$PYTHON_VERSION_MAJOR" == "3" ]; then
+        echo "WARNING: swift does not support python 3 skipping"
+        continue
+    fi
     for indexer in ${GNOCCHI_TEST_INDEXER_DRIVERS}; do
         case $storage in
             ceph)


### PR DESCRIPTION
We currently set the number of sack already configured instead of the
asked number. Making upgrade fail when the number of sack is not yet
set.

This change fixes that.