### PR TITLE
swift: we must use the number of default sack

### DIFF
--- a/gnocchi/storage/incoming/swift.py
+++ b/gnocchi/storage/incoming/swift.py
@@ -43,7 +43,7 @@ class SwiftStorage(_carbonara.CarbonaraBasedStorage):
         self.swift.put_container(self.CFG_PREFIX)
         self.swift.put_object(self.CFG_PREFIX, self.CFG_PREFIX,
                               json.dumps({self.CFG_SACKS: num_sacks}))
-        for i in six.moves.range(self.NUM_SACKS):
+        for i in six.moves.range(num_sacks):
             self.swift.put_container(self.get_sack_name(i))
 
     def remove_sack_group(self, num_sacks):


### PR DESCRIPTION
We currently set the number of sack already configured instead of the
asked number. Making upgrade fail when the number of sack is not yet
set.

This change fixes that.

(cherry picked from commit 1b5a74ac125bdb96a3f36ecc99258c69aedb05fb)