### PR TITLE
Add rate of change aggregation methods

### DIFF
--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -148,8 +148,11 @@ Archive Policy
 
 When sending measures for a metric to Gnocchi, the values are dynamically
 aggregated. That means that Gnocchi does not store all sent measures, but
-aggregates them over a certain period of time. Gnocchi provides several
-aggregation methods (mean, min, max, sum…) that are builtin.
+aggregates them over a certain period of time.
+
+Gnocchi provides several aggregation methods (mean, min, max, sum…) that are
+builtin. Those can be prefix by `rate:` to compute the rate of change before
+doing the aggregation.
 
 An archive policy is defined by a list of items in the `definition` field. Each
 item is composed of the timespan and the level of precision that must be kept

--- a/gnocchi/archive_policy.py
+++ b/gnocchi/archive_policy.py
@@ -35,6 +35,10 @@ class ArchivePolicy(object):
          'std', 'median', 'first', 'count')).union(
              set((str(i) + 'pct' for i in six.moves.range(1, 100))))
 
+    VALID_AGGREGATION_METHODS = VALID_AGGREGATION_METHODS.union(
+        set(map(lambda s: "rate:" + s,
+                VALID_AGGREGATION_METHODS)))
+
     # Set that contains all the above values + their minus equivalent (-mean)
     # and the "*" entry.
     VALID_AGGREGATION_METHODS_VALUES = VALID_AGGREGATION_METHODS.union(

--- a/gnocchi/storage/_carbonara.py
+++ b/gnocchi/storage/_carbonara.py
@@ -258,9 +258,16 @@ class CarbonaraBasedStorage(storage.StorageDriver):
                       metric, grouped_serie,
                       previous_oldest_mutable_timestamp,
                       oldest_mutable_timestamp):
+
+        if aggregation.startswith("rate:"):
+            grouped_serie = grouped_serie.derived()
+            aggregation_to_compute = aggregation[5:]
+        else:
+            aggregation_to_compute = aggregation
+
         ts = carbonara.AggregatedTimeSerie.from_grouped_serie(
             grouped_serie, archive_policy_def.granularity,
-            aggregation, max_size=archive_policy_def.points)
+            aggregation_to_compute, max_size=archive_policy_def.points)
 
         # Don't do anything if the timeserie is empty
         if not ts:
@@ -389,6 +396,10 @@ class CarbonaraBasedStorage(storage.StorageDriver):
         block_size = metric.archive_policy.max_block_size
         back_window = metric.archive_policy.back_window
         definition = metric.archive_policy.definition
