### PR TITLE
tests: pass incoming driver to load_app() in Gabbi tests

### DIFF
--- a/gnocchi/tests/functional/fixtures.py
+++ b/gnocchi/tests/functional/fixtures.py
@@ -135,6 +135,7 @@ class ConfigFixture(fixture.GabbiFixture):
         LOAD_APP_KWARGS = {
             'storage': s,
             'indexer': index,
+            'incoming': i,
             'conf': conf,
         }
 


### PR DESCRIPTION
The incoming driver created by Gabbi fixtures is not passed to the created WSGI
app. While it works anyway (the conf object is passed and used to re-recreate
that incoming object) it's faster to re-use the same object. Let's do that.