+        # NOTE(sileht): We keep one more blocks to calculate rate of change
+        # correctly
+        if any(filter(lambda x: x.startswith("rate:"), agg_methods)):
+            back_window += 1
 
         try:
             ts = self._get_unaggregated_timeserie_and_unserialize(

--- a/gnocchi/tests/functional/gabbits/archive.yaml
+++ b/gnocchi/tests/functional/gabbits/archive.yaml
@@ -579,3 +579,25 @@ tests:
           $.definition[0].points: 514
           $.definition[0].granularity: "0:00:07"
           $.definition[0].timespan: "0:59:58"
+
+    - name: policy rated
+      POST: /v1/archive_policy
+      request_headers:
+          # User admin
+          authorization: "basic YWRtaW46"
+      data:
+          name: 595228db-ea29-4415-9d5b-ecb5366abb1c
+          aggregation_methods:
+            - rate:mean
+            - rate:last
+          definition:
+              - timespan: 1 hour
+                points: 1000
+      status: 201
+      response_json_paths:
+          $.aggregation_methods.`sorted`:
+            - rate:last
+            - rate:mean
+          $.definition[0].points: 1000
+          $.definition[0].granularity: "0:00:04"
+          $.definition[0].timespan: "1:06:40"

--- a/gnocchi/tests/functional/gabbits/metric-derived.yaml
+++ b/gnocchi/tests/functional/gabbits/metric-derived.yaml
@@ -1,0 +1,199 @@
+fixtures:
+    - ConfigFixture
+
+defaults:
+  request_headers:
+    # User foobar
+    authorization: "basic Zm9vYmFyOg=="
+    content-type: application/json
+
+tests:
+    - name: create archive policy
+      desc: for later use
+      POST: /v1/archive_policy
+      request_headers:
+        # User admin
+        authorization: "basic YWRtaW46"
+      data:
+          name: carrot-cake
+          aggregation_methods:
+              - rate:mean
+              - rate:max
+              - rate:95pct
+              - max
+          definition:
+              - granularity: 1 minute
+      status: 201
+
+    - name: create valid metric
+      POST: /v1/metric
+      data:
+          archive_policy_name: carrot-cake
+      status: 201
+
+    - name: push measurements to metric
+      POST: /v1/metric/$RESPONSE['$.id']/measures
+      data:
+          - timestamp: "2015-03-06T14:33:00"
+            value: 10
+          - timestamp: "2015-03-06T14:34:10"
+            value: 13
+          - timestamp: "2015-03-06T14:34:20"
+            value: 13
+          - timestamp: "2015-03-06T14:34:30"
+            value: 15
+          - timestamp: "2015-03-06T14:34:40"
+            value: 18
+          - timestamp: "2015-03-06T14:34:50"
+            value: 20
+          - timestamp: "2015-03-06T14:35:00"
+            value: 22
+          - timestamp: "2015-03-06T14:35:10"
+            value: 26
+          - timestamp: "2015-03-06T14:35:20"
+            value: 30
+          - timestamp: "2015-03-06T14:35:30"
+            value: 31
+          - timestamp: "2015-03-06T14:35:40"
+            value: 37
+          - timestamp: "2015-03-06T14:35:50"
+            value: 55
+          - timestamp: "2015-03-06T14:36:00"
+            value: 62
+          - timestamp: "2015-03-06T14:36:10"
+            value: 100
+          - timestamp: "2015-03-06T14:36:20"
+            value: 102
+          - timestamp: "2015-03-06T14:36:30"
+            value: 103
+          - timestamp: "2015-03-06T14:36:40"
+            value: 104
+          - timestamp: "2015-03-06T14:36:50"
+            value: 110
+      status: 202
+
+    - name: get measurements rate:mean
+      GET: /v1/metric/$HISTORY['create valid metric'].$RESPONSE['id']/measures?aggregation=rate:mean&refresh=true
+      status: 200
+      response_json_paths:
+          $:
+            - ['2015-03-06T14:34:00+00:00', 60.0, 2.0]
+            - ['2015-03-06T14:35:00+00:00', 60.0, 5.833333333333333]
+            - ['2015-03-06T14:36:00+00:00', 60.0, 9.166666666666666]
+
+    - name: get measurements rate:95pct
+      GET: /v1/metric/$HISTORY['create valid metric'].$RESPONSE['id']/measures?aggregation=rate:95pct
+      status: 200
+      response_json_paths:
+          $:
+            - ['2015-03-06T14:34:00+00:00', 60.0, 3.0]
+            - ['2015-03-06T14:35:00+00:00', 60.0, 15.0]
+            - ['2015-03-06T14:36:00+00:00', 60.0, 30.25]
+
+    - name: get measurements rate:max
+      GET: /v1/metric/$HISTORY['create valid metric'].$RESPONSE['id']/measures?aggregation=rate:max
+      status: 200
+      response_json_paths:
+          $:
+            - ['2015-03-06T14:34:00+00:00', 60.0, 3.0]
+            - ['2015-03-06T14:35:00+00:00', 60.0, 18.0]
+            - ['2015-03-06T14:36:00+00:00', 60.0, 38.0]
+
+    - name: get measurements max
+      GET: /v1/metric/$HISTORY['create valid metric'].$RESPONSE['id']/measures?aggregation=max
+      status: 200
+      response_json_paths:
+          $:
+            - ['2015-03-06T14:33:00+00:00', 60.0, 10.0]
+            - ['2015-03-06T14:34:00+00:00', 60.0, 20.0]
+            - ['2015-03-06T14:35:00+00:00', 60.0, 55.0]
+            - ['2015-03-06T14:36:00+00:00', 60.0, 110.0]
+
+    - name: create a second metric
+      POST: /v1/metric
+      data:
+          archive_policy_name: carrot-cake
+      status: 201
+
+    - name: push measurements to the second metric
+      POST: /v1/metric/$RESPONSE['$.id']/measures
+      data:
+          - timestamp: "2015-03-06T14:33:00"
+            value: 10
+          - timestamp: "2015-03-06T14:34:10"
+            value: 13
+          - timestamp: "2015-03-06T14:34:20"
+            value: 13
+          - timestamp: "2015-03-06T14:34:30"
+            value: 15
+          - timestamp: "2015-03-06T14:34:40"
+            value: 18
+          - timestamp: "2015-03-06T14:34:50"
+            value: 20
+          - timestamp: "2015-03-06T14:35:00"
+            value: 22
+          - timestamp: "2015-03-06T14:35:10"
+            value: 26
+      status: 202
+
+    - name: push other measurements to the second metric
+      POST: /v1/metric/$HISTORY['create a second metric'].$RESPONSE['$.id']/measures
+      data:
+          - timestamp: "2015-03-06T14:35:20"
+            value: 30
+          - timestamp: "2015-03-06T14:35:30"
+            value: 31
+          - timestamp: "2015-03-06T14:35:40"
+            value: 37
+          - timestamp: "2015-03-06T14:35:50"
+            value: 55
+          - timestamp: "2015-03-06T14:36:00"
+            value: 62
+          - timestamp: "2015-03-06T14:36:10"
+            value: 100
+          - timestamp: "2015-03-06T14:36:20"
+            value: 102
+          - timestamp: "2015-03-06T14:36:30"
+            value: 103
+          - timestamp: "2015-03-06T14:36:40"
+            value: 104
+          - timestamp: "2015-03-06T14:36:50"
+            value: 110
+      status: 202
+
+    - name: get measurements rate:mean second metric
+      GET: /v1/metric/$HISTORY['create a second metric'].$RESPONSE['id']/measures?aggregation=rate:mean&refresh=true
+      status: 200
+      response_json_paths:
+          $:
+            - ['2015-03-06T14:34:00+00:00', 60.0, 2.0]
+            - ['2015-03-06T14:35:00+00:00', 60.0, 5.833333333333333]
+            - ['2015-03-06T14:36:00+00:00', 60.0, 9.166666666666666]
+
+    - name: get measurements rate:95pct second metric
+      GET: /v1/metric/$HISTORY['create a second metric'].$RESPONSE['id']/measures?aggregation=rate:95pct
+      status: 200
+      response_json_paths:
+          $:
+            - ['2015-03-06T14:34:00+00:00', 60.0, 3.0]
+            - ['2015-03-06T14:35:00+00:00', 60.0, 15.0]
+            - ['2015-03-06T14:36:00+00:00', 60.0, 30.25]
+
+    - name: get measurements rate:max second metric
+      GET: /v1/metric/$HISTORY['create a second metric'].$RESPONSE['id']/measures?aggregation=rate:max
+      status: 200
+      response_json_paths:
+          $:
+            - ['2015-03-06T14:34:00+00:00', 60.0, 3.0]
+            - ['2015-03-06T14:35:00+00:00', 60.0, 18.0]
+            - ['2015-03-06T14:36:00+00:00', 60.0, 38.0]
+
+    - name: get measurements max second metric
+      GET: /v1/metric/$HISTORY['create a second metric'].$RESPONSE['id']/measures?aggregation=max
+      status: 200
+      response_json_paths:
+          $:
+            - ['2015-03-06T14:33:00+00:00', 60.0, 10.0]
+            - ['2015-03-06T14:34:00+00:00', 60.0, 20.0]
+            - ['2015-03-06T14:35:00+00:00', 60.0, 55.0]
+            - ['2015-03-06T14:36:00+00:00', 60.0, 110.0]

--- a/gnocchi/tests/test_archive_policy.py
+++ b/gnocchi/tests/test_archive_policy.py
@@ -73,6 +73,15 @@ class TestArchivePolicy(base.BaseTestCase):
              .union(set(["12pct"]))),
             ap.aggregation_methods)
 
+        ap = archive_policy.ArchivePolicy("foobar",
+                                          0,
+                                          [],
+                                          ["+rate:last"])
+        self.assertEqual(
+            (set(conf.archive_policy.default_aggregation_methods)
+             .union(set(["rate:last"]))),
+            ap.aggregation_methods)
+
     def test_max_block_size(self):
         ap = archive_policy.ArchivePolicy("foobar",
                                           0,

--- a/releasenotes/notes/rate-archive-policy-74888634f90a81e3.yaml
+++ b/releasenotes/notes/rate-archive-policy-74888634f90a81e3.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    New aggregation methods are available for archive policy; rate:mean, rate:last, .... These new methods
+    allow to compute the timeseries rate of change before applying the selected aggregation method.


### PR DESCRIPTION
This change allows to compute the rate of change before applying
the aggregation method. To do so, aggregation method need to be
prefixed by "rate:"