### PR TITLE
Mimimize Pandas usage and use Numpy types

### DIFF
--- a/gnocchi/aggregates/moving_stats.py
+++ b/gnocchi/aggregates/moving_stats.py
@@ -13,8 +13,6 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-import datetime
-
 import numpy
 import pandas
 import six
@@ -26,23 +24,14 @@ from gnocchi import utils
 class MovingAverage(aggregates.CustomAggregator):
 
     @staticmethod
-    def check_window_valid(window):
-        """Takes in the window parameter string, reformats as a float."""
-        if window is None:
-            msg = 'Moving aggregate must have window specified.'
-            raise aggregates.CustomAggFailure(msg)
-        try:
-            return utils.to_timespan(six.text_type(window)).total_seconds()
-        except Exception:
-            raise aggregates.CustomAggFailure('Invalid value for window')
-
-    @staticmethod
     def retrieve_data(storage_obj, metric, start, stop, window):
         """Retrieves finest-res data available from storage."""
+        window_seconds = utils.timespan_total_seconds(window)
         try:
             min_grain = min(
                 ap.granularity for ap in metric.archive_policy.definition
-                if window % ap.granularity == 0)
+                if (window_seconds % utils.timespan_total_seconds(
+                    ap.granularity) == 0))
         except ValueError:
             msg = ("No data available that is either full-res or "
                    "of a granularity that factors into the window size "
@@ -76,12 +65,11 @@ class MovingAverage(aggregates.CustomAggregator):
             center = utils.strtobool(center)
 
         def moving_window(x):
-            msec = datetime.timedelta(milliseconds=1)
-            zero = datetime.timedelta(seconds=0)
-            half_span = datetime.timedelta(seconds=window / 2)
+            msec = numpy.timedelta64(1, 'ms')
+            zero = numpy.timedelta64(0, 's')
+            half_span = window / 2
             start = utils.normalize_time(data.index[0])
-            stop = utils.normalize_time(
-                data.index[-1] + datetime.timedelta(seconds=min_grain))
+            stop = utils.normalize_time(data.index[-1] + min_grain)
             # min_grain addition necessary since each bin of rolled-up data
             # is indexed by leftmost timestamp of bin.
 
@@ -138,7 +126,15 @@ class MovingAverage(aggregates.CustomAggregator):
         :param center: how to index the aggregated data (central timestamp or
             leftmost timestamp)
         """
-        window = self.check_window_valid(window)
+        if window is None:
+            raise aggregates.CustomAggFailure(
+                'Moving aggregate must have window specified.'
+            )
+        try:
+            window = utils.to_timespan(window)
+        except ValueError:
+            raise aggregates.CustomAggFailure('Invalid value for window')
+
         min_grain, data = self.retrieve_data(storage_obj, metric, start,
                                              stop, window)
         return self.aggregate_data(data, numpy.mean, window, min_grain, center,

--- a/gnocchi/archive_policy.py
+++ b/gnocchi/archive_policy.py
@@ -18,9 +18,12 @@ import collections
 import datetime
 import operator
 
+import numpy
 from oslo_config import cfg
 from oslo_config import types
 import six
+
+from gnocchi import utils
 
 
 class ArchivePolicy(object):
@@ -71,7 +74,7 @@ class ArchivePolicy(object):
             raise ValueError(
                 "More than one archive policy "
                 "uses granularity `%s'"
-                % duplicate_granularities[0]
+                % utils.timespan_total_seconds(duplicate_granularities[0])
             )
 
         if aggregation_methods is None:
@@ -155,20 +158,25 @@ class ArchivePolicyItem(dict):
                 raise ValueError(
                     u"timespan ≠ granularity × points")
 
-        if granularity is not None and granularity <= 0:
-            raise ValueError("Granularity should be > 0")
+        if granularity is not None:
+            if not isinstance(granularity, numpy.timedelta64):
+                granularity = numpy.timedelta64(int(granularity * 10e8), 'ns')
+            if granularity <= numpy.timedelta64(0, 'ns'):
+                raise ValueError("Granularity should be > 0")
 
         if points is not None and points <= 0:
             raise ValueError("Number of points should be > 0")
+
+        if (timespan is not None
+           and not isinstance(timespan, numpy.timedelta64)):
+            timespan = numpy.timedelta64(int(timespan * 10e8), 'ns')
 
         if granularity is None:
             if points is None or timespan is None:
                 raise ValueError(
                     "At least two of granularity/points/timespan "
                     "must be provided")
-            granularity = round(timespan / float(points))
-        else:
-            granularity = float(granularity)
+            granularity = timespan / float(points)
 
         if points is None:
             if timespan is None:
@@ -201,11 +209,25 @@ class ArchivePolicyItem(dict):
         """Return a dict representation with human readable values."""
         return {
             'timespan': six.text_type(
-                datetime.timedelta(seconds=self.timespan))
+                datetime.timedelta(
+                    seconds=utils.timespan_total_seconds(
+                        self.timespan)))
             if self.timespan is not None
             else None,
             'granularity': six.text_type(
-                datetime.timedelta(seconds=self.granularity)),
+                datetime.timedelta(
+                    seconds=utils.timespan_total_seconds(
+                        self.granularity))),
+            'points': self.points,
+        }
+
+    def serialize(self):
+        return {
+            'timespan': None
+            if self.timespan is None
+            else float(utils.timespan_total_seconds(self.timespan)),
+            'granularity': float(
+                utils.timespan_total_seconds(self.granularity)),
             'points': self.points,
         }
 
@@ -214,36 +236,39 @@ DEFAULT_ARCHIVE_POLICIES = {
     'bool': ArchivePolicy(
         "bool", 3600, [
             # 1 second resolution for 365 days
-            ArchivePolicyItem(granularity=1,
-                              timespan=365 * 24 * 60 * 60),
+            ArchivePolicyItem(granularity=numpy.timedelta64(1, 's'),
+                              timespan=numpy.timedelta64(365, 'D')),
         ],
         aggregation_methods=("last",),
     ),
     'low': ArchivePolicy(
         "low", 0, [
             # 5 minutes resolution for 30 days
-            ArchivePolicyItem(granularity=300,
-                              timespan=30 * 24 * 60 * 60),
+            ArchivePolicyItem(granularity=numpy.timedelta64(5, 'm'),
+                              timespan=numpy.timedelta64(30, 'D')),
         ],
     ),
     'medium': ArchivePolicy(
         "medium", 0, [
             # 1 minute resolution for 7 days
-            ArchivePolicyItem(granularity=60,
-                              timespan=7 * 24 * 60 * 60),
+            ArchivePolicyItem(granularity=numpy.timedelta64(1, 'm'),
+                              timespan=numpy.timedelta64(7, 'D')),
             # 1 hour resolution for 365 days
-            ArchivePolicyItem(granularity=3600,
-                              timespan=365 * 24 * 60 * 60),
+            ArchivePolicyItem(granularity=numpy.timedelta64(1, 'h'),
+                              timespan=numpy.timedelta64(365, 'D')),
         ],
     ),
     'high': ArchivePolicy(
         "high", 0, [
             # 1 second resolution for an hour
-            ArchivePolicyItem(granularity=1, points=3600),
+            ArchivePolicyItem(granularity=numpy.timedelta64(1, 's'),
+                              timespan=numpy.timedelta64(1, 'h')),
             # 1 minute resolution for a week
-            ArchivePolicyItem(granularity=60, points=60 * 24 * 7),
+            ArchivePolicyItem(granularity=numpy.timedelta64(1, 'm'),
+                              timespan=numpy.timedelta64(7, 'D')),
             # 1 hour resolution for a year
-            ArchivePolicyItem(granularity=3600, points=365 * 24),
+            ArchivePolicyItem(granularity=numpy.timedelta64(1, 'h'),
+                              timespan=numpy.timedelta64(365, 'D')),
         ],
     ),
 }

--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -21,7 +21,6 @@ import functools
 import itertools
 import logging
 import math
-import numbers
 import random
 import re
 import struct
@@ -43,7 +42,8 @@ time.strptime("2016-02-19", "%Y-%m-%d")
 LOG = logging.getLogger(__name__)
 
 
-UNIX_UNIVERSAL_START64 = numpy.datetime64("1970")
+UNIX_UNIVERSAL_START64 = numpy.datetime64("1970", 'ns')
+ONE_SECOND = numpy.timedelta64(1, 's')
 
 
 class BeforeEpochError(Exception):
@@ -76,9 +76,13 @@ class InvalidData(ValueError):
         super(InvalidData, self).__init__("Unable to unpack, invalid data")
 
 
+def datetime64_to_epoch(dt):
+    return (dt - UNIX_UNIVERSAL_START64) / ONE_SECOND
+
+
 def round_timestamp(ts, freq):
-    return pandas.Timestamp(
-        (pandas.Timestamp(ts).value // freq) * freq)
+    return UNIX_UNIVERSAL_START64 + numpy.floor(
+        (ts - UNIX_UNIVERSAL_START64) / freq) * freq
 
 
 class GroupedTimeSeries(object):
@@ -86,9 +90,9 @@ class GroupedTimeSeries(object):
         # NOTE(sileht): The whole class assumes ts is ordered and don't have
         # duplicate timestamps, it uses numpy.unique that sorted list, but
         # we always assume the orderd to be the same as the input.
-        freq = granularity * 10e8
         self._ts = ts
-        self.indexes = (numpy.array(ts.index, numpy.float) // freq) * freq
+        self.indexes = round_timestamp(
+            numpy.array(ts.index, dtype=numpy.datetime64), granularity)
         self.tstamps, self.counts = numpy.unique(self.indexes,
                                                  return_counts=True)
 
@@ -203,12 +207,6 @@ class TimeSerie(object):
     def __len__(self):
         return len(self.ts)
 
-    @staticmethod
-    def _to_offset(value):
-        if isinstance(value, numbers.Real):
-            return pandas.tseries.offsets.Nano(value * 10e8)
-        return pandas.tseries.frequencies.to_offset(value)
-
     @property
     def first(self):
         try:
@@ -258,7 +256,7 @@ class BoundTimeSerie(TimeSerie):
 
         """
         super(BoundTimeSerie, self).__init__(ts)
-        self.block_size = self._to_offset(block_size)
+        self.block_size = block_size
         self.back_window = back_window
         self._truncate()
 
@@ -371,7 +369,7 @@ class BoundTimeSerie(TimeSerie):
 
             t0 = time.time()
             for i in six.moves.range(serialize_times):
-                cls.unserialize(s, 1, 1)
+                cls.unserialize(s, numpy.timedelta64(1, 's'), 1)
             t1 = time.time()
             print("  Unserialization speed: %.2f MB/s"
                   % (((points * 2 * 8)
@@ -380,7 +378,7 @@ class BoundTimeSerie(TimeSerie):
     def first_block_timestamp(self):
         """Return the timestamp of the first block."""
         rounded = round_timestamp(self.ts.index[-1],
-                                  self.block_size.delta.value)
+                                  self.block_size)
 
         return rounded - (self.block_size * self.back_window)
 
@@ -408,14 +406,8 @@ class SplitKey(object):
     def __init__(self, value, sampling):
         if isinstance(value, SplitKey):
             self.key = value.key
-        elif isinstance(value, pandas.Timestamp):
-            self.key = value.value / 10e8
-        elif isinstance(value, numpy.datetime64):
-            self.key = (
-                (value - UNIX_UNIVERSAL_START64) / numpy.timedelta64(1, 's')
-            )
         else:
-            self.key = float(value)
+            self.key = value
 
         self.sampling = sampling
 
@@ -423,7 +415,8 @@ class SplitKey(object):
     def from_timestamp_and_sampling(cls, timestamp, sampling):
         return cls(
             round_timestamp(
-                timestamp, freq=sampling * cls.POINTS_PER_SPLIT * 10e8),
+                timestamp,
+                freq=sampling * cls.POINTS_PER_SPLIT),
             sampling)
 
     def __next__(self):
@@ -441,35 +434,44 @@ class SplitKey(object):
         return self
 
     def __hash__(self):
-        return hash(self.key)
+        return hash(
+            str(datetime64_to_epoch(self.key))
+            +
+            str(self.sampling / ONE_SECOND)
+        )
 
     def __lt__(self, other):
         if isinstance(other, SplitKey):
+            if self.sampling != other.sampling:
+                raise TypeError(
+                    "Cannot compare %s with different sampling" %
+                    self.__class__.__name__)
             return self.key < other.key
-        if isinstance(other, pandas.Timestamp):
-            return self.key * 10e8 < other.value
-        return self.key < other
+        if isinstance(other, numpy.datetime64):
+            return self.key < other
+        raise TypeError("Cannot compare %r with %r" % (self, other))
 
     def __eq__(self, other):
         if isinstance(other, SplitKey):
+            if self.sampling != other.sampling:
+                raise TypeError(
+                    "Cannot compare %s with different sampling" %
+                    self.__class__.__name__)
             return self.key == other.key
-        if isinstance(other, pandas.Timestamp):
-            return self.key * 10e8 == other.value
-        return self.key == other
+        if isinstance(other, numpy.datetime64):
+            return self.key == other
+        raise TypeError("Cannot compare %r with %r" % (self, other))
 
     def __str__(self):
         return str(float(self))
 
     def __float__(self):
-        return self.key
-
-    def as_datetime(self):
-        return pandas.Timestamp(self.key, unit='s')
+        return datetime64_to_epoch(self.key)
 
     def __repr__(self):
-        return "<%s: %s / %fs>" % (self.__class__.__name__,
-                                   repr(self.key),
-                                   self.sampling)
+        return "<%s: %s / %s>" % (self.__class__.__name__,
+                                  self.key,
+                                  self.sampling)
 
 
 class AggregatedTimeSerie(TimeSerie):
@@ -488,7 +490,7 @@ class AggregatedTimeSerie(TimeSerie):
 
         """
         super(AggregatedTimeSerie, self).__init__(ts)
-        self.sampling = self._to_offset(sampling).nanos / 10e8
+        self.sampling = sampling
         self.max_size = max_size
         self.aggregation_method = aggregation_method
         self._truncate(quick=True)
@@ -525,8 +527,11 @@ class AggregatedTimeSerie(TimeSerie):
         # but we have ordered timestamps, so don't need
         # to iter the whole series.
         freq = self.sampling * SplitKey.POINTS_PER_SPLIT
-        ix = numpy.array(self.ts.index, numpy.float64) / 10e8
-        keys, counts = numpy.unique((ix // freq) * freq, return_counts=True)
+        keys, counts = numpy.unique(
+            round_timestamp(
+                numpy.array(self.ts.index, dtype=numpy.datetime64),
+                freq),
+            return_counts=True)
         start = 0
         for key, count in six.moves.zip(keys, counts):
             end = start + count
@@ -566,7 +571,7 @@ class AggregatedTimeSerie(TimeSerie):
                 and self.aggregation_method == other.aggregation_method)
 
     def __repr__(self):
-        return "<%s 0x%x sampling=%fs max_size=%s agg_method=%s>" % (
+        return "<%s 0x%x sampling=%s max_size=%s agg_method=%s>" % (
             self.__class__.__name__,
             id(self),
             self.sampling,
@@ -619,9 +624,6 @@ class AggregatedTimeSerie(TimeSerie):
                 y = index * key.sampling + key.key
                 x = everything['v'][index]
 
-            y = y.astype(numpy.float64, copy=False) * 10e8
-            y = y.astype('datetime64[ns]', copy=False)
-            y = pandas.to_datetime(y)
         return cls.from_data(key.sampling, agg_method, y, x)
 
     def get_split_key(self, timestamp=None):
@@ -653,9 +655,9 @@ class AggregatedTimeSerie(TimeSerie):
         """
         if not self.ts.index.is_monotonic:
             self.ts = self.ts.sort_index()
-        offset_div = self.sampling * 10e8
+        offset_div = self.sampling
         if isinstance(start, SplitKey):
-            start = start.as_datetime().value
+            start = start.key
         else:
             start = pandas.Timestamp(start).value
         # calculate how many seconds from start the series runs until and
@@ -663,8 +665,8 @@ class AggregatedTimeSerie(TimeSerie):
         if compressed:
             # NOTE(jd) Use a double delta encoding for timestamps
             timestamps = numpy.insert(
-                numpy.diff(self.ts.index) // offset_div,
-                0, int((self.first.value - start) // offset_div))
+                numpy.floor(numpy.diff(self.ts.index) / offset_div),
+                0, numpy.floor((self.first - start) / offset_div))
             timestamps = timestamps.astype('<H', copy=False)
             values = self.ts.values.astype('<d', copy=False)
             payload = (timestamps.tobytes() + values.tobytes())
@@ -678,10 +680,11 @@ class AggregatedTimeSerie(TimeSerie):
         # aggregate value is 0. calculate how many seconds from start the
         # series runs until and initialize list to store alternating
         # delimiter, float entries
-        first = self.first.value  # NOTE(jd) needed because faster
-        e_offset = int((self.last.value - first) // offset_div) + 1
+        first = self.first  # NOTE(jd) needed because faster
+        e_offset = int(numpy.floor((self.last - first) / offset_div) + 1)
 
-        locs = (numpy.cumsum(numpy.diff(self.ts.index)) // offset_div)
+        locs = numpy.floor(numpy.cumsum(numpy.diff(self.ts.index))
+                           / offset_div)
         locs = numpy.insert(locs, 0, 0)
         locs = locs.astype(numpy.int, copy=False)
 
@@ -698,7 +701,8 @@ class AggregatedTimeSerie(TimeSerie):
         serial[locs] = values
 
         payload = serial.tobytes()
-        offset = int((first - start) // offset_div) * self.PADDED_SERIAL_LEN
+        offset = numpy.floor(
+            (first - start) / offset_div) * self.PADDED_SERIAL_LEN
         return offset, payload
 
     def _truncate(self, quick=False):
@@ -724,7 +728,7 @@ class AggregatedTimeSerie(TimeSerie):
         if from_timestamp is None:
             from_ = None
         else:
-            from_ = round_timestamp(from_timestamp, self.sampling * 10e8)
+            from_ = round_timestamp(from_timestamp, self.sampling)
         points = self[from_:to_timestamp]
         try:
             # Do not include stop timestamp
@@ -747,7 +751,7 @@ class AggregatedTimeSerie(TimeSerie):
         """Run a speed benchmark!"""
         points = SplitKey.POINTS_PER_SPLIT
         sampling = 5
-        resample = 35
+        resample = numpy.timedelta64(35, 's')
 
         now = datetime.datetime(2015, 4, 3, 23, 11)
 
@@ -779,7 +783,8 @@ class AggregatedTimeSerie(TimeSerie):
                                 [now + datetime.timedelta(seconds=i*sampling)
                                  for i in six.moves.range(points)])
             pts = pts.sort_index()
-            ts = cls(ts=pts, sampling=sampling, aggregation_method='mean')
+            ts = cls(ts=pts, sampling=numpy.timedelta64(sampling, 's'),
+                     aggregation_method='mean')
             t0 = time.time()
             key = ts.get_split_key()
             for i in six.moves.range(serialize_times):
@@ -823,7 +828,8 @@ class AggregatedTimeSerie(TimeSerie):
 
             # NOTE(sileht): propose a new series with half overload timestamps
             pts = ts.ts.copy(deep=True)
-            tsbis = cls(ts=pts, sampling=sampling, aggregation_method='mean')
+            tsbis = cls(ts=pts, sampling=numpy.timedelta64(sampling, 's'),
+                        aggregation_method='mean')
             tsbis.ts.reindex(tsbis.ts.index -
                              datetime.timedelta(seconds=sampling * points / 2))
 
@@ -836,7 +842,8 @@ class AggregatedTimeSerie(TimeSerie):
             for agg in ['mean', 'sum', 'max', 'min', 'std', 'median', 'first',
                         'last', 'count', '5pct', '90pct']:
                 serialize_times = 3 if agg.endswith('pct') else 10
-                ts = cls(ts=pts, sampling=sampling, aggregation_method=agg)
+                ts = cls(ts=pts, sampling=numpy.timedelta64(sampling, 's'),
+                         aggregation_method=agg)
                 t0 = time.time()
                 for i in six.moves.range(serialize_times):
                     ts.resample(resample)

--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -210,14 +210,14 @@ class TimeSerie(object):
     @property
     def first(self):
         try:
-            return self.ts.index[0]
+            return self.ts.index[0].to_datetime64()
         except IndexError:
             return
 
     @property
     def last(self):
         try:
-            return self.ts.index[-1]
+            return self.ts.index[-1].to_datetime64()
         except IndexError:
             return
 
@@ -313,8 +313,8 @@ class BoundTimeSerie(TimeSerie):
 
     def serialize(self):
         # NOTE(jd) Use a double delta encoding for timestamps
-        timestamps = numpy.insert(numpy.diff(self.ts.index),
-                                  0, self.first.value)
+        timestamps = numpy.insert(numpy.diff(self.ts.index), 0,
+                                  int(datetime64_to_epoch(self.first) * 10e8))
         timestamps = timestamps.astype('<Q', copy=False)
         values = self.ts.values.astype('<d', copy=False)
         payload = (timestamps.tobytes() + values.tobytes())

--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -43,6 +43,9 @@ time.strptime("2016-02-19", "%Y-%m-%d")
 LOG = logging.getLogger(__name__)
 
 
+UNIX_UNIVERSAL_START64 = numpy.datetime64("1970")
+
+
 class BeforeEpochError(Exception):
     """Error raised when a timestamp before Epoch is used."""
 
@@ -407,6 +410,10 @@ class SplitKey(object):
             self.key = value.key
         elif isinstance(value, pandas.Timestamp):
             self.key = value.value / 10e8
+        elif isinstance(value, numpy.datetime64):
+            self.key = (
+                (value - UNIX_UNIVERSAL_START64) / numpy.timedelta64(1, 's')
+            )
         else:
             self.key = float(value)
 

--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 #
-# Copyright © 2016 Red Hat, Inc.
+# Copyright © 2016-2017 Red Hat, Inc.
 # Copyright © 2014-2015 eNovance
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -417,7 +417,7 @@ class SplitKey(object):
         else:
             self.key = float(value)
 
-        self._carbonara_sampling = float(sampling)
+        self.sampling = sampling
 
     @classmethod
     def from_timestamp_and_sampling(cls, timestamp, sampling):
@@ -432,8 +432,8 @@ class SplitKey(object):
         :return: A `SplitKey` object.
         """
         return self.__class__(
-            self.key + self._carbonara_sampling * self.POINTS_PER_SPLIT,
-            self._carbonara_sampling)
+            self.key + self.sampling * self.POINTS_PER_SPLIT,
+            self.sampling)
 
     next = __next__
 
@@ -469,7 +469,7 @@ class SplitKey(object):
     def __repr__(self):
         return "<%s: %s / %fs>" % (self.__class__.__name__,
                                    repr(self.key),
-                                   self._carbonara_sampling)
+                                   self.sampling)
 
 
 class AggregatedTimeSerie(TimeSerie):

--- a/gnocchi/indexer/sqlalchemy.py
+++ b/gnocchi/indexer/sqlalchemy.py
@@ -14,6 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 from __future__ import absolute_import
+import datetime
 import itertools
 import operator
 import os.path
@@ -582,7 +583,7 @@ class SQLAlchemyIndexer(indexer.IndexerDriver):
                 if c.granularity != n.granularity:
                     raise indexer.UnsupportedArchivePolicyChange(
                         name, '%s granularity interval was changed'
-                        % c.granularity)
+                        % utils.timespan_total_seconds(c.granularity))
             # NOTE(gordc): ORM doesn't update JSON column unless new
             ap.definition = ap_items
             return ap
@@ -1170,7 +1171,9 @@ class QueryTransformer(object):
 
         if field_name == "lifespan":
             attr = getattr(table, "ended_at") - getattr(table, "started_at")
-            value = utils.to_timespan(value)
+            value = datetime.timedelta(
+                seconds=utils.timespan_total_seconds(
+                    utils.to_timespan(value)))
             if engine == "mysql":
                 # NOTE(jd) So subtracting 2 timestamps in MySQL result in some
                 # weird results based on string comparison. It's useless and it

--- a/gnocchi/indexer/sqlalchemy_base.py
+++ b/gnocchi/indexer/sqlalchemy_base.py
@@ -129,6 +129,13 @@ class GnocchiBase(models.ModelBase):
 
 
 class ArchivePolicyDefinitionType(sqlalchemy_utils.JSONType):
+    def process_bind_param(self, value, dialect):
+        if value is not None:
+            return super(
+                ArchivePolicyDefinitionType, self).process_bind_param(
+                    [v.serialize() for v in value],
+                    dialect)
+
     def process_result_value(self, value, dialect):
         values = super(ArchivePolicyDefinitionType,
                        self).process_result_value(value, dialect)

--- a/gnocchi/json.py
+++ b/gnocchi/json.py
@@ -17,6 +17,7 @@ import datetime
 import uuid
 
 import numpy
+import pandas
 import six
 import ujson
 
@@ -33,6 +34,15 @@ def to_primitive(obj):
     if isinstance(obj, numpy.datetime64):
         # Do not include nanoseconds if null
         return str(obj).rpartition(".000000000")[0] + "+00:00"
+    if isinstance(obj, numpy.timedelta64):
+        return obj / numpy.timedelta64(1, 's')
+    if isinstance(obj, pandas.Timedelta):
+        # >>> pandas.Timedelta("1 minute").total_seconds()
+        # 60.00000000000001
+        # Never forget that bro.
+        return to_primitive(obj.to_timedelta64())
+    if isinstance(obj, datetime.timedelta):
+        return obj.total_seconds()
     # This mimics what Pecan implements in its default JSON encoder
     if hasattr(obj, "jsonify"):
         return to_primitive(obj.jsonify())

--- a/gnocchi/rest/__init__.py
+++ b/gnocchi/rest/__init__.py
@@ -145,7 +145,10 @@ def PositiveNotNullInt(value):
 
 
 def Timespan(value):
-    return utils.to_timespan(value).total_seconds()
+    try:
+        return utils.to_timespan(value)
+    except ValueError as e:
+        raise voluptuous.Invalid(e)
 
 
 def get_header_option(name, params):
@@ -421,13 +424,13 @@ class MetricController(rest.RestController):
 
         if start is not None:
             try:
-                start = utils.to_datetime(start)
+                start = utils.to_timestamp(start)
             except Exception:
                 abort(400, "Invalid value for start")
 
         if stop is not None:
             try:
-                stop = utils.to_datetime(stop)
+                stop = utils.to_timestamp(stop)
             except Exception:
                 abort(400, "Invalid value for stop")
 
@@ -435,7 +438,7 @@ class MetricController(rest.RestController):
             if not granularity:
                 abort(400, 'A granularity must be specified to resample')
             try:
-                resample = Timespan(resample)
+                resample = utils.to_timespan(resample)
             except ValueError as e:
                 abort(400, e)
 
@@ -457,7 +460,8 @@ class MetricController(rest.RestController):
             else:
                 measures = pecan.request.storage.get_measures(
                     self.metric, start, stop, aggregation,
-                    Timespan(granularity) if granularity is not None else None,
+                    utils.to_timespan(granularity)
+                    if granularity is not None else None,
                     resample)
             # Replace timestamp keys by their string versions
             return [(timestamp.isoformat(), offset, v)
@@ -1340,7 +1344,7 @@ class SearchMetricController(rest.RestController):
     @pecan.expose('json')
     def post(self, metric_id, start=None, stop=None, aggregation='mean',
              granularity=None):
-        granularity = [Timespan(g)
+        granularity = [utils.to_timespan(g)
                        for g in arg_to_list(granularity or [])]
         metrics = pecan.request.indexer.list_metrics(
             ids=arg_to_list(metric_id))
@@ -1355,13 +1359,13 @@ class SearchMetricController(rest.RestController):
 
         if start is not None:
             try:
-                start = utils.to_datetime(start)
+                start = utils.to_timestamp(start)
             except Exception:
                 abort(400, "Invalid value for start")
 
         if stop is not None:
             try:
-                stop = utils.to_datetime(stop)
+                stop = utils.to_timestamp(stop)
             except Exception:
                 abort(400, "Invalid value for stop")
 
@@ -1518,14 +1522,14 @@ class MetricsMeasuresBatchController(rest.RestController):
         start = kwargs.get('start')
         if start is not None:
             try:
-                start = utils.to_datetime(start)
+                start = utils.to_timestamp(start)
             except Exception:
                 abort(400, "Invalid value for start")
 
         stop = kwargs.get('stop')
         if stop is not None:
             try:
-                stop = utils.to_datetime(stop)
+                stop = utils.to_timestamp(stop)
             except Exception:
                 abort(400, "Invalid value for stop")
 
@@ -1541,7 +1545,7 @@ class MetricsMeasuresBatchController(rest.RestController):
         granularity = kwargs.get('granularity')
         if granularity is not None:
             try:
-                granularity = Timespan(granularity)
+                granularity = utils.to_timespan(granularity)
             except ValueError as e:
                 abort(400, e)
 
@@ -1650,13 +1654,13 @@ class AggregationController(rest.RestController):
 
         if start is not None:
             try:
-                start = utils.to_datetime(start)
+                start = utils.to_timestamp(start)
             except Exception:
                 abort(400, "Invalid value for start")
 
         if stop is not None:
             try:
-                stop = utils.to_datetime(stop)
+                stop = utils.to_timestamp(stop)
             except Exception:
                 abort(400, "Invalid value for stop")
 
@@ -1676,7 +1680,7 @@ class AggregationController(rest.RestController):
             return []
         if granularity is not None:
             try:
-                granularity = Timespan(granularity)
+                granularity = utils.to_timespan(granularity)
             except ValueError as e:
                 abort(400, e)
 
@@ -1684,7 +1688,7 @@ class AggregationController(rest.RestController):
             if not granularity:
                 abort(400, 'A granularity must be specified to resample')
             try:
-                resample = Timespan(resample)
+                resample = utils.to_timespan(resample)
             except ValueError as e:
                 abort(400, e)
 

--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -111,7 +111,7 @@ class GranularityDoesNotExist(StorageError):
         self.granularity = granularity
         super(GranularityDoesNotExist, self).__init__(
             "Granularity '%s' for metric %s does not exist" %
-            (granularity, metric))
+            (utils.timespan_total_seconds(granularity), metric))
 
 
 class MetricAlreadyExists(StorageError):
@@ -254,10 +254,12 @@ class StorageDriver(object):
         for metric in metrics:
             if aggregation not in metric.archive_policy.aggregation_methods:
                 raise AggregationDoesNotExist(metric, aggregation)
-            if (granularity is not None and granularity
-               not in set(d.granularity
-                          for d in metric.archive_policy.definition)):
-                raise GranularityDoesNotExist(metric, granularity)
+            if granularity is not None:
+                for d in metric.archive_policy.definition:
+                    if d.granularity == granularity:
+                        break
+                else:
+                    raise GranularityDoesNotExist(metric, granularity)
 
     @staticmethod
     def search_value(metrics, query, from_timestamp=None,

--- a/gnocchi/storage/_carbonara.py
+++ b/gnocchi/storage/_carbonara.py
@@ -15,7 +15,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 import collections
-import datetime
 import functools
 import itertools
 import operator
@@ -280,8 +279,7 @@ class CarbonaraBasedStorage(storage.StorageDriver):
 
         # First delete old splits
         if archive_policy_def.timespan:
-            oldest_point_to_keep = ts.last - datetime.timedelta(
-                seconds=archive_policy_def.timespan)
+            oldest_point_to_keep = ts.last - archive_policy_def.timespan
             oldest_key_to_keep = ts.get_split_key(oldest_point_to_keep)
             for key in list(existing_keys):
                 # NOTE(jd) Only delete if the key is strictly inferior to
@@ -292,17 +290,16 @@ class CarbonaraBasedStorage(storage.StorageDriver):
                     self._delete_metric_measures(metric, key, aggregation)
                     existing_keys.remove(key)
         else:
-            oldest_key_to_keep = carbonara.SplitKey(0, 0)
+            oldest_key_to_keep = None
 
         # Rewrite all read-only splits just for fun (and compression). This
         # only happens if `previous_oldest_mutable_timestamp' exists, which
         # means we already wrote some splits at some point – so this is not the
         # first time we treat this timeserie.
         if need_rewrite:
-            previous_oldest_mutable_key = str(ts.get_split_key(
-                previous_oldest_mutable_timestamp))
-            oldest_mutable_key = str(ts.get_split_key(
-                oldest_mutable_timestamp))
+            previous_oldest_mutable_key = ts.get_split_key(
+                previous_oldest_mutable_timestamp)
+            oldest_mutable_key = ts.get_split_key(oldest_mutable_timestamp)
 
             if previous_oldest_mutable_key != oldest_mutable_key:
                 for key in existing_keys:
@@ -317,7 +314,7 @@ class CarbonaraBasedStorage(storage.StorageDriver):
                             None, aggregation, oldest_mutable_timestamp)
 
         for key, split in ts.split():
-            if key >= oldest_key_to_keep:
+            if oldest_key_to_keep is None or key >= oldest_key_to_keep:
                 LOG.debug(
                     "Storing split %s (%s) for metric %s",
                     key, aggregation, metric)
@@ -431,7 +428,7 @@ class CarbonaraBasedStorage(storage.StorageDriver):
             for d in definition:
                 ts = bound_timeserie.group_serie(
                     d.granularity, carbonara.round_timestamp(
-                        tstamp, d.granularity * 10e8))
+                        tstamp, d.granularity))
 
                 self._map_in_thread(
                     self._add_measures,

--- a/gnocchi/storage/_carbonara.py
+++ b/gnocchi/storage/_carbonara.py
@@ -162,7 +162,7 @@ class CarbonaraBasedStorage(storage.StorageDriver):
         data = self._get_measures(metric, key, aggregation)
         try:
             return carbonara.AggregatedTimeSerie.unserialize(
-                data, key, aggregation, key.sampling)
+                data, key, aggregation)
         except carbonara.InvalidData:
             LOG.error("Data corruption detected for %s "
                       "aggregated `%s' timeserie, granularity `%s' "

--- a/gnocchi/storage/_carbonara.py
+++ b/gnocchi/storage/_carbonara.py
@@ -74,8 +74,7 @@ class CarbonaraBasedStorage(storage.StorageDriver):
             self.coord.stop()
 
     @staticmethod
-    def _get_measures(metric, timestamp_key, aggregation, granularity,
-                      version=3):
+    def _get_measures(metric, timestamp_key, aggregation, version=3):
         raise NotImplementedError
 
     @staticmethod
@@ -115,7 +114,7 @@ class CarbonaraBasedStorage(storage.StorageDriver):
 
     @staticmethod
     def _store_metric_measures(metric, timestamp_key, aggregation,
-                               granularity, data, offset=None, version=3):
+                               data, offset=None, version=3):
         raise NotImplementedError
 
     def _list_split_keys_for_metric(self, metric, aggregation, granularity,
@@ -159,17 +158,16 @@ class CarbonaraBasedStorage(storage.StorageDriver):
                 for ts in agg_timeseries
                 for timestamp, r, v in ts.fetch(from_timestamp, to_timestamp)]
 
-    def _get_measures_and_unserialize(self, metric, key,
-                                      aggregation, granularity):
-        data = self._get_measures(metric, key, aggregation, granularity)
+    def _get_measures_and_unserialize(self, metric, key, aggregation):
+        data = self._get_measures(metric, key, aggregation)
         try:
             return carbonara.AggregatedTimeSerie.unserialize(
-                data, key, aggregation, granularity)
+                data, key, aggregation, key.sampling)
         except carbonara.InvalidData:
             LOG.error("Data corruption detected for %s "
                       "aggregated `%s' timeserie, granularity `%s' "
                       "around time `%s', ignoring.",
-                      metric.id, aggregation, granularity, key)
+                      metric.id, aggregation, key.sampling, key)
 
     def _get_measures_timeserie(self, metric,
                                 aggregation, granularity,
@@ -208,7 +206,7 @@ class CarbonaraBasedStorage(storage.StorageDriver):
             lambda x: x is not None,
             self._map_in_thread(
                 self._get_measures_and_unserialize,
-                ((metric, key, aggregation, granularity)
+                ((metric, key, aggregation)
                  for key in sorted(all_keys)
                  if ((not from_timestamp or key >= from_timestamp)
                      and (not to_timestamp or key <= to_timestamp))))
@@ -221,17 +219,14 @@ class CarbonaraBasedStorage(storage.StorageDriver):
             max_size=points)
 
     def _store_timeserie_split(self, metric, key, split,
-                               aggregation, archive_policy_def,
-                               oldest_mutable_timestamp):
+                               aggregation, oldest_mutable_timestamp):
         # NOTE(jd) We write the full split only if the driver works that way
         # (self.WRITE_FULL) or if the oldest_mutable_timestamp is out of range.
         write_full = self.WRITE_FULL or next(key) <= oldest_mutable_timestamp
-        key_as_str = str(key)
         if write_full:
             try:
                 existing = self._get_measures_and_unserialize(
-                    metric, key_as_str, aggregation,
-                    archive_policy_def.granularity)
+                    metric, key, aggregation)
             except storage.AggregationDoesNotExist:
                 pass
             else:
@@ -251,15 +246,14 @@ class CarbonaraBasedStorage(storage.StorageDriver):
             LOG.warning("No data found for metric %s, granularity %f "
                         "and aggregation method %s (split key %s): "
                         "possible data corruption",
-                        metric, archive_policy_def.granularity,
+                        metric, key.sampling,
                         aggregation, key)
             return
 
         offset, data = split.serialize(key, compressed=write_full)
 
-        return self._store_metric_measures(
-            metric, key_as_str, aggregation, archive_policy_def.granularity,
-            data, offset=offset)
+        return self._store_metric_measures(metric, key, aggregation,
+                                           data, offset=offset)
 
     def _add_measures(self, aggregation, archive_policy_def,
                       metric, grouped_serie,
@@ -295,9 +289,7 @@ class CarbonaraBasedStorage(storage.StorageDriver):
                 # contains our timestamp, so we prefer to keep a bit more
                 # than deleting too much
                 if key < oldest_key_to_keep:
-                    self._delete_metric_measures(
-                        metric, key, aggregation,
-                        archive_policy_def.granularity)
+                    self._delete_metric_measures(metric, key, aggregation)
                     existing_keys.remove(key)
         else:
             oldest_key_to_keep = carbonara.SplitKey(0, 0)
@@ -322,8 +314,7 @@ class CarbonaraBasedStorage(storage.StorageDriver):
                         # compression). For that, we just pass None as split.
                         self._store_timeserie_split(
                             metric, key,
-                            None, aggregation, archive_policy_def,
-                            oldest_mutable_timestamp)
+                            None, aggregation, oldest_mutable_timestamp)
 
         for key, split in ts.split():
             if key >= oldest_key_to_keep:
@@ -331,8 +322,7 @@ class CarbonaraBasedStorage(storage.StorageDriver):
                     "Storing split %s (%s) for metric %s",
                     key, aggregation, metric)
                 self._store_timeserie_split(
-                    metric, key, split, aggregation, archive_policy_def,
-                    oldest_mutable_timestamp)
+                    metric, key, split, aggregation, oldest_mutable_timestamp)
 
     @staticmethod
     def _delete_metric(metric):

--- a/gnocchi/storage/ceph.py
+++ b/gnocchi/storage/ceph.py
@@ -56,10 +56,9 @@ class CephStorage(_carbonara.CarbonaraBasedStorage):
         super(CephStorage, self).stop()
 
     @staticmethod
-    def _get_object_name(metric, timestamp_key, aggregation, granularity,
-                         version=3):
+    def _get_object_name(metric, key, aggregation, version=3):
         name = str("gnocchi_%s_%s_%s_%s" % (
-            metric.id, timestamp_key, aggregation, granularity))
+            metric.id, key, aggregation, key.sampling))
         return name + '_v%s' % version if version else name
 
     def _object_exists(self, name):
@@ -76,10 +75,9 @@ class CephStorage(_carbonara.CarbonaraBasedStorage):
         else:
             self.ioctx.write_full(name, b"")
 
-    def _store_metric_measures(self, metric, timestamp_key, aggregation,
-                               granularity, data, offset=None, version=3):
-        name = self._get_object_name(metric, timestamp_key,
-                                     aggregation, granularity, version)
+    def _store_metric_measures(self, metric, key, aggregation,
+                               data, offset=None, version=3):
+        name = self._get_object_name(metric, key, aggregation, version)
         if offset is None:
             self.ioctx.write_full(name, data)
         else:
@@ -89,10 +87,8 @@ class CephStorage(_carbonara.CarbonaraBasedStorage):
             self.ioctx.operate_write_op(
                 op, self._build_unaggregated_timeserie_path(metric, 3))
 
-    def _delete_metric_measures(self, metric, timestamp_key, aggregation,
-                                granularity, version=3):
-        name = self._get_object_name(metric, timestamp_key,
-                                     aggregation, granularity, version)
+    def _delete_metric_measures(self, metric, key, aggregation, version=3):
+        name = self._get_object_name(metric, key, aggregation, version)
 
         try:
             self.ioctx.remove_object(name)
@@ -139,11 +135,9 @@ class CephStorage(_carbonara.CarbonaraBasedStorage):
             # It's possible that the object does not exists
             pass
 
-    def _get_measures(self, metric, timestamp_key, aggregation, granularity,
-                      version=3):
+    def _get_measures(self, metric, key, aggregation, version=3):
         try:
-            name = self._get_object_name(metric, timestamp_key,
-                                         aggregation, granularity, version)
+            name = self._get_object_name(metric, key, aggregation, version)
             return self._get_object_content(name)
         except rados.ObjectNotFound:
             if self._object_exists(

--- a/gnocchi/storage/ceph.py
+++ b/gnocchi/storage/ceph.py
@@ -152,8 +152,7 @@ class CephStorage(_carbonara.CarbonaraBasedStorage):
             else:
                 raise storage.MetricDoesNotExist(metric)
 
-    def _list_split_keys_for_metric(self, metric, aggregation, granularity,
-                                    version=3):
+    def _list_split_keys(self, metric, aggregation, granularity, version=3):
         with rados.ReadOpCtx() as op:
             omaps, ret = self.ioctx.get_omap_vals(op, "", "", -1)
             try:

--- a/gnocchi/storage/file.py
+++ b/gnocchi/storage/file.py
@@ -68,7 +68,7 @@ class FileStorage(_carbonara.CarbonaraBasedStorage):
     def _build_metric_path_for_split(self, metric, aggregation,
                                      timestamp_key, granularity, version=3):
         path = os.path.join(self._build_metric_path(metric, aggregation),
-                            timestamp_key + "_" + str(granularity))
+                            str(timestamp_key) + "_" + str(granularity))
         return path + '_v%s' % version if version else path
 
     def _create_metric(self, metric):
@@ -101,8 +101,7 @@ class FileStorage(_carbonara.CarbonaraBasedStorage):
                 raise storage.MetricDoesNotExist(metric)
             raise
 
-    def _list_split_keys_for_metric(self, metric, aggregation, granularity,
-                                    version=3):
+    def _list_split_keys(self, metric, aggregation, granularity, version=3):
         try:
             files = os.listdir(self._build_metric_path(metric, aggregation))
         except OSError as e:

--- a/gnocchi/storage/file.py
+++ b/gnocchi/storage/file.py
@@ -67,8 +67,11 @@ class FileStorage(_carbonara.CarbonaraBasedStorage):
 
     def _build_metric_path_for_split(self, metric, aggregation,
                                      key, version=3):
-        path = os.path.join(self._build_metric_path(metric, aggregation),
-                            str(key) + "_" + str(key.sampling))
+        path = os.path.join(
+            self._build_metric_path(metric, aggregation),
+            str(key)
+            + "_"
+            + str(utils.timespan_total_seconds(key.sampling)))
         return path + '_v%s' % version if version else path
 
     def _create_metric(self, metric):
@@ -109,9 +112,10 @@ class FileStorage(_carbonara.CarbonaraBasedStorage):
                 raise storage.MetricDoesNotExist(metric)
             raise
         keys = set()
+        granularity = str(utils.timespan_total_seconds(granularity))
         for f in files:
             meta = f.split("_")
-            if meta[1] == str(granularity) and self._version_check(f, version):
+            if meta[1] == granularity and self._version_check(f, version):
                 keys.add(meta[0])
         return keys
 

--- a/gnocchi/storage/file.py
+++ b/gnocchi/storage/file.py
@@ -66,9 +66,9 @@ class FileStorage(_carbonara.CarbonaraBasedStorage):
                             "agg_" + aggregation)
 
     def _build_metric_path_for_split(self, metric, aggregation,
-                                     timestamp_key, granularity, version=3):
+                                     key, version=3):
         path = os.path.join(self._build_metric_path(metric, aggregation),
-                            str(timestamp_key) + "_" + str(granularity))
+                            str(key) + "_" + str(key.sampling))
         return path + '_v%s' % version if version else path
 
     def _create_metric(self, metric):
@@ -115,17 +115,15 @@ class FileStorage(_carbonara.CarbonaraBasedStorage):
                 keys.add(meta[0])
         return keys
 
-    def _delete_metric_measures(self, metric, timestamp_key, aggregation,
-                                granularity, version=3):
+    def _delete_metric_measures(self, metric, key, aggregation, version=3):
         os.unlink(self._build_metric_path_for_split(
-            metric, aggregation, timestamp_key, granularity, version))
+            metric, aggregation, key, version))
 
-    def _store_metric_measures(self, metric, timestamp_key, aggregation,
-                               granularity, data, offset=None, version=3):
+    def _store_metric_measures(self, metric, key, aggregation,
+                               data, offset=None, version=3):
         self._atomic_file_store(
-            self._build_metric_path_for_split(metric, aggregation,
-                                              timestamp_key, granularity,
-                                              version),
+            self._build_metric_path_for_split(
+                metric, aggregation, key, version),
             data)
 
     def _delete_metric(self, metric):
@@ -138,10 +136,9 @@ class FileStorage(_carbonara.CarbonaraBasedStorage):
                 # measures)
                 raise
 
-    def _get_measures(self, metric, timestamp_key, aggregation, granularity,
-                      version=3):
+    def _get_measures(self, metric, key, aggregation, version=3):
         path = self._build_metric_path_for_split(
-            metric, aggregation, timestamp_key, granularity, version)
+            metric, aggregation, key, version)
         try:
             with open(path, 'rb') as aggregation_file:
                 return aggregation_file.read()

--- a/gnocchi/storage/redis.py
+++ b/gnocchi/storage/redis.py
@@ -18,6 +18,7 @@ from oslo_config import cfg
 from gnocchi.common import redis
 from gnocchi import storage
 from gnocchi.storage import _carbonara
+from gnocchi import utils
 
 
 OPTS = [
@@ -50,8 +51,9 @@ class RedisStorage(_carbonara.CarbonaraBasedStorage):
     @classmethod
     def _aggregated_field_for_split(cls, aggregation, key, version=3,
                                     granularity=None):
-        path = cls.FIELD_SEP.join([str(key), aggregation,
-                                   str(granularity or key.sampling)])
+        path = cls.FIELD_SEP.join([
+            str(key), aggregation,
+            str(utils.timespan_total_seconds(granularity or key.sampling))])
         return path + '_v%s' % version if version else path
 
     def _create_metric(self, metric):

--- a/gnocchi/storage/redis.py
+++ b/gnocchi/storage/redis.py
@@ -50,7 +50,7 @@ class RedisStorage(_carbonara.CarbonaraBasedStorage):
     @classmethod
     def _aggregated_field_for_split(cls, aggregation, timestamp_key,
                                     granularity, version=3):
-        path = cls.FIELD_SEP.join([timestamp_key, aggregation,
+        path = cls.FIELD_SEP.join([str(timestamp_key), aggregation,
                                    str(granularity)])
         return path + '_v%s' % version if version else path
 
@@ -71,8 +71,7 @@ class RedisStorage(_carbonara.CarbonaraBasedStorage):
             raise storage.MetricDoesNotExist(metric)
         return data
 
-    def _list_split_keys_for_metric(self, metric, aggregation, granularity,
-                                    version=3):
+    def _list_split_keys(self, metric, aggregation, granularity, version=3):
         key = self._metric_key(metric)
         if not self._client.exists(key):
             raise storage.MetricDoesNotExist(metric)

--- a/gnocchi/storage/s3.py
+++ b/gnocchi/storage/s3.py
@@ -87,8 +87,8 @@ class S3Storage(_carbonara.CarbonaraBasedStorage):
                 raise
 
     @staticmethod
-    def _object_name(split_key, aggregation, granularity, version=3):
-        name = '%s_%s_%s' % (aggregation, granularity, split_key)
+    def _object_name(split_key, aggregation, version=3):
+        name = '%s_%s_%s' % (aggregation, split_key.sampling, split_key)
         return name + '_v%s' % version if version else name
 
     @staticmethod
@@ -113,20 +113,20 @@ class S3Storage(_carbonara.CarbonaraBasedStorage):
                 wait=self._consistency_wait,
                 stop=self._consistency_stop)(_head)
 
-    def _store_metric_measures(self, metric, timestamp_key, aggregation,
-                               granularity, data, offset=0, version=3):
+    def _store_metric_measures(self, metric, key, aggregation,
+                               data, offset=0, version=3):
         self._put_object_safe(
             Bucket=self._bucket_name,
             Key=self._prefix(metric) + self._object_name(
-                timestamp_key, aggregation, granularity, version),
+                key, aggregation, version),
             Body=data)
 
-    def _delete_metric_measures(self, metric, timestamp_key, aggregation,
-                                granularity, version=3):
+    def _delete_metric_measures(self, metric, key, aggregation,
+                                version=3):
         self.s3.delete_object(
             Bucket=self._bucket_name,
             Key=self._prefix(metric) + self._object_name(
-                timestamp_key, aggregation, granularity, version))
+                key, aggregation, version))
 
     def _delete_metric(self, metric):
         bucket = self._bucket_name
@@ -149,13 +149,12 @@ class S3Storage(_carbonara.CarbonaraBasedStorage):
             s3.bulk_delete(self.s3, bucket,
                            [c['Key'] for c in response.get('Contents', ())])
 
-    def _get_measures(self, metric, timestamp_key, aggregation, granularity,
-                      version=3):
+    def _get_measures(self, metric, key, aggregation, version=3):
         try:
             response = self.s3.get_object(
                 Bucket=self._bucket_name,
                 Key=self._prefix(metric) + self._object_name(
-                    timestamp_key, aggregation, granularity, version))
+                    key, aggregation, version))
         except botocore.exceptions.ClientError as e:
             if e.response['Error'].get('Code') == 'NoSuchKey':
                 try:

--- a/gnocchi/storage/s3.py
+++ b/gnocchi/storage/s3.py
@@ -169,8 +169,7 @@ class S3Storage(_carbonara.CarbonaraBasedStorage):
             raise
         return response['Body'].read()
 
-    def _list_split_keys_for_metric(self, metric, aggregation, granularity,
-                                    version=3):
+    def _list_split_keys(self, metric, aggregation, granularity, version=3):
         bucket = self._bucket_name
         keys = set()
         response = {}

--- a/gnocchi/storage/swift.py
+++ b/gnocchi/storage/swift.py
@@ -19,6 +19,7 @@ from oslo_config import cfg
 from gnocchi.common import swift
 from gnocchi import storage
 from gnocchi.storage import _carbonara
+from gnocchi import utils
 
 swclient = swift.swclient
 swift_utils = swift.swift_utils
@@ -81,7 +82,10 @@ class SwiftStorage(_carbonara.CarbonaraBasedStorage):
 
     @staticmethod
     def _object_name(split_key, aggregation, version=3):
-        name = '%s_%s_%s' % (split_key, aggregation, split_key.sampling)
+        name = '%s_%s_%s' % (
+            split_key, aggregation,
+            utils.timespan_total_seconds(split_key.sampling),
+        )
         return name + '_v%s' % version if version else name
 
     def _create_metric(self, metric):
@@ -151,10 +155,11 @@ class SwiftStorage(_carbonara.CarbonaraBasedStorage):
                 raise storage.MetricDoesNotExist(metric)
             raise
         keys = set()
+        granularity = str(utils.timespan_total_seconds(granularity))
         for f in files:
             try:
                 meta = f['name'].split('_')
-                if (aggregation == meta[1] and granularity == float(meta[2])
+                if (aggregation == meta[1] and granularity == meta[2]
                         and self._version_check(f['name'], version)):
                     keys.add(meta[0])
             except (ValueError, IndexError):

--- a/gnocchi/storage/swift.py
+++ b/gnocchi/storage/swift.py
@@ -145,8 +145,7 @@ class SwiftStorage(_carbonara.CarbonaraBasedStorage):
             raise
         return contents
 
-    def _list_split_keys_for_metric(self, metric, aggregation, granularity,
-                                    version=3):
+    def _list_split_keys(self, metric, aggregation, granularity, version=3):
         container = self._container_name(metric)
         try:
             headers, files = self.swift.get_container(

--- a/gnocchi/tests/base.py
+++ b/gnocchi/tests/base.py
@@ -22,6 +22,7 @@ import uuid
 
 import daiquiri
 import fixtures
+import numpy
 import six
 from six.moves.urllib.parse import unquote
 try:
@@ -218,46 +219,48 @@ class TestCase(BaseTestCase):
             0, [
                 # 2 second resolution for a day
                 archive_policy.ArchivePolicyItem(
-                    granularity=2, points=3600 * 24),
+                    granularity=numpy.timedelta64(2, 's'),
+                    timespan=numpy.timedelta64(1, 'D'),
+                ),
             ],
         ),
         'low': archive_policy.ArchivePolicy(
             "low", 0, [
                 # 5 minutes resolution for an hour
                 archive_policy.ArchivePolicyItem(
-                    granularity=300, points=12),
+                    granularity=numpy.timedelta64(5, 'm'), points=12),
                 # 1 hour resolution for a day
                 archive_policy.ArchivePolicyItem(
-                    granularity=3600, points=24),
+                    granularity=numpy.timedelta64(1, 'h'), points=24),
                 # 1 day resolution for a month
                 archive_policy.ArchivePolicyItem(
-                    granularity=3600 * 24, points=30),
+                    granularity=numpy.timedelta64(1, 'D'), points=30),
             ],
         ),
         'medium': archive_policy.ArchivePolicy(
             "medium", 0, [
                 # 1 minute resolution for an day
                 archive_policy.ArchivePolicyItem(
-                    granularity=60, points=60 * 24),
+                    granularity=numpy.timedelta64(1, 'm'), points=60 * 24),
                 # 1 hour resolution for a week
                 archive_policy.ArchivePolicyItem(
-                    granularity=3600, points=7 * 24),
+                    granularity=numpy.timedelta64(1, 'h'), points=7 * 24),
                 # 1 day resolution for a year
                 archive_policy.ArchivePolicyItem(
-                    granularity=3600 * 24, points=365),
+                    granularity=numpy.timedelta64(1, 'D'), points=365),
             ],
         ),
         'high': archive_policy.ArchivePolicy(
             "high", 0, [
                 # 1 second resolution for an hour
                 archive_policy.ArchivePolicyItem(
-                    granularity=1, points=3600),
+                    granularity=numpy.timedelta64(1, 's'), points=3600),
                 # 1 minute resolution for a week
                 archive_policy.ArchivePolicyItem(
-                    granularity=60, points=60 * 24 * 7),
+                    granularity=numpy.timedelta64(1, 'm'), points=60 * 24 * 7),
                 # 1 hour resolution for a year
                 archive_policy.ArchivePolicyItem(
-                    granularity=3600, points=365 * 24),
+                    granularity=numpy.timedelta64(1, 'h'), points=365 * 24),
             ],
         ),
     }

--- a/gnocchi/tests/functional/gabbits/archive.yaml
+++ b/gnocchi/tests/functional/gabbits/archive.yaml
@@ -441,7 +441,7 @@ tests:
                 points: 60
       status: 400
       response_strings:
-          - "Invalid input: not a valid value for dictionary value"
+          - "Invalid input: Timespan must be positive for dictionary value"
 
     - name: create invalid points policy
       POST: /v1/archive_policy
@@ -561,8 +561,8 @@ tests:
       status: 201
       response_json_paths:
           $.definition[0].points: 1000
-          $.definition[0].granularity: "0:00:04"
-          $.definition[0].timespan: "1:06:40"
+          $.definition[0].granularity: "0:00:03.600000"
+          $.definition[0].timespan: "1:00:00"
 
     - name: policy float timespan
       POST: /v1/archive_policy

--- a/gnocchi/tests/test_aggregates.py
+++ b/gnocchi/tests/test_aggregates.py
@@ -16,6 +16,7 @@
 import datetime
 import uuid
 
+import numpy
 from stevedore import extension
 
 from gnocchi import aggregates
@@ -38,18 +39,6 @@ class TestAggregates(tests_base.TestCase):
         self.assertIsInstance(self.custom_agg['moving-average'],
                               moving_stats.MovingAverage)
 
-    def test_check_window_valid(self):
-        for agg_method in self.custom_agg:
-            window = '60s'
-            agg_obj = self.custom_agg[agg_method]
-            result = agg_obj.check_window_valid(window)
-            self.assertEqual(60.0, result)
-
-            window = '60'
-            agg_obj = self.custom_agg[agg_method]
-            result = agg_obj.check_window_valid(window)
-            self.assertEqual(60.0, result)
-
     def _test_create_metric_and_data(self, data, spacing):
         metric = storage.Metric(
             uuid.uuid4(), self.archive_policies['medium'])
@@ -71,18 +60,18 @@ class TestAggregates(tests_base.TestCase):
                                                    spacing=20)
         for agg_method in self.custom_agg:
             agg_obj = self.custom_agg[agg_method]
-            window = 90.0
+            window = numpy.timedelta64(90, 's')
             self.assertRaises(aggregates.CustomAggFailure,
                               agg_obj.retrieve_data,
                               self.storage, metric,
                               start=None, stop=None,
                               window=window)
 
-            window = 120.0
+            window = numpy.timedelta64(120, 's')
             grain, result = agg_obj.retrieve_data(self.storage, metric,
                                                   start=None, stop=None,
                                                   window=window)
-            self.assertEqual(60.0, grain)
+            self.assertEqual(numpy.timedelta64(1, 'm'), grain)
             self.assertEqual(39.0, result[datetime.datetime(2014, 1, 1, 12)])
             self.assertEqual(25.5,
                              result[datetime.datetime(2014, 1, 1, 12, 1)])
@@ -98,16 +87,20 @@ class TestAggregates(tests_base.TestCase):
         result = agg_obj.compute(self.storage, metric,
                                  start=None, stop=None,
                                  window=window, center=center)
-        expected = [(utils.datetime_utc(2014, 1, 1, 12), 120.0, 32.25)]
-        self.assertEqual(expected, result)
+        self.assertEqual([(utils.datetime_utc(2014, 1, 1, 12),
+                           numpy.timedelta64(120, 's'),
+                           32.25)],
+                         result)
 
         center = 'True'
         result = agg_obj.compute(self.storage, metric,
                                  start=None, stop=None,
                                  window=window, center=center)
 
-        expected = [(utils.datetime_utc(2014, 1, 1, 12, 1), 120.0, 28.875)]
-        self.assertEqual(expected, result)
+        self.assertEqual([(utils.datetime_utc(2014, 1, 1, 12, 1),
+                           numpy.timedelta64(120, 's'),
+                           28.875)],
+                         result)
         # (FIXME) atmalagon: doing a centered average when
         # there are only two points in the retrieved data seems weird.
         # better to raise an error or return nan in this case?

--- a/gnocchi/tests/test_archive_policy.py
+++ b/gnocchi/tests/test_archive_policy.py
@@ -11,6 +11,8 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+import numpy
+
 from gnocchi import archive_policy
 from gnocchi import service
 from gnocchi.tests import base
@@ -78,7 +80,7 @@ class TestArchivePolicy(base.BaseTestCase):
                                           0,
                                           [(20, 60), (10, 300), (10, 5)],
                                           ["-mean", "-last"])
-        self.assertEqual(ap.max_block_size, 300)
+        self.assertEqual(ap.max_block_size, numpy.timedelta64(300, 's'))
 
 
 class TestArchivePolicyItem(base.BaseTestCase):

--- a/gnocchi/tests/test_carbonara.py
+++ b/gnocchi/tests/test_carbonara.py
@@ -177,7 +177,7 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
         key = ts.get_split_key()
         o, s = ts.serialize(key)
         saved_ts = carbonara.AggregatedTimeSerie.unserialize(
-            s, key, '74pct', ts.sampling)
+            s, key, '74pct')
 
         ts = carbonara.TimeSerie.from_tuples(
             [(datetime.datetime(2014, 1, 1, 12, 0, 0), 3),
@@ -850,8 +850,7 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
         o, s = ts['return'].serialize(key)
         self.assertEqual(ts['return'],
                          carbonara.AggregatedTimeSerie.unserialize(
-                             s, key,
-                             'mean', 0.5))
+                             s, key, 'mean'))
 
     def test_no_truncation(self):
         ts = {'sampling': 60, 'agg': 'mean'}

--- a/gnocchi/tests/test_carbonara.py
+++ b/gnocchi/tests/test_carbonara.py
@@ -19,11 +19,15 @@ import math
 
 import fixtures
 import iso8601
-import pandas
+import numpy
 import six
 
 from gnocchi import carbonara
 from gnocchi.tests import base
+
+
+def datetime64(*args):
+    return numpy.datetime64(datetime.datetime(*args))
 
 
 class TestBoundTimeSerie(base.BaseTestCase):
@@ -34,62 +38,62 @@ class TestBoundTimeSerie(base.BaseTestCase):
     @staticmethod
     def test_base():
         carbonara.BoundTimeSerie.from_data(
-            [datetime.datetime(2014, 1, 1, 12, 0, 0),
-             datetime.datetime(2014, 1, 1, 12, 0, 4),
-             datetime.datetime(2014, 1, 1, 12, 0, 9)],
+            [datetime64(2014, 1, 1, 12, 0, 0),
+             datetime64(2014, 1, 1, 12, 0, 4),
+             datetime64(2014, 1, 1, 12, 0, 9)],
             [3, 5, 6])
 
     def test_block_size(self):
         ts = carbonara.BoundTimeSerie.from_data(
-            [datetime.datetime(2014, 1, 1, 12, 0, 0),
-             datetime.datetime(2014, 1, 1, 12, 0, 4),
-             datetime.datetime(2014, 1, 1, 12, 0, 9)],
+            [datetime64(2014, 1, 1, 12, 0, 0),
+             datetime64(2014, 1, 1, 12, 0, 4),
+             datetime64(2014, 1, 1, 12, 0, 9)],
             [3, 5, 6],
-            block_size='5s')
+            block_size=numpy.timedelta64(5, 's'))
         self.assertEqual(1, len(ts))
-        ts.set_values([(datetime.datetime(2014, 1, 1, 12, 0, 10), 3),
-                       (datetime.datetime(2014, 1, 1, 12, 0, 11), 4)])
+        ts.set_values([(datetime64(2014, 1, 1, 12, 0, 10), 3),
+                       (datetime64(2014, 1, 1, 12, 0, 11), 4)])
         self.assertEqual(2, len(ts))
 
     def test_block_size_back_window(self):
         ts = carbonara.BoundTimeSerie.from_data(
-            [datetime.datetime(2014, 1, 1, 12, 0, 0),
-             datetime.datetime(2014, 1, 1, 12, 0, 4),
-             datetime.datetime(2014, 1, 1, 12, 0, 9)],
+            [datetime64(2014, 1, 1, 12, 0, 0),
+             datetime64(2014, 1, 1, 12, 0, 4),
+             datetime64(2014, 1, 1, 12, 0, 9)],
             [3, 5, 6],
-            block_size='5s',
+            block_size=numpy.timedelta64(5, 's'),
             back_window=1)
         self.assertEqual(3, len(ts))
-        ts.set_values([(datetime.datetime(2014, 1, 1, 12, 0, 10), 3),
-                       (datetime.datetime(2014, 1, 1, 12, 0, 11), 4)])
+        ts.set_values([(datetime64(2014, 1, 1, 12, 0, 10), 3),
+                       (datetime64(2014, 1, 1, 12, 0, 11), 4)])
         self.assertEqual(3, len(ts))
 
     def test_block_size_unordered(self):
         ts = carbonara.BoundTimeSerie.from_data(
-            [datetime.datetime(2014, 1, 1, 12, 0, 0),
-             datetime.datetime(2014, 1, 1, 12, 0, 5),
-             datetime.datetime(2014, 1, 1, 12, 0, 9)],
+            [datetime64(2014, 1, 1, 12, 0, 0),
+             datetime64(2014, 1, 1, 12, 0, 5),
+             datetime64(2014, 1, 1, 12, 0, 9)],
             [10, 5, 23],
-            block_size='5s')
+            block_size=numpy.timedelta64(5, 's'))
         self.assertEqual(2, len(ts))
-        ts.set_values([(datetime.datetime(2014, 1, 1, 12, 0, 11), 3),
-                       (datetime.datetime(2014, 1, 1, 12, 0, 10), 4)])
+        ts.set_values([(datetime64(2014, 1, 1, 12, 0, 11), 3),
+                       (datetime64(2014, 1, 1, 12, 0, 10), 4)])
         self.assertEqual(2, len(ts))
 
     def test_duplicate_timestamps(self):
         ts = carbonara.BoundTimeSerie.from_data(
-            [datetime.datetime(2014, 1, 1, 12, 0, 0),
-             datetime.datetime(2014, 1, 1, 12, 0, 9)],
+            [datetime64(2014, 1, 1, 12, 0, 0),
+             datetime64(2014, 1, 1, 12, 0, 9)],
             [10, 23])
         self.assertEqual(2, len(ts))
         self.assertEqual(10.0, ts[0])
         self.assertEqual(23.0, ts[1])
 
-        ts.set_values([(datetime.datetime(2014, 1, 1, 13, 0, 10), 3),
-                       (datetime.datetime(2014, 1, 1, 13, 0, 11), 9),
-                       (datetime.datetime(2014, 1, 1, 13, 0, 11), 8),
-                       (datetime.datetime(2014, 1, 1, 13, 0, 11), 7),
-                       (datetime.datetime(2014, 1, 1, 13, 0, 11), 4)])
+        ts.set_values([(datetime64(2014, 1, 1, 13, 0, 10), 3),
+                       (datetime64(2014, 1, 1, 13, 0, 11), 9),
+                       (datetime64(2014, 1, 1, 13, 0, 11), 8),
+                       (datetime64(2014, 1, 1, 13, 0, 11), 7),
+                       (datetime64(2014, 1, 1, 13, 0, 11), 4)])
         self.assertEqual(4, len(ts))
         self.assertEqual(10.0, ts[0])
         self.assertEqual(23.0, ts[1])
@@ -102,15 +106,15 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
     def test_base():
         carbonara.AggregatedTimeSerie.from_data(
             3, 'mean',
-            [datetime.datetime(2014, 1, 1, 12, 0, 0),
-             datetime.datetime(2014, 1, 1, 12, 0, 4),
-             datetime.datetime(2014, 1, 1, 12, 0, 9)],
+            [datetime64(2014, 1, 1, 12, 0, 0),
+             datetime64(2014, 1, 1, 12, 0, 4),
+             datetime64(2014, 1, 1, 12, 0, 9)],
             [3, 5, 6])
         carbonara.AggregatedTimeSerie.from_data(
             "4s", 'mean',
-            [datetime.datetime(2014, 1, 1, 12, 0, 0),
-             datetime.datetime(2014, 1, 1, 12, 0, 4),
-             datetime.datetime(2014, 1, 1, 12, 0, 9)],
+            [datetime64(2014, 1, 1, 12, 0, 0),
+             datetime64(2014, 1, 1, 12, 0, 4),
+             datetime64(2014, 1, 1, 12, 0, 9)],
             [3, 5, 6])
 
     def test_benchmark(self):
@@ -119,40 +123,49 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
 
     def test_fetch_basic(self):
         ts = carbonara.AggregatedTimeSerie.from_data(
-            timestamps=[datetime.datetime(2014, 1, 1, 12, 0, 0),
-                        datetime.datetime(2014, 1, 1, 12, 0, 4),
-                        datetime.datetime(2014, 1, 1, 12, 0, 9)],
+            timestamps=[datetime64(2014, 1, 1, 12, 0, 0),
+                        datetime64(2014, 1, 1, 12, 0, 4),
+                        datetime64(2014, 1, 1, 12, 0, 9)],
             aggregation_method='mean',
             values=[3, 5, 6],
-            sampling="1s")
+            sampling=numpy.timedelta64(1, 's'))
         self.assertEqual(
-            [(datetime.datetime(2014, 1, 1, 12), 1, 3),
-             (datetime.datetime(2014, 1, 1, 12, 0, 4), 1, 5),
-             (datetime.datetime(2014, 1, 1, 12, 0, 9), 1, 6)],
+            [(datetime.datetime(2014, 1, 1, 12),
+              numpy.timedelta64(1000000, 'us'), 3),
+             (datetime.datetime(2014, 1, 1, 12, 0, 4),
+              numpy.timedelta64(1000000, 'us'), 5),
+             (datetime.datetime(2014, 1, 1, 12, 0, 9),
+              numpy.timedelta64(1000000, 'us'), 6)],
             list(ts.fetch()))
         self.assertEqual(
-            [(datetime.datetime(2014, 1, 1, 12, 0, 4), 1, 5),
-             (datetime.datetime(2014, 1, 1, 12, 0, 9), 1, 6)],
+            [(datetime.datetime(2014, 1, 1, 12, 0, 4),
+              numpy.timedelta64(1000000, 'us'), 5),
+             (datetime.datetime(2014, 1, 1, 12, 0, 9),
+              numpy.timedelta64(1000000, 'us'), 6)],
             list(ts.fetch(
-                from_timestamp=datetime.datetime(2014, 1, 1, 12, 0, 4))))
+                from_timestamp=datetime64(2014, 1, 1, 12, 0, 4))))
         self.assertEqual(
-            [(datetime.datetime(2014, 1, 1, 12, 0, 4), 1, 5),
-             (datetime.datetime(2014, 1, 1, 12, 0, 9), 1, 6)],
+            [(datetime.datetime(2014, 1, 1, 12, 0, 4),
+              numpy.timedelta64(1000000, 'us'), 5),
+             (datetime.datetime(2014, 1, 1, 12, 0, 9),
+              numpy.timedelta64(1000000, 'us'), 6)],
             list(ts.fetch(
-                from_timestamp=iso8601.parse_date(
-                    "2014-01-01 12:00:04"))))
+                from_timestamp=numpy.datetime64(iso8601.parse_date(
+                    "2014-01-01 12:00:04")))))
         self.assertEqual(
-            [(datetime.datetime(2014, 1, 1, 12, 0, 4), 1, 5),
-             (datetime.datetime(2014, 1, 1, 12, 0, 9), 1, 6)],
+            [(datetime.datetime(2014, 1, 1, 12, 0, 4),
+              numpy.timedelta64(1000000, 'us'), 5),
+             (datetime.datetime(2014, 1, 1, 12, 0, 9),
+              numpy.timedelta64(1000000, 'us'), 6)],
             list(ts.fetch(
-                from_timestamp=iso8601.parse_date(
-                    "2014-01-01 13:00:04+01:00"))))
+                from_timestamp=numpy.datetime64(iso8601.parse_date(
+                    "2014-01-01 13:00:04+01:00")))))
 
     def test_before_epoch(self):
         ts = carbonara.TimeSerie.from_tuples(
-            [(datetime.datetime(1950, 1, 1, 12), 3),
-             (datetime.datetime(2014, 1, 1, 12), 5),
-             (datetime.datetime(2014, 1, 1, 12), 6)])
+            [(datetime64(1950, 1, 1, 12), 3),
+             (datetime64(2014, 1, 1, 12), 5),
+             (datetime64(2014, 1, 1, 12), 6)])
 
         self.assertRaises(carbonara.BeforeEpochError,
                           ts.group_serie, 60)
@@ -165,13 +178,13 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
 
     def test_74_percentile_serialized(self):
         ts = carbonara.TimeSerie.from_tuples(
-            [(datetime.datetime(2014, 1, 1, 12, 0, 0), 3),
-             (datetime.datetime(2014, 1, 1, 12, 0, 4), 5),
-             (datetime.datetime(2014, 1, 1, 12, 0, 9), 6)])
-        ts = self._resample(ts, 60, '74pct')
+            [(datetime64(2014, 1, 1, 12, 0, 0), 3),
+             (datetime64(2014, 1, 1, 12, 0, 4), 5),
+             (datetime64(2014, 1, 1, 12, 0, 9), 6)])
+        ts = self._resample(ts, numpy.timedelta64(60, 's'), '74pct')
 
         self.assertEqual(1, len(ts))
-        self.assertEqual(5.48, ts[datetime.datetime(2014, 1, 1, 12, 0, 0)])
+        self.assertEqual(5.48, ts[datetime64(2014, 1, 1, 12, 0, 0)])
 
         # Serialize and unserialize
         key = ts.get_split_key()
@@ -180,38 +193,38 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
             s, key, '74pct')
 
         ts = carbonara.TimeSerie.from_tuples(
-            [(datetime.datetime(2014, 1, 1, 12, 0, 0), 3),
-             (datetime.datetime(2014, 1, 1, 12, 0, 4), 5),
-             (datetime.datetime(2014, 1, 1, 12, 0, 9), 6)])
-        ts = self._resample(ts, 60, '74pct')
+            [(datetime64(2014, 1, 1, 12, 0, 0), 3),
+             (datetime64(2014, 1, 1, 12, 0, 4), 5),
+             (datetime64(2014, 1, 1, 12, 0, 9), 6)])
+        ts = self._resample(ts, numpy.timedelta64(60, 's'), '74pct')
         ts.merge(saved_ts)
 
         self.assertEqual(1, len(ts))
-        self.assertEqual(5.48, ts[datetime.datetime(2014, 1, 1, 12, 0, 0)])
+        self.assertEqual(5.48, ts[datetime64(2014, 1, 1, 12, 0, 0)])
 
     def test_95_percentile(self):
         ts = carbonara.TimeSerie.from_tuples(
-            [(datetime.datetime(2014, 1, 1, 12, 0, 0), 3),
-             (datetime.datetime(2014, 1, 1, 12, 0, 4), 5),
-             (datetime.datetime(2014, 1, 1, 12, 0, 9), 6)])
-        ts = self._resample(ts, 60, '95pct')
+            [(datetime64(2014, 1, 1, 12, 0, 0), 3),
+             (datetime64(2014, 1, 1, 12, 0, 4), 5),
+             (datetime64(2014, 1, 1, 12, 0, 9), 6)])
+        ts = self._resample(ts, numpy.timedelta64(60, 's'), '95pct')
 
         self.assertEqual(1, len(ts))
         self.assertEqual(5.9000000000000004,
-                         ts[datetime.datetime(2014, 1, 1, 12, 0, 0)])
+                         ts[datetime64(2014, 1, 1, 12, 0, 0)])
 
     def _do_test_aggregation(self, name, v1, v2):
         ts = carbonara.TimeSerie.from_tuples(
-            [(datetime.datetime(2014, 1, 1, 12, 0, 0), 3),
-             (datetime.datetime(2014, 1, 1, 12, 0, 4), 6),
-             (datetime.datetime(2014, 1, 1, 12, 0, 9), 5),
-             (datetime.datetime(2014, 1, 1, 12, 1, 4), 8),
-             (datetime.datetime(2014, 1, 1, 12, 1, 6), 9)])
-        ts = self._resample(ts, 60, name)
+            [(datetime64(2014, 1, 1, 12, 0, 0), 3),
+             (datetime64(2014, 1, 1, 12, 0, 4), 6),
+             (datetime64(2014, 1, 1, 12, 0, 9), 5),
+             (datetime64(2014, 1, 1, 12, 1, 4), 8),
+             (datetime64(2014, 1, 1, 12, 1, 6), 9)])
+        ts = self._resample(ts, numpy.timedelta64(60, 's'), name)
 
         self.assertEqual(2, len(ts))
-        self.assertEqual(v1, ts[datetime.datetime(2014, 1, 1, 12, 0, 0)])
-        self.assertEqual(v2, ts[datetime.datetime(2014, 1, 1, 12, 1, 0)])
+        self.assertEqual(v1, ts[datetime64(2014, 1, 1, 12, 0, 0)])
+        self.assertEqual(v2, ts[datetime64(2014, 1, 1, 12, 1, 0)])
 
     def test_aggregation_first(self):
         self._do_test_aggregation('first', 3, 8)
@@ -243,37 +256,37 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
 
     def test_aggregation_std_with_unique(self):
         ts = carbonara.TimeSerie.from_tuples(
-            [(datetime.datetime(2014, 1, 1, 12, 0, 0), 3)])
-        ts = self._resample(ts, 60, 'std')
+            [(datetime64(2014, 1, 1, 12, 0, 0), 3)])
+        ts = self._resample(ts, numpy.timedelta64(60, 's'), 'std')
         self.assertEqual(0, len(ts), ts.ts.values)
 
         ts = carbonara.TimeSerie.from_tuples(
-            [(datetime.datetime(2014, 1, 1, 12, 0, 0), 3),
-             (datetime.datetime(2014, 1, 1, 12, 0, 4), 6),
-             (datetime.datetime(2014, 1, 1, 12, 0, 9), 5),
-             (datetime.datetime(2014, 1, 1, 12, 1, 6), 9)])
-        ts = self._resample(ts, 60, "std")
+            [(datetime64(2014, 1, 1, 12, 0, 0), 3),
+             (datetime64(2014, 1, 1, 12, 0, 4), 6),
+             (datetime64(2014, 1, 1, 12, 0, 9), 5),
+             (datetime64(2014, 1, 1, 12, 1, 6), 9)])
+        ts = self._resample(ts, numpy.timedelta64(60, 's'), "std")
 
         self.assertEqual(1, len(ts))
         self.assertEqual(1.5275252316519465,
-                         ts[datetime.datetime(2014, 1, 1, 12, 0, 0)])
+                         ts[datetime64(2014, 1, 1, 12, 0, 0)])
 
     def test_different_length_in_timestamps_and_data(self):
         self.assertRaises(ValueError,
                           carbonara.AggregatedTimeSerie.from_data,
                           3, 'mean',
-                          [datetime.datetime(2014, 1, 1, 12, 0, 0),
-                           datetime.datetime(2014, 1, 1, 12, 0, 4),
-                           datetime.datetime(2014, 1, 1, 12, 0, 9)],
+                          [datetime64(2014, 1, 1, 12, 0, 0),
+                           datetime64(2014, 1, 1, 12, 0, 4),
+                           datetime64(2014, 1, 1, 12, 0, 9)],
                           [3, 5])
 
     def test_max_size(self):
         ts = carbonara.TimeSerie.from_data(
-            [datetime.datetime(2014, 1, 1, 12, 0, 0),
-             datetime.datetime(2014, 1, 1, 12, 0, 4),
-             datetime.datetime(2014, 1, 1, 12, 0, 9)],
+            [datetime64(2014, 1, 1, 12, 0, 0),
+             datetime64(2014, 1, 1, 12, 0, 4),
+             datetime64(2014, 1, 1, 12, 0, 9)],
             [3, 5, 6])
-        ts = self._resample(ts, 1, 'mean', max_size=2)
+        ts = self._resample(ts, numpy.timedelta64(1, 's'), 'mean', max_size=2)
 
         self.assertEqual(2, len(ts))
         self.assertEqual(5, ts[0])
@@ -281,40 +294,40 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
 
     def test_down_sampling(self):
         ts = carbonara.TimeSerie.from_data(
-            [datetime.datetime(2014, 1, 1, 12, 0, 0),
-             datetime.datetime(2014, 1, 1, 12, 0, 4),
-             datetime.datetime(2014, 1, 1, 12, 0, 9)],
+            [datetime64(2014, 1, 1, 12, 0, 0),
+             datetime64(2014, 1, 1, 12, 0, 4),
+             datetime64(2014, 1, 1, 12, 0, 9)],
             [3, 5, 7])
-        ts = self._resample(ts, 300, 'mean')
+        ts = self._resample(ts, numpy.timedelta64(300, 's'), 'mean')
 
         self.assertEqual(1, len(ts))
-        self.assertEqual(5, ts[datetime.datetime(2014, 1, 1, 12, 0, 0)])
+        self.assertEqual(5, ts[datetime64(2014, 1, 1, 12, 0, 0)])
 
     def test_down_sampling_with_max_size(self):
         ts = carbonara.TimeSerie.from_data(
-            [datetime.datetime(2014, 1, 1, 12, 0, 0),
-             datetime.datetime(2014, 1, 1, 12, 1, 4),
-             datetime.datetime(2014, 1, 1, 12, 1, 9),
-             datetime.datetime(2014, 1, 1, 12, 2, 12)],
+            [datetime64(2014, 1, 1, 12, 0, 0),
+             datetime64(2014, 1, 1, 12, 1, 4),
+             datetime64(2014, 1, 1, 12, 1, 9),
+             datetime64(2014, 1, 1, 12, 2, 12)],
             [3, 5, 7, 1])
-        ts = self._resample(ts, 60, 'mean', max_size=2)
+        ts = self._resample(ts, numpy.timedelta64(60, 's'), 'mean', max_size=2)
 
         self.assertEqual(2, len(ts))
-        self.assertEqual(6, ts[datetime.datetime(2014, 1, 1, 12, 1, 0)])
-        self.assertEqual(1, ts[datetime.datetime(2014, 1, 1, 12, 2, 0)])
+        self.assertEqual(6, ts[datetime64(2014, 1, 1, 12, 1, 0)])
+        self.assertEqual(1, ts[datetime64(2014, 1, 1, 12, 2, 0)])
 
     def test_down_sampling_with_max_size_and_method_max(self):
         ts = carbonara.TimeSerie.from_data(
-            [datetime.datetime(2014, 1, 1, 12, 0, 0),
-             datetime.datetime(2014, 1, 1, 12, 1, 4),
-             datetime.datetime(2014, 1, 1, 12, 1, 9),
-             datetime.datetime(2014, 1, 1, 12, 2, 12)],
+            [datetime64(2014, 1, 1, 12, 0, 0),
+             datetime64(2014, 1, 1, 12, 1, 4),
+             datetime64(2014, 1, 1, 12, 1, 9),
+             datetime64(2014, 1, 1, 12, 2, 12)],
             [3, 5, 70, 1])
-        ts = self._resample(ts, 60, 'max', max_size=2)
+        ts = self._resample(ts, numpy.timedelta64(60, 's'), 'max', max_size=2)
 
         self.assertEqual(2, len(ts))
-        self.assertEqual(70, ts[datetime.datetime(2014, 1, 1, 12, 1, 0)])
-        self.assertEqual(1, ts[datetime.datetime(2014, 1, 1, 12, 2, 0)])
+        self.assertEqual(70, ts[datetime64(2014, 1, 1, 12, 1, 0)])
+        self.assertEqual(1, ts[datetime64(2014, 1, 1, 12, 2, 0)])
 
     @staticmethod
     def _resample_and_merge(ts, agg_dict):
@@ -328,31 +341,36 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
             agg_dict['return'].merge(existing)
 
     def test_aggregated_different_archive_no_overlap(self):
-        tsc1 = {'sampling': 60, 'size': 50, 'agg': 'mean'}
+        tsc1 = {'sampling': numpy.timedelta64(60, 's'),
+                'size': 50, 'agg': 'mean'}
         tsb1 = carbonara.BoundTimeSerie(block_size=tsc1['sampling'])
-        tsc2 = {'sampling': 60, 'size': 50, 'agg': 'mean'}
+        tsc2 = {'sampling': numpy.timedelta64(60, 's'),
+                'size': 50, 'agg': 'mean'}
         tsb2 = carbonara.BoundTimeSerie(block_size=tsc2['sampling'])
 
-        tsb1.set_values([(datetime.datetime(2014, 1, 1, 11, 46, 4), 4)],
+        tsb1.set_values([(datetime64(2014, 1, 1, 11, 46, 4), 4)],
                         before_truncate_callback=functools.partial(
                             self._resample_and_merge, agg_dict=tsc1))
-        tsb2.set_values([(datetime.datetime(2014, 1, 1, 9, 1, 4), 4)],
+        tsb2.set_values([(datetime64(2014, 1, 1, 9, 1, 4), 4)],
                         before_truncate_callback=functools.partial(
                             self._resample_and_merge, agg_dict=tsc2))
 
-        dtfrom = datetime.datetime(2014, 1, 1, 11, 0, 0)
+        dtfrom = datetime64(2014, 1, 1, 11, 0, 0)
         self.assertRaises(carbonara.UnAggregableTimeseries,
                           carbonara.AggregatedTimeSerie.aggregated,
                           [tsc1['return'], tsc2['return']],
                           from_timestamp=dtfrom, aggregation='mean')
 
     def test_aggregated_different_archive_no_overlap2(self):
-        tsc1 = {'sampling': 60, 'size': 50, 'agg': 'mean'}
+        tsc1 = {'sampling': numpy.timedelta64(60, 's'),
+                'size': 50, 'agg': 'mean'}
         tsb1 = carbonara.BoundTimeSerie(block_size=tsc1['sampling'])
-        tsc2 = carbonara.AggregatedTimeSerie(sampling=60, max_size=50,
-                                             aggregation_method='mean')
+        tsc2 = carbonara.AggregatedTimeSerie(
+            sampling=numpy.timedelta64(60, 's'),
+            max_size=50,
+            aggregation_method='mean')
 
-        tsb1.set_values([(datetime.datetime(2014, 1, 1, 12, 3, 0), 4)],
+        tsb1.set_values([(datetime64(2014, 1, 1, 12, 3, 0), 4)],
                         before_truncate_callback=functools.partial(
                             self._resample_and_merge, agg_dict=tsc1))
         self.assertRaises(carbonara.UnAggregableTimeseries,
@@ -360,42 +378,44 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
                           [tsc1['return'], tsc2], aggregation='mean')
 
     def test_aggregated_different_archive_overlap(self):
-        tsc1 = {'sampling': 60, 'size': 10, 'agg': 'mean'}
+        tsc1 = {'sampling': numpy.timedelta64(60, 's'),
+                'size': 10, 'agg': 'mean'}
         tsb1 = carbonara.BoundTimeSerie(block_size=tsc1['sampling'])
-        tsc2 = {'sampling': 60, 'size': 10, 'agg': 'mean'}
+        tsc2 = {'sampling': numpy.timedelta64(60, 's'),
+                'size': 10, 'agg': 'mean'}
         tsb2 = carbonara.BoundTimeSerie(block_size=tsc2['sampling'])
 
         # NOTE(sileht): minute 8 is missing in both and
         # minute 7 in tsc2 too, but it looks like we have
         # enough point to do the aggregation
         tsb1.set_values([
-            (datetime.datetime(2014, 1, 1, 11, 0, 0), 4),
-            (datetime.datetime(2014, 1, 1, 12, 1, 0), 3),
-            (datetime.datetime(2014, 1, 1, 12, 2, 0), 2),
-            (datetime.datetime(2014, 1, 1, 12, 3, 0), 4),
-            (datetime.datetime(2014, 1, 1, 12, 4, 0), 2),
-            (datetime.datetime(2014, 1, 1, 12, 5, 0), 3),
-            (datetime.datetime(2014, 1, 1, 12, 6, 0), 4),
-            (datetime.datetime(2014, 1, 1, 12, 7, 0), 10),
-            (datetime.datetime(2014, 1, 1, 12, 9, 0), 2),
+            (datetime64(2014, 1, 1, 11, 0, 0), 4),
+            (datetime64(2014, 1, 1, 12, 1, 0), 3),
+            (datetime64(2014, 1, 1, 12, 2, 0), 2),
+            (datetime64(2014, 1, 1, 12, 3, 0), 4),
+            (datetime64(2014, 1, 1, 12, 4, 0), 2),
+            (datetime64(2014, 1, 1, 12, 5, 0), 3),
+            (datetime64(2014, 1, 1, 12, 6, 0), 4),
+            (datetime64(2014, 1, 1, 12, 7, 0), 10),
+            (datetime64(2014, 1, 1, 12, 9, 0), 2),
         ], before_truncate_callback=functools.partial(
             self._resample_and_merge, agg_dict=tsc1))
 
         tsb2.set_values([
-            (datetime.datetime(2014, 1, 1, 12, 1, 0), 3),
-            (datetime.datetime(2014, 1, 1, 12, 2, 0), 4),
-            (datetime.datetime(2014, 1, 1, 12, 3, 0), 4),
-            (datetime.datetime(2014, 1, 1, 12, 4, 0), 6),
-            (datetime.datetime(2014, 1, 1, 12, 5, 0), 3),
-            (datetime.datetime(2014, 1, 1, 12, 6, 0), 6),
-            (datetime.datetime(2014, 1, 1, 12, 9, 0), 2),
-            (datetime.datetime(2014, 1, 1, 12, 11, 0), 2),
-            (datetime.datetime(2014, 1, 1, 12, 12, 0), 2),
+            (datetime64(2014, 1, 1, 12, 1, 0), 3),
+            (datetime64(2014, 1, 1, 12, 2, 0), 4),
+            (datetime64(2014, 1, 1, 12, 3, 0), 4),
+            (datetime64(2014, 1, 1, 12, 4, 0), 6),
+            (datetime64(2014, 1, 1, 12, 5, 0), 3),
+            (datetime64(2014, 1, 1, 12, 6, 0), 6),
+            (datetime64(2014, 1, 1, 12, 9, 0), 2),
+            (datetime64(2014, 1, 1, 12, 11, 0), 2),
+            (datetime64(2014, 1, 1, 12, 12, 0), 2),
         ], before_truncate_callback=functools.partial(
             self._resample_and_merge, agg_dict=tsc2))
 
-        dtfrom = datetime.datetime(2014, 1, 1, 12, 0, 0)
-        dtto = datetime.datetime(2014, 1, 1, 12, 10, 0)
+        dtfrom = datetime64(2014, 1, 1, 12, 0, 0)
+        dtto = datetime64(2014, 1, 1, 12, 10, 0)
 
         # By default we require 100% of point that overlap
         # so that fail
@@ -412,56 +432,50 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
             aggregation='mean', needed_percent_of_overlap=80.0)
 
         self.assertEqual([
-            (datetime.datetime(
-                2014, 1, 1, 12, 1, 0
-            ), 60.0, 3.0),
-            (datetime.datetime(
-                2014, 1, 1, 12, 2, 0
-            ), 60.0, 3.0),
-            (datetime.datetime(
-                2014, 1, 1, 12, 3, 0
-            ), 60.0, 4.0),
-            (datetime.datetime(
-                2014, 1, 1, 12, 4, 0
-            ), 60.0, 4.0),
-            (datetime.datetime(
-                2014, 1, 1, 12, 5, 0
-            ), 60.0, 3.0),
-            (datetime.datetime(
-                2014, 1, 1, 12, 6, 0
-            ), 60.0, 5.0),
-            (datetime.datetime(
-                2014, 1, 1, 12, 7, 0
-            ), 60.0, 10.0),
-            (datetime.datetime(
-                2014, 1, 1, 12, 9, 0
-            ), 60.0, 2.0),
+            (datetime64(2014, 1, 1, 12, 1, 0),
+             numpy.timedelta64(60, 's'), 3.0),
+            (datetime64(2014, 1, 1, 12, 2, 0),
+             numpy.timedelta64(60, 's'), 3.0),
+            (datetime64(2014, 1, 1, 12, 3, 0),
+             numpy.timedelta64(60, 's'), 4.0),
+            (datetime64(2014, 1, 1, 12, 4, 0),
+             numpy.timedelta64(60, 's'), 4.0),
+            (datetime64(2014, 1, 1, 12, 5, 0),
+             numpy.timedelta64(60, 's'), 3.0),
+            (datetime64(2014, 1, 1, 12, 6, 0),
+             numpy.timedelta64(60, 's'), 5.0),
+            (datetime64(2014, 1, 1, 12, 7, 0),
+             numpy.timedelta64(60, 's'), 10.0),
+            (datetime64(2014, 1, 1, 12, 9, 0),
+             numpy.timedelta64(60, 's'), 2.0),
         ], list(output))
 
     def test_aggregated_different_archive_overlap_edge_missing1(self):
-        tsc1 = {'sampling': 60, 'size': 10, 'agg': 'mean'}
+        tsc1 = {'sampling': numpy.timedelta64(60, 's'),
+                'size': 10, 'agg': 'mean'}
         tsb1 = carbonara.BoundTimeSerie(block_size=tsc1['sampling'])
-        tsc2 = {'sampling': 60, 'size': 10, 'agg': 'mean'}
+        tsc2 = {'sampling': numpy.timedelta64(60, 's'),
+                'size': 10, 'agg': 'mean'}
         tsb2 = carbonara.BoundTimeSerie(block_size=tsc2['sampling'])
 
         tsb1.set_values([
-            (datetime.datetime(2014, 1, 1, 12, 3, 0), 9),
-            (datetime.datetime(2014, 1, 1, 12, 4, 0), 1),
-            (datetime.datetime(2014, 1, 1, 12, 5, 0), 2),
-            (datetime.datetime(2014, 1, 1, 12, 6, 0), 7),
-            (datetime.datetime(2014, 1, 1, 12, 7, 0), 5),
-            (datetime.datetime(2014, 1, 1, 12, 8, 0), 3),
+            (datetime64(2014, 1, 1, 12, 3, 0), 9),
+            (datetime64(2014, 1, 1, 12, 4, 0), 1),
+            (datetime64(2014, 1, 1, 12, 5, 0), 2),
+            (datetime64(2014, 1, 1, 12, 6, 0), 7),
+            (datetime64(2014, 1, 1, 12, 7, 0), 5),
+            (datetime64(2014, 1, 1, 12, 8, 0), 3),
         ], before_truncate_callback=functools.partial(
             self._resample_and_merge, agg_dict=tsc1))
 
         tsb2.set_values([
-            (datetime.datetime(2014, 1, 1, 11, 0, 0), 6),
-            (datetime.datetime(2014, 1, 1, 12, 1, 0), 2),
-            (datetime.datetime(2014, 1, 1, 12, 2, 0), 13),
-            (datetime.datetime(2014, 1, 1, 12, 3, 0), 24),
-            (datetime.datetime(2014, 1, 1, 12, 4, 0), 4),
-            (datetime.datetime(2014, 1, 1, 12, 5, 0), 16),
-            (datetime.datetime(2014, 1, 1, 12, 6, 0), 12),
+            (datetime64(2014, 1, 1, 11, 0, 0), 6),
+            (datetime64(2014, 1, 1, 12, 1, 0), 2),
+            (datetime64(2014, 1, 1, 12, 2, 0), 13),
+            (datetime64(2014, 1, 1, 12, 3, 0), 24),
+            (datetime64(2014, 1, 1, 12, 4, 0), 4),
+            (datetime64(2014, 1, 1, 12, 5, 0), 16),
+            (datetime64(2014, 1, 1, 12, 6, 0), 12),
         ], before_truncate_callback=functools.partial(
             self._resample_and_merge, agg_dict=tsc2))
 
@@ -472,120 +486,137 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
             tsc1['return'], tsc2['return']], aggregation='sum')
 
         self.assertEqual([
-            (datetime.datetime(
-                2014, 1, 1, 12, 3, 0
-            ), 60.0, 33.0),
-            (datetime.datetime(
-                2014, 1, 1, 12, 4, 0
-            ), 60.0, 5.0),
-            (datetime.datetime(
-                2014, 1, 1, 12, 5, 0
-            ), 60.0, 18.0),
-            (datetime.datetime(
-                2014, 1, 1, 12, 6, 0
-            ), 60.0, 19.0),
+            (datetime64(2014, 1, 1, 12, 3, 0),
+             numpy.timedelta64(60, 's'), 33.0),
+            (datetime64(2014, 1, 1, 12, 4, 0),
+             numpy.timedelta64(60, 's'), 5.0),
+            (datetime64(2014, 1, 1, 12, 5, 0),
+             numpy.timedelta64(60, 's'), 18.0),
+            (datetime64(2014, 1, 1, 12, 6, 0),
+             numpy.timedelta64(60, 's'), 19.0),
         ], list(output))
 
     def test_aggregated_different_archive_overlap_edge_missing2(self):
-        tsc1 = {'sampling': 60, 'size': 10, 'agg': 'mean'}
+        tsc1 = {'sampling': numpy.timedelta64(60, 's'),
+                'size': 10, 'agg': 'mean'}
         tsb1 = carbonara.BoundTimeSerie(block_size=tsc1['sampling'])
-        tsc2 = {'sampling': 60, 'size': 10, 'agg': 'mean'}
+        tsc2 = {'sampling': numpy.timedelta64(60, 's'),
+                'size': 10, 'agg': 'mean'}
         tsb2 = carbonara.BoundTimeSerie(block_size=tsc2['sampling'])
 
         tsb1.set_values([
-            (datetime.datetime(2014, 1, 1, 12, 3, 0), 4),
+            (datetime64(2014, 1, 1, 12, 3, 0), 4),
         ], before_truncate_callback=functools.partial(
             self._resample_and_merge, agg_dict=tsc1))
 
         tsb2.set_values([
-            (datetime.datetime(2014, 1, 1, 11, 0, 0), 4),
-            (datetime.datetime(2014, 1, 1, 12, 3, 0), 4),
+            (datetime64(2014, 1, 1, 11, 0, 0), 4),
+            (datetime64(2014, 1, 1, 12, 3, 0), 4),
         ], before_truncate_callback=functools.partial(
             self._resample_and_merge, agg_dict=tsc2))
 
         output = carbonara.AggregatedTimeSerie.aggregated(
             [tsc1['return'], tsc2['return']], aggregation='mean')
         self.assertEqual([
-            (datetime.datetime(
+            (datetime64(
                 2014, 1, 1, 12, 3, 0
-            ), 60.0, 4.0),
+            ), numpy.timedelta64(60000000000, 'ns'), 4.0),
         ], list(output))
 
     def test_fetch(self):
-        ts = {'sampling': 60, 'size': 10, 'agg': 'mean'}
+        ts = {'sampling': numpy.timedelta64(60, 's'),
+              'size': 10, 'agg': 'mean'}
         tsb = carbonara.BoundTimeSerie(block_size=ts['sampling'])
 
         tsb.set_values([
-            (datetime.datetime(2014, 1, 1, 11, 46, 4), 4),
-            (datetime.datetime(2014, 1, 1, 11, 47, 34), 8),
-            (datetime.datetime(2014, 1, 1, 11, 50, 54), 50),
-            (datetime.datetime(2014, 1, 1, 11, 54, 45), 4),
-            (datetime.datetime(2014, 1, 1, 11, 56, 49), 4),
-            (datetime.datetime(2014, 1, 1, 11, 57, 22), 6),
-            (datetime.datetime(2014, 1, 1, 11, 58, 22), 5),
-            (datetime.datetime(2014, 1, 1, 12, 1, 4), 4),
-            (datetime.datetime(2014, 1, 1, 12, 1, 9), 7),
-            (datetime.datetime(2014, 1, 1, 12, 2, 1), 15),
-            (datetime.datetime(2014, 1, 1, 12, 2, 12), 1),
-            (datetime.datetime(2014, 1, 1, 12, 3, 0), 3),
-            (datetime.datetime(2014, 1, 1, 12, 4, 9), 7),
-            (datetime.datetime(2014, 1, 1, 12, 5, 1), 15),
-            (datetime.datetime(2014, 1, 1, 12, 5, 12), 1),
-            (datetime.datetime(2014, 1, 1, 12, 6, 0, 2), 3),
+            (datetime64(2014, 1, 1, 11, 46, 4), 4),
+            (datetime64(2014, 1, 1, 11, 47, 34), 8),
+            (datetime64(2014, 1, 1, 11, 50, 54), 50),
+            (datetime64(2014, 1, 1, 11, 54, 45), 4),
+            (datetime64(2014, 1, 1, 11, 56, 49), 4),
+            (datetime64(2014, 1, 1, 11, 57, 22), 6),
+            (datetime64(2014, 1, 1, 11, 58, 22), 5),
+            (datetime64(2014, 1, 1, 12, 1, 4), 4),
+            (datetime64(2014, 1, 1, 12, 1, 9), 7),
+            (datetime64(2014, 1, 1, 12, 2, 1), 15),
+            (datetime64(2014, 1, 1, 12, 2, 12), 1),
+            (datetime64(2014, 1, 1, 12, 3, 0), 3),
+            (datetime64(2014, 1, 1, 12, 4, 9), 7),
+            (datetime64(2014, 1, 1, 12, 5, 1), 15),
+            (datetime64(2014, 1, 1, 12, 5, 12), 1),
+            (datetime64(2014, 1, 1, 12, 6, 0, 2), 3),
         ], before_truncate_callback=functools.partial(
             self._resample_and_merge, agg_dict=ts))
 
         tsb.set_values([
-            (datetime.datetime(2014, 1, 1, 12, 6), 5),
+            (datetime64(2014, 1, 1, 12, 6), 5),
         ], before_truncate_callback=functools.partial(
             self._resample_and_merge, agg_dict=ts))
 
         self.assertEqual([
-            (datetime.datetime(2014, 1, 1, 11, 54), 60.0, 4.0),
-            (datetime.datetime(2014, 1, 1, 11, 56), 60.0, 4.0),
-            (datetime.datetime(2014, 1, 1, 11, 57), 60.0, 6.0),
-            (datetime.datetime(2014, 1, 1, 11, 58), 60.0, 5.0),
-            (datetime.datetime(2014, 1, 1, 12, 1), 60.0, 5.5),
-            (datetime.datetime(2014, 1, 1, 12, 2), 60.0, 8.0),
-            (datetime.datetime(2014, 1, 1, 12, 3), 60.0, 3.0),
-            (datetime.datetime(2014, 1, 1, 12, 4), 60.0, 7.0),
-            (datetime.datetime(2014, 1, 1, 12, 5), 60.0, 8.0),
-            (datetime.datetime(2014, 1, 1, 12, 6), 60.0, 4.0)
+            (datetime.datetime(2014, 1, 1, 11, 54),
+             numpy.timedelta64(60000000000, 'ns'), 4.0),
+            (datetime.datetime(2014, 1, 1, 11, 56),
+             numpy.timedelta64(60000000000, 'ns'), 4.0),
+            (datetime.datetime(2014, 1, 1, 11, 57),
+             numpy.timedelta64(60000000000, 'ns'), 6.0),
+            (datetime.datetime(2014, 1, 1, 11, 58),
+             numpy.timedelta64(60000000000, 'ns'), 5.0),
+            (datetime.datetime(2014, 1, 1, 12, 1),
+             numpy.timedelta64(60000000000, 'ns'), 5.5),
+            (datetime.datetime(2014, 1, 1, 12, 2),
+             numpy.timedelta64(60000000000, 'ns'), 8.0),
+            (datetime.datetime(2014, 1, 1, 12, 3),
+             numpy.timedelta64(60000000000, 'ns'), 3.0),
+            (datetime.datetime(2014, 1, 1, 12, 4),
+             numpy.timedelta64(60000000000, 'ns'), 7.0),
+            (datetime.datetime(2014, 1, 1, 12, 5),
+             numpy.timedelta64(60000000000, 'ns'), 8.0),
+            (datetime.datetime(2014, 1, 1, 12, 6),
+             numpy.timedelta64(60000000000, 'ns'), 4.0)
         ], list(ts['return'].fetch()))
 
         self.assertEqual([
-            (datetime.datetime(2014, 1, 1, 12, 1), 60.0, 5.5),
-            (datetime.datetime(2014, 1, 1, 12, 2), 60.0, 8.0),
-            (datetime.datetime(2014, 1, 1, 12, 3), 60.0, 3.0),
-            (datetime.datetime(2014, 1, 1, 12, 4), 60.0, 7.0),
-            (datetime.datetime(2014, 1, 1, 12, 5), 60.0, 8.0),
-            (datetime.datetime(2014, 1, 1, 12, 6), 60.0, 4.0)
-        ], list(ts['return'].fetch(datetime.datetime(2014, 1, 1, 12, 0, 0))))
+            (datetime.datetime(2014, 1, 1, 12, 1),
+             numpy.timedelta64(60000000000, 'ns'), 5.5),
+            (datetime.datetime(2014, 1, 1, 12, 2),
+             numpy.timedelta64(60000000000, 'ns'), 8.0),
+            (datetime.datetime(2014, 1, 1, 12, 3),
+             numpy.timedelta64(60000000000, 'ns'), 3.0),
+            (datetime.datetime(2014, 1, 1, 12, 4),
+             numpy.timedelta64(60000000000, 'ns'), 7.0),
+            (datetime.datetime(2014, 1, 1, 12, 5),
+             numpy.timedelta64(60000000000, 'ns'), 8.0),
+            (datetime.datetime(2014, 1, 1, 12, 6),
+             numpy.timedelta64(60000000000, 'ns'), 4.0)
+        ], list(ts['return'].fetch(datetime64(2014, 1, 1, 12, 0, 0))))
 
     def test_aggregated_some_overlap_with_fill_zero(self):
-        tsc1 = {'sampling': 60, 'size': 10, 'agg': 'mean'}
+        tsc1 = {'sampling': numpy.timedelta64(60, 's'),
+                'size': 10, 'agg': 'mean'}
         tsb1 = carbonara.BoundTimeSerie(block_size=tsc1['sampling'])
-        tsc2 = {'sampling': 60, 'size': 10, 'agg': 'mean'}
+        tsc2 = {'sampling': numpy.timedelta64(60, 's'),
+                'size': 10, 'agg': 'mean'}
         tsb2 = carbonara.BoundTimeSerie(block_size=tsc2['sampling'])
 
         tsb1.set_values([
-            (datetime.datetime(2014, 1, 1, 12, 3, 0), 9),
-            (datetime.datetime(2014, 1, 1, 12, 4, 0), 1),
-            (datetime.datetime(2014, 1, 1, 12, 5, 0), 2),
-            (datetime.datetime(2014, 1, 1, 12, 6, 0), 7),
-            (datetime.datetime(2014, 1, 1, 12, 7, 0), 5),
-            (datetime.datetime(2014, 1, 1, 12, 8, 0), 3),
+            (datetime64(2014, 1, 1, 12, 3, 0), 9),
+            (datetime64(2014, 1, 1, 12, 4, 0), 1),
+            (datetime64(2014, 1, 1, 12, 5, 0), 2),
+            (datetime64(2014, 1, 1, 12, 6, 0), 7),
+            (datetime64(2014, 1, 1, 12, 7, 0), 5),
+            (datetime64(2014, 1, 1, 12, 8, 0), 3),
         ], before_truncate_callback=functools.partial(
             self._resample_and_merge, agg_dict=tsc1))
 
         tsb2.set_values([
-            (datetime.datetime(2014, 1, 1, 12, 0, 0), 6),
-            (datetime.datetime(2014, 1, 1, 12, 1, 0), 2),
-            (datetime.datetime(2014, 1, 1, 12, 2, 0), 13),
-            (datetime.datetime(2014, 1, 1, 12, 3, 0), 24),
-            (datetime.datetime(2014, 1, 1, 12, 4, 0), 4),
-            (datetime.datetime(2014, 1, 1, 12, 5, 0), 16),
-            (datetime.datetime(2014, 1, 1, 12, 6, 0), 12),
+            (datetime64(2014, 1, 1, 12, 0, 0), 6),
+            (datetime64(2014, 1, 1, 12, 1, 0), 2),
+            (datetime64(2014, 1, 1, 12, 2, 0), 13),
+            (datetime64(2014, 1, 1, 12, 3, 0), 24),
+            (datetime64(2014, 1, 1, 12, 4, 0), 4),
+            (datetime64(2014, 1, 1, 12, 5, 0), 16),
+            (datetime64(2014, 1, 1, 12, 6, 0), 12),
         ], before_truncate_callback=functools.partial(
             self._resample_and_merge, agg_dict=tsc2))
 
@@ -593,41 +624,52 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
             tsc1['return'], tsc2['return']], aggregation='mean', fill=0)
 
         self.assertEqual([
-            (datetime.datetime(2014, 1, 1, 12, 0, 0), 60.0, 3.0),
-            (datetime.datetime(2014, 1, 1, 12, 1, 0), 60.0, 1.0),
-            (datetime.datetime(2014, 1, 1, 12, 2, 0), 60.0, 6.5),
-            (datetime.datetime(2014, 1, 1, 12, 3, 0), 60.0, 16.5),
-            (datetime.datetime(2014, 1, 1, 12, 4, 0), 60.0, 2.5),
-            (datetime.datetime(2014, 1, 1, 12, 5, 0), 60.0, 9.0),
-            (datetime.datetime(2014, 1, 1, 12, 6, 0), 60.0, 9.5),
-            (datetime.datetime(2014, 1, 1, 12, 7, 0), 60.0, 2.5),
-            (datetime.datetime(2014, 1, 1, 12, 8, 0), 60.0, 1.5),
+            (datetime.datetime(2014, 1, 1, 12, 0, 0),
+             numpy.timedelta64(60000000000, 'ns'), 3.0),
+            (datetime.datetime(2014, 1, 1, 12, 1, 0),
+             numpy.timedelta64(60000000000, 'ns'), 1.0),
+            (datetime.datetime(2014, 1, 1, 12, 2, 0),
+             numpy.timedelta64(60000000000, 'ns'), 6.5),
+            (datetime.datetime(2014, 1, 1, 12, 3, 0),
+             numpy.timedelta64(60000000000, 'ns'), 16.5),
+            (datetime.datetime(2014, 1, 1, 12, 4, 0),
+             numpy.timedelta64(60000000000, 'ns'), 2.5),
+            (datetime.datetime(2014, 1, 1, 12, 5, 0),
+             numpy.timedelta64(60000000000, 'ns'), 9.0),
+            (datetime.datetime(2014, 1, 1, 12, 6, 0),
+             numpy.timedelta64(60000000000, 'ns'), 9.5),
+            (datetime.datetime(2014, 1, 1, 12, 7, 0),
+             numpy.timedelta64(60000000000, 'ns'), 2.5),
+            (datetime.datetime(2014, 1, 1, 12, 8, 0),
+             numpy.timedelta64(60000000000, 'ns'), 1.5),
         ], list(output))
 
     def test_aggregated_some_overlap_with_fill_null(self):
-        tsc1 = {'sampling': 60, 'size': 10, 'agg': 'mean'}
+        tsc1 = {'sampling': numpy.timedelta64(60, 's'),
+                'size': 10, 'agg': 'mean'}
         tsb1 = carbonara.BoundTimeSerie(block_size=tsc1['sampling'])
-        tsc2 = {'sampling': 60, 'size': 10, 'agg': 'mean'}
+        tsc2 = {'sampling': numpy.timedelta64(60, 's'),
+                'size': 10, 'agg': 'mean'}
         tsb2 = carbonara.BoundTimeSerie(block_size=tsc2['sampling'])
 
         tsb1.set_values([
-            (datetime.datetime(2014, 1, 1, 12, 3, 0), 9),
-            (datetime.datetime(2014, 1, 1, 12, 4, 0), 1),
-            (datetime.datetime(2014, 1, 1, 12, 5, 0), 2),
-            (datetime.datetime(2014, 1, 1, 12, 6, 0), 7),
-            (datetime.datetime(2014, 1, 1, 12, 7, 0), 5),
-            (datetime.datetime(2014, 1, 1, 12, 8, 0), 3),
+            (datetime64(2014, 1, 1, 12, 3, 0), 9),
+            (datetime64(2014, 1, 1, 12, 4, 0), 1),
+            (datetime64(2014, 1, 1, 12, 5, 0), 2),
+            (datetime64(2014, 1, 1, 12, 6, 0), 7),
+            (datetime64(2014, 1, 1, 12, 7, 0), 5),
+            (datetime64(2014, 1, 1, 12, 8, 0), 3),
         ], before_truncate_callback=functools.partial(
             self._resample_and_merge, agg_dict=tsc1))
 
         tsb2.set_values([
-            (datetime.datetime(2014, 1, 1, 12, 0, 0), 6),
-            (datetime.datetime(2014, 1, 1, 12, 1, 0), 2),
-            (datetime.datetime(2014, 1, 1, 12, 2, 0), 13),
-            (datetime.datetime(2014, 1, 1, 12, 3, 0), 24),
-            (datetime.datetime(2014, 1, 1, 12, 4, 0), 4),
-            (datetime.datetime(2014, 1, 1, 12, 5, 0), 16),
-            (datetime.datetime(2014, 1, 1, 12, 6, 0), 12),
+            (datetime64(2014, 1, 1, 12, 0, 0), 6),
+            (datetime64(2014, 1, 1, 12, 1, 0), 2),
+            (datetime64(2014, 1, 1, 12, 2, 0), 13),
+            (datetime64(2014, 1, 1, 12, 3, 0), 24),
+            (datetime64(2014, 1, 1, 12, 4, 0), 4),
+            (datetime64(2014, 1, 1, 12, 5, 0), 16),
+            (datetime64(2014, 1, 1, 12, 6, 0), 12),
         ], before_truncate_callback=functools.partial(
             self._resample_and_merge, agg_dict=tsc2))
 
@@ -635,37 +677,48 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
             tsc1['return'], tsc2['return']], aggregation='mean', fill='null')
 
         self.assertEqual([
-            (datetime.datetime(2014, 1, 1, 12, 0, 0), 60.0, 6.0),
-            (datetime.datetime(2014, 1, 1, 12, 1, 0), 60.0, 2.0),
-            (datetime.datetime(2014, 1, 1, 12, 2, 0), 60.0, 13.0),
-            (datetime.datetime(2014, 1, 1, 12, 3, 0), 60.0, 16.5),
-            (datetime.datetime(2014, 1, 1, 12, 4, 0), 60.0, 2.5),
-            (datetime.datetime(2014, 1, 1, 12, 5, 0), 60.0, 9.0),
-            (datetime.datetime(2014, 1, 1, 12, 6, 0), 60.0, 9.5),
-            (datetime.datetime(2014, 1, 1, 12, 7, 0), 60.0, 5.0),
-            (datetime.datetime(2014, 1, 1, 12, 8, 0), 60.0, 3.0),
+            (datetime.datetime(2014, 1, 1, 12, 0, 0),
+             numpy.timedelta64(60000000000, 'ns'), 6.0),
+            (datetime.datetime(2014, 1, 1, 12, 1, 0),
+             numpy.timedelta64(60000000000, 'ns'), 2.0),
+            (datetime.datetime(2014, 1, 1, 12, 2, 0),
+             numpy.timedelta64(60000000000, 'ns'), 13.0),
+            (datetime.datetime(2014, 1, 1, 12, 3, 0),
+             numpy.timedelta64(60000000000, 'ns'), 16.5),
+            (datetime.datetime(2014, 1, 1, 12, 4, 0),
+             numpy.timedelta64(60000000000, 'ns'), 2.5),
+            (datetime.datetime(2014, 1, 1, 12, 5, 0),
+             numpy.timedelta64(60000000000, 'ns'), 9.0),
+            (datetime.datetime(2014, 1, 1, 12, 6, 0),
+             numpy.timedelta64(60000000000, 'ns'), 9.5),
+            (datetime.datetime(2014, 1, 1, 12, 7, 0),
+             numpy.timedelta64(60000000000, 'ns'), 5.0),
+            (datetime.datetime(2014, 1, 1, 12, 8, 0),
+             numpy.timedelta64(60000000000, 'ns'), 3.0),
         ], list(output))
 
     def test_aggregate_no_points_with_fill_zero(self):
-        tsc1 = {'sampling': 60, 'size': 10, 'agg': 'mean'}
+        tsc1 = {'sampling': numpy.timedelta64(60, 's'),
+                'size': 10, 'agg': 'mean'}
         tsb1 = carbonara.BoundTimeSerie(block_size=tsc1['sampling'])
-        tsc2 = {'sampling': 60, 'size': 10, 'agg': 'mean'}
+        tsc2 = {'sampling': numpy.timedelta64(60, 's'),
+                'size': 10, 'agg': 'mean'}
         tsb2 = carbonara.BoundTimeSerie(block_size=tsc2['sampling'])
 
         tsb1.set_values([
-            (datetime.datetime(2014, 1, 1, 12, 3, 0), 9),
-            (datetime.datetime(2014, 1, 1, 12, 4, 0), 1),
-            (datetime.datetime(2014, 1, 1, 12, 7, 0), 5),
-            (datetime.datetime(2014, 1, 1, 12, 8, 0), 3),
+            (datetime64(2014, 1, 1, 12, 3, 0), 9),
+            (datetime64(2014, 1, 1, 12, 4, 0), 1),
+            (datetime64(2014, 1, 1, 12, 7, 0), 5),
+            (datetime64(2014, 1, 1, 12, 8, 0), 3),
         ], before_truncate_callback=functools.partial(
             self._resample_and_merge, agg_dict=tsc1))
 
         tsb2.set_values([
-            (datetime.datetime(2014, 1, 1, 12, 0, 0), 6),
-            (datetime.datetime(2014, 1, 1, 12, 1, 0), 2),
-            (datetime.datetime(2014, 1, 1, 12, 2, 0), 13),
-            (datetime.datetime(2014, 1, 1, 12, 3, 0), 24),
-            (datetime.datetime(2014, 1, 1, 12, 4, 0), 4),
+            (datetime64(2014, 1, 1, 12, 0, 0), 6),
+            (datetime64(2014, 1, 1, 12, 1, 0), 2),
+            (datetime64(2014, 1, 1, 12, 2, 0), 13),
+            (datetime64(2014, 1, 1, 12, 3, 0), 24),
+            (datetime64(2014, 1, 1, 12, 4, 0), 4),
         ], before_truncate_callback=functools.partial(
             self._resample_and_merge, agg_dict=tsc2))
 
@@ -673,31 +726,39 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
             tsc1['return'], tsc2['return']], aggregation='mean', fill=0)
 
         self.assertEqual([
-            (datetime.datetime(2014, 1, 1, 12, 0, 0), 60.0, 3.0),
-            (datetime.datetime(2014, 1, 1, 12, 1, 0), 60.0, 1.0),
-            (datetime.datetime(2014, 1, 1, 12, 2, 0), 60.0, 6.5),
-            (datetime.datetime(2014, 1, 1, 12, 3, 0), 60.0, 16.5),
-            (datetime.datetime(2014, 1, 1, 12, 4, 0), 60.0, 2.5),
-            (datetime.datetime(2014, 1, 1, 12, 7, 0), 60.0, 2.5),
-            (datetime.datetime(2014, 1, 1, 12, 8, 0), 60.0, 1.5),
+            (datetime.datetime(2014, 1, 1, 12, 0, 0),
+             numpy.timedelta64(60000000000, 'ns'), 3.0),
+            (datetime.datetime(2014, 1, 1, 12, 1, 0),
+             numpy.timedelta64(60000000000, 'ns'), 1.0),
+            (datetime.datetime(2014, 1, 1, 12, 2, 0),
+             numpy.timedelta64(60000000000, 'ns'), 6.5),
+            (datetime.datetime(2014, 1, 1, 12, 3, 0),
+             numpy.timedelta64(60000000000, 'ns'), 16.5),
+            (datetime.datetime(2014, 1, 1, 12, 4, 0),
+             numpy.timedelta64(60000000000, 'ns'), 2.5),
+            (datetime.datetime(2014, 1, 1, 12, 7, 0),
+             numpy.timedelta64(60000000000, 'ns'), 2.5),
+            (datetime.datetime(2014, 1, 1, 12, 8, 0),
+             numpy.timedelta64(60000000000, 'ns'), 1.5),
         ], list(output))
 
     def test_fetch_agg_pct(self):
-        ts = {'sampling': 1, 'size': 3600 * 24, 'agg': '90pct'}
+        ts = {'sampling': numpy.timedelta64(1, 's'),
+              'size': 3600 * 24, 'agg': '90pct'}
         tsb = carbonara.BoundTimeSerie(block_size=ts['sampling'])
 
-        tsb.set_values([(datetime.datetime(2014, 1, 1, 12, 0, 0), 3),
-                        (datetime.datetime(2014, 1, 1, 12, 0, 0, 123), 4),
-                        (datetime.datetime(2014, 1, 1, 12, 0, 2), 4)],
+        tsb.set_values([(datetime64(2014, 1, 1, 12, 0, 0), 3),
+                        (datetime64(2014, 1, 1, 12, 0, 0, 123), 4),
+                        (datetime64(2014, 1, 1, 12, 0, 2), 4)],
                        before_truncate_callback=functools.partial(
                            self._resample_and_merge, agg_dict=ts))
 
-        result = ts['return'].fetch(datetime.datetime(2014, 1, 1, 12, 0, 0))
+        result = ts['return'].fetch(datetime64(2014, 1, 1, 12, 0, 0))
         reference = [
-            (datetime.datetime(
+            (datetime64(
                 2014, 1, 1, 12, 0, 0
             ), 1.0, 3.9),
-            (datetime.datetime(
+            (datetime64(
                 2014, 1, 1, 12, 0, 2
             ), 1.0, 4)
         ]
@@ -710,16 +771,16 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
             # Rounding \o/
             self.assertAlmostEqual(ref[2], res[2])
 
-        tsb.set_values([(datetime.datetime(2014, 1, 1, 12, 0, 2, 113), 110)],
+        tsb.set_values([(datetime64(2014, 1, 1, 12, 0, 2, 113), 110)],
                        before_truncate_callback=functools.partial(
                            self._resample_and_merge, agg_dict=ts))
 
-        result = ts['return'].fetch(datetime.datetime(2014, 1, 1, 12, 0, 0))
+        result = ts['return'].fetch(datetime64(2014, 1, 1, 12, 0, 0))
         reference = [
-            (datetime.datetime(
+            (datetime64(
                 2014, 1, 1, 12, 0, 0
             ), 1.0, 3.9),
-            (datetime.datetime(
+            (datetime64(
                 2014, 1, 1, 12, 0, 2
             ), 1.0, 99.4)
         ]
@@ -733,116 +794,120 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
             self.assertAlmostEqual(ref[2], res[2])
 
     def test_fetch_nano(self):
-        ts = {'sampling': 0.2, 'size': 10, 'agg': 'mean'}
+        ts = {'sampling': numpy.timedelta64(200, 'ms'),
+              'size': 10, 'agg': 'mean'}
         tsb = carbonara.BoundTimeSerie(block_size=ts['sampling'])
 
         tsb.set_values([
-            (datetime.datetime(2014, 1, 1, 11, 46, 0, 200123), 4),
-            (datetime.datetime(2014, 1, 1, 11, 46, 0, 340000), 8),
-            (datetime.datetime(2014, 1, 1, 11, 47, 0, 323154), 50),
-            (datetime.datetime(2014, 1, 1, 11, 48, 0, 590903), 4),
-            (datetime.datetime(2014, 1, 1, 11, 48, 0, 903291), 4),
+            (datetime64(2014, 1, 1, 11, 46, 0, 200123), 4),
+            (datetime64(2014, 1, 1, 11, 46, 0, 340000), 8),
+            (datetime64(2014, 1, 1, 11, 47, 0, 323154), 50),
+            (datetime64(2014, 1, 1, 11, 48, 0, 590903), 4),
+            (datetime64(2014, 1, 1, 11, 48, 0, 903291), 4),
         ], before_truncate_callback=functools.partial(
             self._resample_and_merge, agg_dict=ts))
 
         tsb.set_values([
-            (datetime.datetime(2014, 1, 1, 11, 48, 0, 821312), 5),
+            (datetime64(2014, 1, 1, 11, 48, 0, 821312), 5),
         ], before_truncate_callback=functools.partial(
             self._resample_and_merge, agg_dict=ts))
 
         self.assertEqual([
-            (datetime.datetime(2014, 1, 1, 11, 46, 0, 200000), 0.2, 6.0),
-            (datetime.datetime(2014, 1, 1, 11, 47, 0, 200000), 0.2, 50.0),
-            (datetime.datetime(2014, 1, 1, 11, 48, 0, 400000), 0.2, 4.0),
-            (datetime.datetime(2014, 1, 1, 11, 48, 0, 800000), 0.2, 4.5)
+            (datetime.datetime(2014, 1, 1, 11, 46, 0, 200000),
+             numpy.timedelta64(200000000, 'ns'), 6.0),
+            (datetime.datetime(2014, 1, 1, 11, 47, 0, 200000),
+             numpy.timedelta64(200000000, 'ns'), 50.0),
+            (datetime.datetime(2014, 1, 1, 11, 48, 0, 400000),
+             numpy.timedelta64(200000000, 'ns'), 4.0),
+            (datetime.datetime(2014, 1, 1, 11, 48, 0, 800000),
+             numpy.timedelta64(200000000, 'ns'), 4.5)
         ], list(ts['return'].fetch()))
 
     def test_fetch_agg_std(self):
         # NOTE (gordc): this is a good test to ensure we drop NaN entries
         # 2014-01-01 12:00:00 will appear if we don't dropna()
-        ts = {'sampling': 60, 'size': 60, 'agg': 'std'}
+        ts = {'sampling': numpy.timedelta64(60, 's'),
+              'size': 60, 'agg': 'std'}
         tsb = carbonara.BoundTimeSerie(block_size=ts['sampling'])
 
-        tsb.set_values([(datetime.datetime(2014, 1, 1, 12, 0, 0), 3),
-                        (datetime.datetime(2014, 1, 1, 12, 1, 4), 4),
-                        (datetime.datetime(2014, 1, 1, 12, 1, 9), 7),
-                        (datetime.datetime(2014, 1, 1, 12, 2, 1), 15),
-                        (datetime.datetime(2014, 1, 1, 12, 2, 12), 1)],
+        tsb.set_values([(datetime64(2014, 1, 1, 12, 0, 0), 3),
+                        (datetime64(2014, 1, 1, 12, 1, 4), 4),
+                        (datetime64(2014, 1, 1, 12, 1, 9), 7),
+                        (datetime64(2014, 1, 1, 12, 2, 1), 15),
+                        (datetime64(2014, 1, 1, 12, 2, 12), 1)],
                        before_truncate_callback=functools.partial(
                            self._resample_and_merge, agg_dict=ts))
 
         self.assertEqual([
             (datetime.datetime(
                 2014, 1, 1, 12, 1, 0
-            ), 60.0, 2.1213203435596424),
+            ), numpy.timedelta64(60000000000, 'ns'), 2.1213203435596424),
             (datetime.datetime(
                 2014, 1, 1, 12, 2, 0
-            ), 60.0, 9.8994949366116654),
-        ], list(ts['return'].fetch(datetime.datetime(2014, 1, 1, 12, 0, 0))))
+            ), numpy.timedelta64(60000000000, 'ns'), 9.8994949366116654),
+        ], list(ts['return'].fetch(datetime64(2014, 1, 1, 12, 0, 0))))
 
-        tsb.set_values([(datetime.datetime(2014, 1, 1, 12, 2, 13), 110)],
+        tsb.set_values([(datetime64(2014, 1, 1, 12, 2, 13), 110)],
                        before_truncate_callback=functools.partial(
                            self._resample_and_merge, agg_dict=ts))
 
         self.assertEqual([
             (datetime.datetime(
                 2014, 1, 1, 12, 1, 0
-            ), 60.0, 2.1213203435596424),
+            ), numpy.timedelta64(60000000000, 'ns'), 2.1213203435596424),
             (datetime.datetime(
                 2014, 1, 1, 12, 2, 0
-            ), 60.0, 59.304300012730948),
-        ], list(ts['return'].fetch(datetime.datetime(2014, 1, 1, 12, 0, 0))))
+            ), numpy.timedelta64(60000000000, 'ns'), 59.304300012730948),
+        ], list(ts['return'].fetch(datetime64(2014, 1, 1, 12, 0, 0))))
 
     def test_fetch_agg_max(self):
-        ts = {'sampling': 60, 'size': 60, 'agg': 'max'}
+        ts = {'sampling': numpy.timedelta64(60, 's'),
+              'size': 60, 'agg': 'max'}
         tsb = carbonara.BoundTimeSerie(block_size=ts['sampling'])
 
-        tsb.set_values([(datetime.datetime(2014, 1, 1, 12, 0, 0), 3),
-                        (datetime.datetime(2014, 1, 1, 12, 1, 4), 4),
-                        (datetime.datetime(2014, 1, 1, 12, 1, 9), 7),
-                        (datetime.datetime(2014, 1, 1, 12, 2, 1), 15),
-                        (datetime.datetime(2014, 1, 1, 12, 2, 12), 1)],
+        tsb.set_values([(datetime64(2014, 1, 1, 12, 0, 0), 3),
+                        (datetime64(2014, 1, 1, 12, 1, 4), 4),
+                        (datetime64(2014, 1, 1, 12, 1, 9), 7),
+                        (datetime64(2014, 1, 1, 12, 2, 1), 15),
+                        (datetime64(2014, 1, 1, 12, 2, 12), 1)],
                        before_truncate_callback=functools.partial(
                            self._resample_and_merge, agg_dict=ts))
 
         self.assertEqual([
             (datetime.datetime(
                 2014, 1, 1, 12, 0, 0
-            ), 60.0, 3),
+            ), numpy.timedelta64(60000000000, 'ns'), 3),
             (datetime.datetime(
                 2014, 1, 1, 12, 1, 0
-            ), 60.0, 7),
+            ), numpy.timedelta64(60000000000, 'ns'), 7),
             (datetime.datetime(
                 2014, 1, 1, 12, 2, 0
-            ), 60.0, 15),
-        ], list(ts['return'].fetch(datetime.datetime(2014, 1, 1, 12, 0, 0))))
+            ), numpy.timedelta64(60000000000, 'ns'), 15),
+        ], list(ts['return'].fetch(datetime64(2014, 1, 1, 12, 0, 0))))
 
-        tsb.set_values([(datetime.datetime(2014, 1, 1, 12, 2, 13), 110)],
+        tsb.set_values([(datetime64(2014, 1, 1, 12, 2, 13), 110)],
                        before_truncate_callback=functools.partial(
                            self._resample_and_merge, agg_dict=ts))
 
         self.assertEqual([
             (datetime.datetime(
-                2014, 1, 1, 12, 0, 0
-            ), 60.0, 3),
+                2014, 1, 1, 12, 0, 0), numpy.timedelta64(60, 's'), 3),
             (datetime.datetime(
-                2014, 1, 1, 12, 1, 0
-            ), 60.0, 7),
+                2014, 1, 1, 12, 1, 0), numpy.timedelta64(60, 's'), 7),
             (datetime.datetime(
-                2014, 1, 1, 12, 2, 0
-            ), 60.0, 110),
-        ], list(ts['return'].fetch(datetime.datetime(2014, 1, 1, 12, 0, 0))))
+                2014, 1, 1, 12, 2, 0), numpy.timedelta64(60, 's'), 110),
+        ], list(ts['return'].fetch(datetime64(2014, 1, 1, 12, 0, 0))))
 
     def test_serialize(self):
-        ts = {'sampling': 0.5, 'agg': 'mean'}
+        ts = {'sampling': numpy.timedelta64(500, 'ms'), 'agg': 'mean'}
         tsb = carbonara.BoundTimeSerie(block_size=ts['sampling'])
 
         tsb.set_values([
-            (datetime.datetime(2014, 1, 1, 12, 0, 0, 1234), 3),
-            (datetime.datetime(2014, 1, 1, 12, 0, 0, 321), 6),
-            (datetime.datetime(2014, 1, 1, 12, 1, 4, 234), 5),
-            (datetime.datetime(2014, 1, 1, 12, 1, 9, 32), 7),
-            (datetime.datetime(2014, 1, 1, 12, 2, 12, 532), 1),
+            (datetime64(2014, 1, 1, 12, 0, 0, 1234), 3),
+            (datetime64(2014, 1, 1, 12, 0, 0, 321), 6),
+            (datetime64(2014, 1, 1, 12, 1, 4, 234), 5),
+            (datetime64(2014, 1, 1, 12, 1, 9, 32), 7),
+            (datetime64(2014, 1, 1, 12, 2, 12, 532), 1),
         ], before_truncate_callback=functools.partial(
             self._resample_and_merge, agg_dict=ts))
 
@@ -853,16 +918,16 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
                              s, key, 'mean'))
 
     def test_no_truncation(self):
-        ts = {'sampling': 60, 'agg': 'mean'}
+        ts = {'sampling': numpy.timedelta64(60, 's'), 'agg': 'mean'}
         tsb = carbonara.BoundTimeSerie()
 
         for i in six.moves.range(1, 11):
             tsb.set_values([
-                (datetime.datetime(2014, 1, 1, 12, i, i), float(i))
+                (datetime64(2014, 1, 1, 12, i, i), float(i))
             ], before_truncate_callback=functools.partial(
                 self._resample_and_merge, agg_dict=ts))
             tsb.set_values([
-                (datetime.datetime(2014, 1, 1, 12, i, i + 1), float(i + 1))
+                (datetime64(2014, 1, 1, 12, i, i + 1), float(i + 1))
             ], before_truncate_callback=functools.partial(
                 self._resample_and_merge, agg_dict=ts))
             self.assertEqual(i, len(list(ts['return'].fetch())))
@@ -873,29 +938,29 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
         Test the back window on an archive is not longer than the window we
         aggregate on.
         """
-        ts = {'sampling': 1, 'size': 60, 'agg': 'mean'}
+        ts = {'sampling': numpy.timedelta64(1, 's'), 'size': 60, 'agg': 'mean'}
         tsb = carbonara.BoundTimeSerie(block_size=ts['sampling'])
 
         tsb.set_values([
-            (datetime.datetime(2014, 1, 1, 12, 0, 1, 2300), 1),
-            (datetime.datetime(2014, 1, 1, 12, 0, 1, 4600), 2),
-            (datetime.datetime(2014, 1, 1, 12, 0, 2, 4500), 3),
-            (datetime.datetime(2014, 1, 1, 12, 0, 2, 7800), 4),
-            (datetime.datetime(2014, 1, 1, 12, 0, 3, 8), 2.5),
+            (datetime64(2014, 1, 1, 12, 0, 1, 2300), 1),
+            (datetime64(2014, 1, 1, 12, 0, 1, 4600), 2),
+            (datetime64(2014, 1, 1, 12, 0, 2, 4500), 3),
+            (datetime64(2014, 1, 1, 12, 0, 2, 7800), 4),
+            (datetime64(2014, 1, 1, 12, 0, 3, 8), 2.5),
         ], before_truncate_callback=functools.partial(
             self._resample_and_merge, agg_dict=ts))
 
         self.assertEqual(
             [
-                (datetime.datetime(
+                (datetime64(
                     2014, 1, 1, 12, 0, 1
-                ), 1.0, 1.5),
-                (datetime.datetime(
+                ), numpy.timedelta64(1, 's'), 1.5),
+                (datetime64(
                     2014, 1, 1, 12, 0, 2
-                ), 1.0, 3.5),
-                (datetime.datetime(
+                ), numpy.timedelta64(1, 's'), 3.5),
+                (datetime64(
                     2014, 1, 1, 12, 0, 3
-                ), 1.0, 2.5),
+                ), numpy.timedelta64(1, 's'), 2.5),
             ],
             list(ts['return'].fetch()))
 
@@ -905,15 +970,15 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
         Test the back window on an archive is not longer than the window we
         aggregate on.
         """
-        ts = {'sampling': 1, 'size': 60, 'agg': 'mean'}
+        ts = {'sampling': numpy.timedelta64(1, 's'), 'size': 60, 'agg': 'mean'}
         tsb = carbonara.BoundTimeSerie(block_size=ts['sampling'])
 
         tsb.set_values([
-            (datetime.datetime(2014, 1, 1, 12, 0, 1, 2300), 1),
-            (datetime.datetime(2014, 1, 1, 12, 0, 1, 4600), 2),
-            (datetime.datetime(2014, 1, 1, 12, 0, 2, 4500), 3),
-            (datetime.datetime(2014, 1, 1, 12, 0, 2, 7800), 4),
-            (datetime.datetime(2014, 1, 1, 12, 0, 3, 8), 2.5),
+            (datetime64(2014, 1, 1, 12, 0, 1, 2300), 1),
+            (datetime64(2014, 1, 1, 12, 0, 1, 4600), 2),
+            (datetime64(2014, 1, 1, 12, 0, 2, 4500), 3),
+            (datetime64(2014, 1, 1, 12, 0, 2, 7800), 4),
+            (datetime64(2014, 1, 1, 12, 0, 3, 8), 2.5),
         ], before_truncate_callback=functools.partial(
             self._resample_and_merge, agg_dict=ts))
 
@@ -921,61 +986,65 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
             [
                 (datetime.datetime(
                     2014, 1, 1, 12, 0, 1
-                ), 1.0, 1.5),
+                ), numpy.timedelta64(1, 's'), 1.5),
                 (datetime.datetime(
                     2014, 1, 1, 12, 0, 2
-                ), 1.0, 3.5),
+                ), numpy.timedelta64(1, 's'), 3.5),
                 (datetime.datetime(
                     2014, 1, 1, 12, 0, 3
-                ), 1.0, 2.5),
+                ), numpy.timedelta64(1, 's'), 2.5),
             ],
             list(ts['return'].fetch()))
 
         tsb.set_values([
-            (datetime.datetime(2014, 1, 1, 12, 0, 2, 99), 9),
+            (datetime64(2014, 1, 1, 12, 0, 2, 99), 9),
         ], before_truncate_callback=functools.partial(
             self._resample_and_merge, agg_dict=ts))
 
         self.assertEqual(
             [
-                (datetime.datetime(
+                (datetime64(
                     2014, 1, 1, 12, 0, 1
-                ), 1.0, 1.5),
-                (datetime.datetime(
+                ), numpy.timedelta64(1, 's'), 1.5),
+                (datetime64(
                     2014, 1, 1, 12, 0, 2
-                ), 1.0, 3.5),
-                (datetime.datetime(
+                ), numpy.timedelta64(1, 's'), 3.5),
+                (datetime64(
                     2014, 1, 1, 12, 0, 3
-                ), 1.0, 2.5),
+                ), numpy.timedelta64(1, 's'), 2.5),
             ],
             list(ts['return'].fetch()))
 
         tsb.set_values([
-            (datetime.datetime(2014, 1, 1, 12, 0, 2, 99), 9),
-            (datetime.datetime(2014, 1, 1, 12, 0, 3, 9), 4.5),
+            (datetime64(2014, 1, 1, 12, 0, 2, 99), 9),
+            (datetime64(2014, 1, 1, 12, 0, 3, 9), 4.5),
         ], before_truncate_callback=functools.partial(
             self._resample_and_merge, agg_dict=ts))
 
         self.assertEqual(
             [
-                (datetime.datetime(
+                (datetime64(
                     2014, 1, 1, 12, 0, 1
-                ), 1.0, 1.5),
-                (datetime.datetime(
+                ), numpy.timedelta64(1, 's'), 1.5),
+                (datetime64(
                     2014, 1, 1, 12, 0, 2
-                ), 1.0, 3.5),
-                (datetime.datetime(
+                ), numpy.timedelta64(1, 's'), 3.5),
+                (datetime64(
                     2014, 1, 1, 12, 0, 3
-                ), 1.0, 3.5),
+                ), numpy.timedelta64(1, 's'), 3.5),
             ],
             list(ts['return'].fetch()))
 
     def test_aggregated_nominal(self):
-        tsc1 = {'sampling': 60, 'size': 10, 'agg': 'mean'}
-        tsc12 = {'sampling': 300, 'size': 6, 'agg': 'mean'}
+        tsc1 = {'sampling': numpy.timedelta64(60, 's'),
+                'size': 10, 'agg': 'mean'}
+        tsc12 = {'sampling': numpy.timedelta64(300, 's'),
+                 'size': 6, 'agg': 'mean'}
         tsb1 = carbonara.BoundTimeSerie(block_size=tsc12['sampling'])
-        tsc2 = {'sampling': 60, 'size': 10, 'agg': 'mean'}
-        tsc22 = {'sampling': 300, 'size': 6, 'agg': 'mean'}
+        tsc2 = {'sampling': numpy.timedelta64(60, 's'),
+                'size': 10, 'agg': 'mean'}
+        tsc22 = {'sampling': numpy.timedelta64(300, 's'),
+                 'size': 6, 'agg': 'mean'}
         tsb2 = carbonara.BoundTimeSerie(block_size=tsc22['sampling'])
 
         def ts1_update(ts):
@@ -1011,83 +1080,100 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
                 tsc22['return'].merge(existing)
 
         tsb1.set_values([
-            (datetime.datetime(2014, 1, 1, 11, 46, 4), 4),
-            (datetime.datetime(2014, 1, 1, 11, 47, 34), 8),
-            (datetime.datetime(2014, 1, 1, 11, 50, 54), 50),
-            (datetime.datetime(2014, 1, 1, 11, 54, 45), 4),
-            (datetime.datetime(2014, 1, 1, 11, 56, 49), 4),
-            (datetime.datetime(2014, 1, 1, 11, 57, 22), 6),
-            (datetime.datetime(2014, 1, 1, 11, 58, 22), 5),
-            (datetime.datetime(2014, 1, 1, 12, 1, 4), 4),
-            (datetime.datetime(2014, 1, 1, 12, 1, 9), 7),
-            (datetime.datetime(2014, 1, 1, 12, 2, 1), 15),
-            (datetime.datetime(2014, 1, 1, 12, 2, 12), 1),
-            (datetime.datetime(2014, 1, 1, 12, 3, 0), 3),
-            (datetime.datetime(2014, 1, 1, 12, 4, 9), 7),
-            (datetime.datetime(2014, 1, 1, 12, 5, 1), 15),
-            (datetime.datetime(2014, 1, 1, 12, 5, 12), 1),
-            (datetime.datetime(2014, 1, 1, 12, 6, 0), 3),
+            (datetime64(2014, 1, 1, 11, 46, 4), 4),
+            (datetime64(2014, 1, 1, 11, 47, 34), 8),
+            (datetime64(2014, 1, 1, 11, 50, 54), 50),
+            (datetime64(2014, 1, 1, 11, 54, 45), 4),
+            (datetime64(2014, 1, 1, 11, 56, 49), 4),
+            (datetime64(2014, 1, 1, 11, 57, 22), 6),
+            (datetime64(2014, 1, 1, 11, 58, 22), 5),
+            (datetime64(2014, 1, 1, 12, 1, 4), 4),
+            (datetime64(2014, 1, 1, 12, 1, 9), 7),
+            (datetime64(2014, 1, 1, 12, 2, 1), 15),
+            (datetime64(2014, 1, 1, 12, 2, 12), 1),
+            (datetime64(2014, 1, 1, 12, 3, 0), 3),
+            (datetime64(2014, 1, 1, 12, 4, 9), 7),
+            (datetime64(2014, 1, 1, 12, 5, 1), 15),
+            (datetime64(2014, 1, 1, 12, 5, 12), 1),
+            (datetime64(2014, 1, 1, 12, 6, 0), 3),
         ], before_truncate_callback=ts1_update)
 
         tsb2.set_values([
-            (datetime.datetime(2014, 1, 1, 11, 46, 4), 6),
-            (datetime.datetime(2014, 1, 1, 11, 47, 34), 5),
-            (datetime.datetime(2014, 1, 1, 11, 50, 54), 51),
-            (datetime.datetime(2014, 1, 1, 11, 54, 45), 5),
-            (datetime.datetime(2014, 1, 1, 11, 56, 49), 5),
-            (datetime.datetime(2014, 1, 1, 11, 57, 22), 7),
-            (datetime.datetime(2014, 1, 1, 11, 58, 22), 5),
-            (datetime.datetime(2014, 1, 1, 12, 1, 4), 5),
-            (datetime.datetime(2014, 1, 1, 12, 1, 9), 8),
-            (datetime.datetime(2014, 1, 1, 12, 2, 1), 10),
-            (datetime.datetime(2014, 1, 1, 12, 2, 12), 2),
-            (datetime.datetime(2014, 1, 1, 12, 3, 0), 6),
-            (datetime.datetime(2014, 1, 1, 12, 4, 9), 4),
-            (datetime.datetime(2014, 1, 1, 12, 5, 1), 10),
-            (datetime.datetime(2014, 1, 1, 12, 5, 12), 1),
-            (datetime.datetime(2014, 1, 1, 12, 6, 0), 1),
+            (datetime64(2014, 1, 1, 11, 46, 4), 6),
+            (datetime64(2014, 1, 1, 11, 47, 34), 5),
+            (datetime64(2014, 1, 1, 11, 50, 54), 51),
+            (datetime64(2014, 1, 1, 11, 54, 45), 5),
+            (datetime64(2014, 1, 1, 11, 56, 49), 5),
+            (datetime64(2014, 1, 1, 11, 57, 22), 7),
+            (datetime64(2014, 1, 1, 11, 58, 22), 5),
+            (datetime64(2014, 1, 1, 12, 1, 4), 5),
+            (datetime64(2014, 1, 1, 12, 1, 9), 8),
+            (datetime64(2014, 1, 1, 12, 2, 1), 10),
+            (datetime64(2014, 1, 1, 12, 2, 12), 2),
+            (datetime64(2014, 1, 1, 12, 3, 0), 6),
+            (datetime64(2014, 1, 1, 12, 4, 9), 4),
+            (datetime64(2014, 1, 1, 12, 5, 1), 10),
+            (datetime64(2014, 1, 1, 12, 5, 12), 1),
+            (datetime64(2014, 1, 1, 12, 6, 0), 1),
         ], before_truncate_callback=ts2_update)
 
         output = carbonara.AggregatedTimeSerie.aggregated(
             [tsc1['return'], tsc12['return'], tsc2['return'], tsc22['return']],
             'mean')
         self.assertEqual([
-            (datetime.datetime(2014, 1, 1, 11, 45), 300.0, 5.75),
-            (datetime.datetime(2014, 1, 1, 11, 50), 300.0, 27.5),
-            (datetime.datetime(2014, 1, 1, 11, 55), 300.0, 5.3333333333333339),
-            (datetime.datetime(2014, 1, 1, 12, 0), 300.0, 6.0),
-            (datetime.datetime(2014, 1, 1, 12, 5), 300.0, 5.1666666666666661),
-            (datetime.datetime(2014, 1, 1, 11, 54), 60.0, 4.5),
-            (datetime.datetime(2014, 1, 1, 11, 56), 60.0, 4.5),
-            (datetime.datetime(2014, 1, 1, 11, 57), 60.0, 6.5),
-            (datetime.datetime(2014, 1, 1, 11, 58), 60.0, 5.0),
-            (datetime.datetime(2014, 1, 1, 12, 1), 60.0, 6.0),
-            (datetime.datetime(2014, 1, 1, 12, 2), 60.0, 7.0),
-            (datetime.datetime(2014, 1, 1, 12, 3), 60.0, 4.5),
-            (datetime.datetime(2014, 1, 1, 12, 4), 60.0, 5.5),
-            (datetime.datetime(2014, 1, 1, 12, 5), 60.0, 6.75),
-            (datetime.datetime(2014, 1, 1, 12, 6), 60.0, 2.0),
+            (datetime.datetime(2014, 1, 1, 11, 45),
+             numpy.timedelta64(300, 's'), 5.75),
+            (datetime.datetime(2014, 1, 1, 11, 50),
+             numpy.timedelta64(300, 's'), 27.5),
+            (datetime.datetime(2014, 1, 1, 11, 55),
+             numpy.timedelta64(300, 's'), 5.3333333333333339),
+            (datetime.datetime(2014, 1, 1, 12, 0),
+             numpy.timedelta64(300, 's'), 6.0),
+            (datetime.datetime(2014, 1, 1, 12, 5),
+             numpy.timedelta64(300, 's'), 5.1666666666666661),
+            (datetime.datetime(2014, 1, 1, 11, 54),
+             numpy.timedelta64(60, 's'), 4.5),
+            (datetime.datetime(2014, 1, 1, 11, 56),
+             numpy.timedelta64(60, 's'), 4.5),
+            (datetime.datetime(2014, 1, 1, 11, 57),
+             numpy.timedelta64(60, 's'), 6.5),
+            (datetime.datetime(2014, 1, 1, 11, 58),
+             numpy.timedelta64(60, 's'), 5.0),
+            (datetime.datetime(2014, 1, 1, 12, 1),
+             numpy.timedelta64(60, 's'), 6.0),
+            (datetime.datetime(2014, 1, 1, 12, 2),
+             numpy.timedelta64(60, 's'), 7.0),
+            (datetime.datetime(2014, 1, 1, 12, 3),
+             numpy.timedelta64(60, 's'), 4.5),
+            (datetime.datetime(2014, 1, 1, 12, 4),
+             numpy.timedelta64(60, 's'), 5.5),
+            (datetime.datetime(2014, 1, 1, 12, 5),
+             numpy.timedelta64(60, 's'), 6.75),
+            (datetime.datetime(2014, 1, 1, 12, 6),
+             numpy.timedelta64(60, 's'), 2.0),
         ], list(output))
 
     def test_aggregated_partial_overlap(self):
-        tsc1 = {'sampling': 1, 'size': 86400, 'agg': 'mean'}
+        tsc1 = {'sampling': numpy.timedelta64(1, 's'),
+                'size': 86400, 'agg': 'mean'}
         tsb1 = carbonara.BoundTimeSerie(block_size=tsc1['sampling'])
-        tsc2 = {'sampling': 1, 'size': 60, 'agg': 'mean'}
+        tsc2 = {'sampling': numpy.timedelta64(1, 's'),
+                'size': 60, 'agg': 'mean'}
         tsb2 = carbonara.BoundTimeSerie(block_size=tsc2['sampling'])
 
         tsb1.set_values([
-            (datetime.datetime(2015, 12, 3, 13, 19, 15), 1),
-            (datetime.datetime(2015, 12, 3, 13, 20, 15), 1),
-            (datetime.datetime(2015, 12, 3, 13, 21, 15), 1),
-            (datetime.datetime(2015, 12, 3, 13, 22, 15), 1),
+            (datetime64(2015, 12, 3, 13, 19, 15), 1),
+            (datetime64(2015, 12, 3, 13, 20, 15), 1),
+            (datetime64(2015, 12, 3, 13, 21, 15), 1),
+            (datetime64(2015, 12, 3, 13, 22, 15), 1),
         ], before_truncate_callback=functools.partial(
             self._resample_and_merge, agg_dict=tsc1))
 
         tsb2.set_values([
-            (datetime.datetime(2015, 12, 3, 13, 21, 15), 10),
-            (datetime.datetime(2015, 12, 3, 13, 22, 15), 10),
-            (datetime.datetime(2015, 12, 3, 13, 23, 15), 10),
-            (datetime.datetime(2015, 12, 3, 13, 24, 15), 10),
+            (datetime64(2015, 12, 3, 13, 21, 15), 10),
+            (datetime64(2015, 12, 3, 13, 22, 15), 10),
+            (datetime64(2015, 12, 3, 13, 23, 15), 10),
+            (datetime64(2015, 12, 3, 13, 24, 15), 10),
         ], before_truncate_callback=functools.partial(
             self._resample_and_merge, agg_dict=tsc2))
 
@@ -1095,16 +1181,16 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
             [tsc1['return'], tsc2['return']], aggregation="sum")
 
         self.assertEqual([
-            (datetime.datetime(
+            (datetime64(
                 2015, 12, 3, 13, 21, 15
-            ), 1.0, 11.0),
-            (datetime.datetime(
+            ), numpy.timedelta64(1, 's'), 11.0),
+            (datetime64(
                 2015, 12, 3, 13, 22, 15
-            ), 1.0, 11.0),
+            ), numpy.timedelta64(1, 's'), 11.0),
         ], list(output))
 
-        dtfrom = datetime.datetime(2015, 12, 3, 13, 17, 0)
-        dtto = datetime.datetime(2015, 12, 3, 13, 25, 0)
+        dtfrom = datetime64(2015, 12, 3, 13, 17, 0)
+        dtto = datetime64(2015, 12, 3, 13, 25, 0)
 
         output = carbonara.AggregatedTimeSerie.aggregated(
             [tsc1['return'], tsc2['return']],
@@ -1112,24 +1198,24 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
             aggregation="sum", needed_percent_of_overlap=0)
 
         self.assertEqual([
-            (datetime.datetime(
+            (datetime64(
                 2015, 12, 3, 13, 19, 15
-            ), 1.0, 1.0),
-            (datetime.datetime(
+            ), numpy.timedelta64(1, 's'), 1.0),
+            (datetime64(
                 2015, 12, 3, 13, 20, 15
-            ), 1.0, 1.0),
-            (datetime.datetime(
+            ), numpy.timedelta64(1, 's'), 1.0),
+            (datetime64(
                 2015, 12, 3, 13, 21, 15
-            ), 1.0, 11.0),
-            (datetime.datetime(
+            ), numpy.timedelta64(1, 's'), 11.0),
+            (datetime64(
                 2015, 12, 3, 13, 22, 15
-            ), 1.0, 11.0),
-            (datetime.datetime(
+            ), numpy.timedelta64(1, 's'), 11.0),
+            (datetime64(
                 2015, 12, 3, 13, 23, 15
-            ), 1.0, 10.0),
-            (datetime.datetime(
+            ), numpy.timedelta64(1, 's'), 10.0),
+            (datetime64(
                 2015, 12, 3, 13, 24, 15
-            ), 1.0, 10.0),
+            ), numpy.timedelta64(1, 's'), 10.0),
         ], list(output))
 
         # By default we require 100% of point that overlap
@@ -1149,18 +1235,18 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
             aggregation="sum",
             needed_percent_of_overlap=50.0)
         self.assertEqual([
-            (datetime.datetime(
+            (datetime64(
                 2015, 12, 3, 13, 19, 15
-            ), 1.0, 1.0),
-            (datetime.datetime(
+            ), numpy.timedelta64(1, 's'), 1.0),
+            (datetime64(
                 2015, 12, 3, 13, 20, 15
-            ), 1.0, 1.0),
-            (datetime.datetime(
+            ), numpy.timedelta64(1, 's'), 1.0),
+            (datetime64(
                 2015, 12, 3, 13, 21, 15
-            ), 1.0, 11.0),
-            (datetime.datetime(
+            ), numpy.timedelta64(1, 's'), 11.0),
+            (datetime64(
                 2015, 12, 3, 13, 22, 15
-            ), 1.0, 11.0),
+            ), numpy.timedelta64(1, 's'), 11.0),
         ], list(output))
 
         output = carbonara.AggregatedTimeSerie.aggregated(
@@ -1168,57 +1254,54 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
             aggregation="sum",
             needed_percent_of_overlap=50.0)
         self.assertEqual([
-            (datetime.datetime(
+            (datetime64(
                 2015, 12, 3, 13, 21, 15
-            ), 1.0, 11.0),
-            (datetime.datetime(
+            ), numpy.timedelta64(1, 's'), 11.0),
+            (datetime64(
                 2015, 12, 3, 13, 22, 15
-            ), 1.0, 11.0),
-            (datetime.datetime(
+            ), numpy.timedelta64(1, 's'), 11.0),
+            (datetime64(
                 2015, 12, 3, 13, 23, 15
-            ), 1.0, 10.0),
-            (datetime.datetime(
+            ), numpy.timedelta64(1, 's'), 10.0),
+            (datetime64(
                 2015, 12, 3, 13, 24, 15
-            ), 1.0, 10.0),
+            ), numpy.timedelta64(1, 's'), 10.0),
         ], list(output))
 
     def test_split_key(self):
         self.assertEqual(
-            datetime.datetime(2014, 10, 7),
+            numpy.datetime64("2014-10-07"),
             carbonara.SplitKey.from_timestamp_and_sampling(
-                datetime.datetime(2015, 1, 1, 15, 3), 3600).as_datetime())
+                numpy.datetime64("2015-01-01T15:03"),
+                numpy.timedelta64(3600, 's')))
         self.assertEqual(
-            datetime.datetime(2014, 12, 31, 18),
+            numpy.datetime64("2014-12-31 18:00"),
             carbonara.SplitKey.from_timestamp_and_sampling(
-                datetime.datetime(2015, 1, 1, 15, 3), 58).as_datetime())
-        self.assertEqual(
-            1420048800.0,
-            float(carbonara.SplitKey.from_timestamp_and_sampling(
-                datetime.datetime(2015, 1, 1, 15, 3), 58)))
+                numpy.datetime64("2015-01-01 15:03:58"),
+                numpy.timedelta64(58, 's')))
 
         key = carbonara.SplitKey.from_timestamp_and_sampling(
-            datetime.datetime(2015, 1, 1, 15, 3), 3600)
+            numpy.datetime64("2015-01-01 15:03"),
+            numpy.timedelta64(3600, 's'))
 
-        self.assertGreater(key, pandas.Timestamp(0))
+        self.assertGreater(key, numpy.datetime64("1970"))
 
-        self.assertGreaterEqual(key, pandas.Timestamp(0))
+        self.assertGreaterEqual(key, numpy.datetime64("1970"))
 
     def test_split_key_next(self):
         self.assertEqual(
-            datetime.datetime(2015, 3, 6),
+            numpy.datetime64("2015-03-06"),
             next(carbonara.SplitKey.from_timestamp_and_sampling(
-                datetime.datetime(2015, 1, 1, 15, 3), 3600)).as_datetime())
+                numpy.datetime64("2015-01-01 15:03"),
+                numpy.timedelta64(3600, 's'))))
         self.assertEqual(
-            datetime.datetime(2015, 8, 3),
+            numpy.datetime64("2015-08-03"),
             next(next(carbonara.SplitKey.from_timestamp_and_sampling(
-                datetime.datetime(2015, 1, 1, 15, 3), 3600))).as_datetime())
-        self.assertEqual(
-            113529600000.0,
-            float(next(carbonara.SplitKey.from_timestamp_and_sampling(
-                datetime.datetime(2015, 1, 1, 15, 3), 3600 * 24 * 365))))
+                numpy.datetime64("2015-01-01T15:03"),
+                numpy.timedelta64(3600, 's')))))
 
     def test_split(self):
-        sampling = 5
+        sampling = numpy.timedelta64(5, 's')
         points = 100000
         ts = carbonara.TimeSerie.from_data(
             timestamps=map(datetime.datetime.utcfromtimestamp,
@@ -1229,19 +1312,19 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
         grouped_points = list(agg.split())
 
         self.assertEqual(
-            math.ceil((points / float(sampling))
+            math.ceil((points / sampling.astype(float))
                       / carbonara.SplitKey.POINTS_PER_SPLIT),
             len(grouped_points))
         self.assertEqual("0.0",
                          str(carbonara.SplitKey(grouped_points[0][0], 0)))
         # 3600 × 5s = 5 hours
-        self.assertEqual(datetime.datetime(1970, 1, 1, 5),
-                         grouped_points[1][0].as_datetime())
+        self.assertEqual(datetime64(1970, 1, 1, 5),
+                         grouped_points[1][0])
         self.assertEqual(carbonara.SplitKey.POINTS_PER_SPLIT,
                          len(grouped_points[0][1]))
 
     def test_from_timeseries(self):
-        sampling = 5
+        sampling = numpy.timedelta64(5, 's')
         points = 100000
         ts = carbonara.TimeSerie.from_data(
             timestamps=map(datetime.datetime.utcfromtimestamp,
@@ -1260,16 +1343,16 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
 
     def test_resample(self):
         ts = carbonara.TimeSerie.from_data(
-            [datetime.datetime(2014, 1, 1, 12, 0, 0),
-             datetime.datetime(2014, 1, 1, 12, 0, 4),
-             datetime.datetime(2014, 1, 1, 12, 0, 9),
-             datetime.datetime(2014, 1, 1, 12, 0, 11),
-             datetime.datetime(2014, 1, 1, 12, 0, 12)],
+            [datetime64(2014, 1, 1, 12, 0, 0),
+             datetime64(2014, 1, 1, 12, 0, 4),
+             datetime64(2014, 1, 1, 12, 0, 9),
+             datetime64(2014, 1, 1, 12, 0, 11),
+             datetime64(2014, 1, 1, 12, 0, 12)],
             [3, 5, 6, 2, 4])
-        agg_ts = self._resample(ts, 5, 'mean')
+        agg_ts = self._resample(ts, numpy.timedelta64(5, 's'), 'mean')
         self.assertEqual(3, len(agg_ts))
 
-        agg_ts = agg_ts.resample(10)
+        agg_ts = agg_ts.resample(numpy.timedelta64(10, 's'))
         self.assertEqual(2, len(agg_ts))
         self.assertEqual(5, agg_ts[0])
         self.assertEqual(3, agg_ts[1])

--- a/gnocchi/tests/test_indexer.py
+++ b/gnocchi/tests/test_indexer.py
@@ -18,6 +18,7 @@ import operator
 import uuid
 
 import mock
+import numpy
 
 from gnocchi import archive_policy
 from gnocchi import indexer
@@ -55,9 +56,15 @@ class TestIndexerDriver(tests_base.TestCase):
             'aggregation_methods':
             set(self.conf.archive_policy.default_aggregation_methods),
             'definition': [
-                {u'granularity': 300, u'points': 12, u'timespan': 3600},
-                {u'granularity': 3600, u'points': 24, u'timespan': 86400},
-                {u'granularity': 86400, u'points': 30, u'timespan': 2592000}],
+                {u'granularity': numpy.timedelta64(5, 'm'),
+                 u'points': 12,
+                 u'timespan': numpy.timedelta64(3600, 's')},
+                {u'granularity': numpy.timedelta64(3600, 's'),
+                 u'points': 24,
+                 u'timespan': numpy.timedelta64(86400, 's')},
+                {u'granularity': numpy.timedelta64(86400, 's'),
+                 u'points': 30,
+                 u'timespan': numpy.timedelta64(2592000, 's')}],
             'name': u'low'}, dict(ap))
 
     def test_update_archive_policy(self):
@@ -88,9 +95,15 @@ class TestIndexerDriver(tests_base.TestCase):
             'aggregation_methods':
             set(self.conf.archive_policy.default_aggregation_methods),
             'definition': [
-                {u'granularity': 300, u'points': 6, u'timespan': 1800},
-                {u'granularity': 3600, u'points': 24, u'timespan': 86400},
-                {u'granularity': 86400, u'points': 30, u'timespan': 2592000}],
+                {u'granularity': numpy.timedelta64(300, 's'),
+                 u'points': 6,
+                 u'timespan': numpy.timedelta64(1800, 's')},
+                {u'granularity': numpy.timedelta64(3600, 's'),
+                 u'points': 24,
+                 u'timespan': numpy.timedelta64(86400, 's')},
+                {u'granularity': numpy.timedelta64(86400, 's'),
+                 u'points': 30,
+                 u'timespan': numpy.timedelta64(2592000, 's')}],
             'name': apname}, dict(ap))
         ap = self.index.update_archive_policy(
             apname, [archive_policy.ArchivePolicyItem(granularity=300,
@@ -104,9 +117,15 @@ class TestIndexerDriver(tests_base.TestCase):
             'aggregation_methods':
             set(self.conf.archive_policy.default_aggregation_methods),
             'definition': [
-                {u'granularity': 300, u'points': 12, u'timespan': 3600},
-                {u'granularity': 3600, u'points': 24, u'timespan': 86400},
-                {u'granularity': 86400, u'points': 30, u'timespan': 2592000}],
+                {u'granularity': numpy.timedelta64(300, 's'),
+                 u'points': 12,
+                 u'timespan': numpy.timedelta64(3600, 's')},
+                {u'granularity': numpy.timedelta64(3600, 's'),
+                 u'points': 24,
+                 u'timespan': numpy.timedelta64(86400, 's')},
+                {u'granularity': numpy.timedelta64(86400, 's'),
+                 u'points': 30,
+                 u'timespan': numpy.timedelta64(2592000, 's')}],
             'name': apname}, dict(ap))
 
     def test_delete_archive_policy(self):

--- a/gnocchi/tests/test_statsd.py
+++ b/gnocchi/tests/test_statsd.py
@@ -17,6 +17,7 @@
 import uuid
 
 import mock
+import numpy
 
 from gnocchi import indexer
 from gnocchi import statsd
@@ -71,9 +72,15 @@ class TestStatsd(tests_base.TestCase):
 
         measures = self.storage.get_measures(metric)
         self.assertEqual([
-            (utils.datetime_utc(2015, 1, 7), 86400.0, 1.0),
-            (utils.datetime_utc(2015, 1, 7, 13), 3600.0, 1.0),
-            (utils.datetime_utc(2015, 1, 7, 13, 58), 60.0, 1.0)
+            (utils.datetime_utc(2015, 1, 7),
+             numpy.timedelta64(1, 'D'),
+             1.0),
+            (utils.datetime_utc(2015, 1, 7, 13),
+             numpy.timedelta64(1, 'h'),
+             1.0),
+            (utils.datetime_utc(2015, 1, 7, 13, 58),
+             numpy.timedelta64(1, 'm'),
+             1.0)
         ], measures)
 
         utcnow.return_value = utils.datetime_utc(2015, 1, 7, 13, 59, 37)
@@ -92,10 +99,18 @@ class TestStatsd(tests_base.TestCase):
 
         measures = self.storage.get_measures(metric)
         self.assertEqual([
-            (utils.datetime_utc(2015, 1, 7), 86400.0, 1.5),
-            (utils.datetime_utc(2015, 1, 7, 13), 3600.0, 1.5),
-            (utils.datetime_utc(2015, 1, 7, 13, 58), 60.0, 1.0),
-            (utils.datetime_utc(2015, 1, 7, 13, 59), 60.0, 2.0)
+            (utils.datetime_utc(2015, 1, 7),
+             numpy.timedelta64(1, 'D'),
+             1.5),
+            (utils.datetime_utc(2015, 1, 7, 13),
+             numpy.timedelta64(1, 'h'),
+             1.5),
+            (utils.datetime_utc(2015, 1, 7, 13, 58),
+             numpy.timedelta64(1, 'm'),
+             1.0),
+            (utils.datetime_utc(2015, 1, 7, 13, 59),
+             numpy.timedelta64(1, 'm'),
+             2.0)
         ], measures)
 
     def test_gauge(self):
@@ -126,9 +141,15 @@ class TestStatsd(tests_base.TestCase):
 
         measures = self.storage.get_measures(metric)
         self.assertEqual([
-            (utils.datetime_utc(2015, 1, 7), 86400.0, 1.0),
-            (utils.datetime_utc(2015, 1, 7, 13), 3600.0, 1.0),
-            (utils.datetime_utc(2015, 1, 7, 13, 58), 60.0, 1.0)], measures)
+            (utils.datetime_utc(2015, 1, 7),
+             numpy.timedelta64(1, 'D'),
+             1.0),
+            (utils.datetime_utc(2015, 1, 7, 13),
+             numpy.timedelta64(1, 'h'),
+             1.0),
+            (utils.datetime_utc(2015, 1, 7, 13, 58),
+             numpy.timedelta64(1, 'm'),
+             1.0)], measures)
 
         utcnow.return_value = utils.datetime_utc(2015, 1, 7, 13, 59, 37)
         self.server.datagram_received(
@@ -145,10 +166,18 @@ class TestStatsd(tests_base.TestCase):
 
         measures = self.storage.get_measures(metric)
         self.assertEqual([
-            (utils.datetime_utc(2015, 1, 7), 86400.0, 28),
-            (utils.datetime_utc(2015, 1, 7, 13), 3600.0, 28),
-            (utils.datetime_utc(2015, 1, 7, 13, 58), 60.0, 1.0),
-            (utils.datetime_utc(2015, 1, 7, 13, 59), 60.0, 55.0)], measures)
+            (utils.datetime_utc(2015, 1, 7),
+             numpy.timedelta64(1, 'D'),
+             28),
+            (utils.datetime_utc(2015, 1, 7, 13),
+             numpy.timedelta64(1, 'h'),
+             28),
+            (utils.datetime_utc(2015, 1, 7, 13, 58),
+             numpy.timedelta64(1, 'm'),
+             1.0),
+            (utils.datetime_utc(2015, 1, 7, 13, 59),
+             numpy.timedelta64(1, 'm'),
+             55.0)], measures)
 
 
 class TestStatsdArchivePolicyRule(TestStatsd):

--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -230,7 +230,9 @@ class TestStorageDriver(tests_base.TestCase):
         for call in c.mock_calls:
             # policy is 60 points and split is 48. should only update 2nd half
             args = call[1]
-            if args[0] == m_sql and args[2] == 'mean' and args[3] == 60.0:
+            if (args[0] == m_sql
+               and args[2] == 'mean'
+               and args[1].sampling == 60.0):
                 count += 1
         self.assertEqual(1, count)
 
@@ -329,13 +331,13 @@ class TestStorageDriver(tests_base.TestCase):
             assertCompressedIfWriteFull = self.assertFalse
 
         data = self.storage._get_measures(
-            self.metric, '1451520000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451520000.0, 60.0), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1451736000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451736000.0, 60.0), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1451952000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451952000.0, 60.0), "mean")
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
@@ -363,17 +365,17 @@ class TestStorageDriver(tests_base.TestCase):
             carbonara.SplitKey(numpy.datetime64('2016-01-05T00:00:00'), 60),
         }, self.storage._list_split_keys_for_metric(self.metric, "mean", 60.0))
         data = self.storage._get_measures(
-            self.metric, '1451520000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451520000.0, 60.0), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1451736000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451736000.0, 60.0), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1451952000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451952000.0, 60.0), "mean")
         # Now this one is compressed because it has been rewritten!
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1452384000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1452384000.0, 60.0), "mean")
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
@@ -418,13 +420,13 @@ class TestStorageDriver(tests_base.TestCase):
             assertCompressedIfWriteFull = self.assertFalse
 
         data = self.storage._get_measures(
-            self.metric, '1451520000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451520000.0, 60.0), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1451736000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451736000.0, 60.0), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1451952000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451952000.0, 60.0), "mean")
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
@@ -454,17 +456,17 @@ class TestStorageDriver(tests_base.TestCase):
             carbonara.SplitKey(numpy.datetime64('2016-01-05T00:00:00'), 60),
         }, self.storage._list_split_keys_for_metric(self.metric, "mean", 60.0))
         data = self.storage._get_measures(
-            self.metric, '1451520000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451520000.0, 60.0), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1451736000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451736000.0, 60.0), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1451952000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451952000.0, 60.0), "mean")
         # Now this one is compressed because it has been rewritten!
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1452384000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1452384000.0, 60.0), "mean")
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
@@ -507,13 +509,13 @@ class TestStorageDriver(tests_base.TestCase):
             assertCompressedIfWriteFull = self.assertFalse
 
         data = self.storage._get_measures(
-            self.metric, '1451520000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451520000.0, 60.0), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1451736000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451736000.0, 60.0), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1451952000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451952000.0, 60.0), "mean")
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
@@ -526,9 +528,8 @@ class TestStorageDriver(tests_base.TestCase):
 
         # Test what happens if we delete the latest split and then need to
         # compress it!
-        self.storage._delete_metric_measures(self.metric,
-                                             '1451952000.0',
-                                             'mean', 60.0)
+        self.storage._delete_metric_measures(
+            self.metric, carbonara.SplitKey(1451952000.0, 60.0), 'mean')
 
         # Now store brand new points that should force a rewrite of one of the
         # split (keep in mind the back window size in one hour here). We move
@@ -571,13 +572,13 @@ class TestStorageDriver(tests_base.TestCase):
             assertCompressedIfWriteFull = self.assertFalse
 
         data = self.storage._get_measures(
-            self.metric, '1451520000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451520000.0, 60.0), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1451736000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451736000.0, 60.0), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1451952000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451952000.0, 60.0), "mean")
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
@@ -590,7 +591,8 @@ class TestStorageDriver(tests_base.TestCase):
 
         # Test what happens if we write garbage
         self.storage._store_metric_measures(
-            self.metric, '1451952000.0', "mean", 60.0, b"oh really?")
+            self.metric, carbonara.SplitKey(1451952000.0, 60.0), "mean",
+            b"oh really?")
 
         # Now store brand new points that should force a rewrite of one of the
         # split (keep in mind the back window size in one hour here). We move

--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -18,6 +18,7 @@ import uuid
 
 import iso8601
 import mock
+import numpy
 import six.moves
 
 from gnocchi import archive_policy
@@ -283,15 +284,19 @@ class TestStorageDriver(tests_base.TestCase):
             (utils.datetime_utc(2015, 1, 1, 12), 300.0, 69),
         ], self.storage.get_measures(self.metric))
 
-        self.assertEqual({"1244160000.0"},
-                         self.storage._list_split_keys_for_metric(
-                             self.metric, "mean", 86400.0))
-        self.assertEqual({"1412640000.0"},
-                         self.storage._list_split_keys_for_metric(
-                             self.metric, "mean", 3600.0))
-        self.assertEqual({"1419120000.0"},
-                         self.storage._list_split_keys_for_metric(
-                             self.metric, "mean", 300.0))
+        self.assertEqual({
+            carbonara.SplitKey(
+                numpy.datetime64('2009-06-05T00:00:00'), 86400),
+        }, self.storage._list_split_keys_for_metric(
+            self.metric, "mean", 86400.0))
+        self.assertEqual({
+            carbonara.SplitKey(numpy.datetime64('2014-10-07T00:00:00'), 3600),
+        }, self.storage._list_split_keys_for_metric(
+            self.metric, "mean", 3600.0))
+        self.assertEqual({
+            carbonara.SplitKey(numpy.datetime64('2014-12-21T00:00:00'), 300),
+        }, self.storage._list_split_keys_for_metric(
+            self.metric, "mean", 300.0))
 
     def test_rewrite_measures(self):
         # Create an archive policy that spans on several splits. Each split
@@ -312,10 +317,11 @@ class TestStorageDriver(tests_base.TestCase):
         ])
         self.trigger_processing()
 
-        splits = {'1451520000.0', '1451736000.0', '1451952000.0'}
-        self.assertEqual(splits,
-                         self.storage._list_split_keys_for_metric(
-                             self.metric, "mean", 60.0))
+        self.assertEqual({
+            carbonara.SplitKey(numpy.datetime64('2015-12-31T00:00:00'), 60),
+            carbonara.SplitKey(numpy.datetime64('2016-01-02T12:00:00'), 60),
+            carbonara.SplitKey(numpy.datetime64('2016-01-05T00:00:00'), 60),
+        }, self.storage._list_split_keys_for_metric(self.metric, "mean", 60.0))
 
         if self.storage.WRITE_FULL:
             assertCompressedIfWriteFull = self.assertTrue
@@ -350,10 +356,12 @@ class TestStorageDriver(tests_base.TestCase):
         ])
         self.trigger_processing()
 
-        self.assertEqual({'1452384000.0', '1451736000.0',
-                          '1451520000.0', '1451952000.0'},
-                         self.storage._list_split_keys_for_metric(
-                             self.metric, "mean", 60.0))
+        self.assertEqual({
+            carbonara.SplitKey(numpy.datetime64('2016-01-10T00:00:00'), 60),
+            carbonara.SplitKey(numpy.datetime64('2016-01-02T12:00:00'), 60),
+            carbonara.SplitKey(numpy.datetime64('2015-12-31T00:00:00'), 60),
+            carbonara.SplitKey(numpy.datetime64('2016-01-05T00:00:00'), 60),
+        }, self.storage._list_split_keys_for_metric(self.metric, "mean", 60.0))
         data = self.storage._get_measures(
             self.metric, '1451520000.0', "mean", 60.0)
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
@@ -398,10 +406,11 @@ class TestStorageDriver(tests_base.TestCase):
         ])
         self.trigger_processing()
 
-        splits = {'1451520000.0', '1451736000.0', '1451952000.0'}
-        self.assertEqual(splits,
-                         self.storage._list_split_keys_for_metric(
-                             self.metric, "mean", 60.0))
+        self.assertEqual({
+            carbonara.SplitKey(numpy.datetime64('2015-12-31T00:00:00'), 60),
+            carbonara.SplitKey(numpy.datetime64('2016-01-02T12:00:00'), 60),
+            carbonara.SplitKey(numpy.datetime64('2016-01-05T00:00:00'), 60),
+        }, self.storage._list_split_keys_for_metric(self.metric, "mean", 60.0))
 
         if self.storage.WRITE_FULL:
             assertCompressedIfWriteFull = self.assertTrue
@@ -438,10 +447,12 @@ class TestStorageDriver(tests_base.TestCase):
         ])
         self.trigger_processing()
 
-        self.assertEqual({'1452384000.0', '1451736000.0',
-                          '1451520000.0', '1451952000.0'},
-                         self.storage._list_split_keys_for_metric(
-                             self.metric, "mean", 60.0))
+        self.assertEqual({
+            carbonara.SplitKey(numpy.datetime64('2016-01-10T00:00:00'), 60),
+            carbonara.SplitKey(numpy.datetime64('2016-01-02T12:00:00'), 60),
+            carbonara.SplitKey(numpy.datetime64('2015-12-31T00:00:00'), 60),
+            carbonara.SplitKey(numpy.datetime64('2016-01-05T00:00:00'), 60),
+        }, self.storage._list_split_keys_for_metric(self.metric, "mean", 60.0))
         data = self.storage._get_measures(
             self.metric, '1451520000.0', "mean", 60.0)
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
@@ -484,10 +495,11 @@ class TestStorageDriver(tests_base.TestCase):
         ])
         self.trigger_processing()
 
-        splits = {'1451520000.0', '1451736000.0', '1451952000.0'}
-        self.assertEqual(splits,
-                         self.storage._list_split_keys_for_metric(
-                             self.metric, "mean", 60.0))
+        self.assertEqual({
+            carbonara.SplitKey(numpy.datetime64('2015-12-31T00:00:00'), 60),
+            carbonara.SplitKey(numpy.datetime64('2016-01-02T12:00:00'), 60),
+            carbonara.SplitKey(numpy.datetime64('2016-01-05T00:00:00'), 60),
+        }, self.storage._list_split_keys_for_metric(self.metric, "mean", 60.0))
 
         if self.storage.WRITE_FULL:
             assertCompressedIfWriteFull = self.assertTrue
@@ -547,10 +559,11 @@ class TestStorageDriver(tests_base.TestCase):
         ])
         self.trigger_processing()
 
-        splits = {'1451520000.0', '1451736000.0', '1451952000.0'}
-        self.assertEqual(splits,
-                         self.storage._list_split_keys_for_metric(
-                             self.metric, "mean", 60.0))
+        self.assertEqual({
+            carbonara.SplitKey(numpy.datetime64('2015-12-31T00:00:00'), 60),
+            carbonara.SplitKey(numpy.datetime64('2016-01-02T12:00:00'), 60),
+            carbonara.SplitKey(numpy.datetime64('2016-01-05T00:00:00'), 60),
+        }, self.storage._list_split_keys_for_metric(self.metric, "mean", 60.0))
 
         if self.storage.WRITE_FULL:
             assertCompressedIfWriteFull = self.assertTrue

--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -16,7 +16,6 @@
 import datetime
 import uuid
 
-import iso8601
 import mock
 import numpy
 import six.moves
@@ -34,6 +33,10 @@ from gnocchi.storage import swift
 from gnocchi.tests import base as tests_base
 from gnocchi.tests import utils as tests_utils
 from gnocchi import utils
+
+
+def datetime64(*args):
+    return numpy.datetime64(datetime.datetime(*args))
 
 
 class TestStorageDriver(tests_base.TestCase):
@@ -96,9 +99,12 @@ class TestStorageDriver(tests_base.TestCase):
                 self.trigger_processing()
 
         m = self.storage.get_measures(self.metric)
-        self.assertIn((utils.datetime_utc(2014, 1, 1), 86400.0, 1), m)
-        self.assertIn((utils.datetime_utc(2014, 1, 1, 13), 3600.0, 1), m)
-        self.assertIn((utils.datetime_utc(2014, 1, 1, 13), 300.0, 1), m)
+        self.assertIn((utils.datetime_utc(2014, 1, 1),
+                       numpy.timedelta64(1, 'D'), 1), m)
+        self.assertIn((utils.datetime_utc(2014, 1, 1, 13),
+                       numpy.timedelta64(1, 'h'), 1), m)
+        self.assertIn((utils.datetime_utc(2014, 1, 1, 13),
+                       numpy.timedelta64(5, 'm'), 1), m)
 
     def test_aborted_initial_processing(self):
         self.incoming.add_measures(self.metric, [
@@ -116,9 +122,12 @@ class TestStorageDriver(tests_base.TestCase):
             self.assertFalse(LOG.error.called)
 
         m = self.storage.get_measures(self.metric)
-        self.assertIn((utils.datetime_utc(2014, 1, 1), 86400.0, 5.0), m)
-        self.assertIn((utils.datetime_utc(2014, 1, 1, 12), 3600.0, 5.0), m)
-        self.assertIn((utils.datetime_utc(2014, 1, 1, 12), 300.0, 5.0), m)
+        self.assertIn((utils.datetime_utc(2014, 1, 1),
+                       numpy.timedelta64(1, 'D'), 5.0), m)
+        self.assertIn((utils.datetime_utc(2014, 1, 1, 12),
+                       numpy.timedelta64(1, 'h'), 5.0), m)
+        self.assertIn((utils.datetime_utc(2014, 1, 1, 12),
+                       numpy.timedelta64(5, 'm'), 5.0), m)
 
     def test_list_metric_with_measures_to_process(self):
         metrics = tests_utils.list_all_incoming_metrics(self.incoming)
@@ -232,7 +241,7 @@ class TestStorageDriver(tests_base.TestCase):
             args = call[1]
             if (args[0] == m_sql
                and args[2] == 'mean'
-               and args[1].sampling == 60.0):
+               and args[1].sampling == numpy.timedelta64(1, 'm')):
                 count += 1
         self.assertEqual(1, count)
 
@@ -266,11 +275,16 @@ class TestStorageDriver(tests_base.TestCase):
         self.trigger_processing()
 
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1), 86400.0, 39.75),
-            (utils.datetime_utc(2014, 1, 1, 12), 3600.0, 39.75),
-            (utils.datetime_utc(2014, 1, 1, 12), 300.0, 69.0),
-            (utils.datetime_utc(2014, 1, 1, 12, 5), 300.0, 23.0),
-            (utils.datetime_utc(2014, 1, 1, 12, 10), 300.0, 44.0),
+            (utils.datetime_utc(2014, 1, 1),
+             numpy.timedelta64(1, 'D'), 39.75),
+            (utils.datetime_utc(2014, 1, 1, 12),
+             numpy.timedelta64(1, 'h'), 39.75),
+            (utils.datetime_utc(2014, 1, 1, 12),
+             numpy.timedelta64(5, 'm'), 69.0),
+            (utils.datetime_utc(2014, 1, 1, 12, 5),
+             numpy.timedelta64(5, 'm'), 23.0),
+            (utils.datetime_utc(2014, 1, 1, 12, 10),
+             numpy.timedelta64(5, 'm'), 44.0),
         ], self.storage.get_measures(self.metric))
 
         # One year later…
@@ -280,25 +294,32 @@ class TestStorageDriver(tests_base.TestCase):
         self.trigger_processing()
 
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1), 86400.0, 39.75),
-            (utils.datetime_utc(2015, 1, 1), 86400.0, 69),
-            (utils.datetime_utc(2015, 1, 1, 12), 3600.0, 69),
-            (utils.datetime_utc(2015, 1, 1, 12), 300.0, 69),
+            (utils.datetime_utc(2014, 1, 1),
+             numpy.timedelta64(1, 'D'), 39.75),
+            (utils.datetime_utc(2015, 1, 1),
+             numpy.timedelta64(1, 'D'), 69),
+            (utils.datetime_utc(2015, 1, 1, 12),
+             numpy.timedelta64(1, 'h'), 69),
+            (utils.datetime_utc(2015, 1, 1, 12),
+             numpy.timedelta64(5, 'm'), 69),
         ], self.storage.get_measures(self.metric))
 
         self.assertEqual({
             carbonara.SplitKey(
-                numpy.datetime64('2009-06-05T00:00:00'), 86400),
+                numpy.datetime64('2009-06-05T00:00:00.000000000'),
+                numpy.timedelta64(1, 'D')),
         }, self.storage._list_split_keys_for_metric(
-            self.metric, "mean", 86400.0))
+            self.metric, "mean", numpy.timedelta64(1, 'D')))
         self.assertEqual({
-            carbonara.SplitKey(numpy.datetime64('2014-10-07T00:00:00'), 3600),
+            carbonara.SplitKey(numpy.datetime64('2014-10-07T00:00:00'),
+                               numpy.timedelta64(1, 'h')),
         }, self.storage._list_split_keys_for_metric(
-            self.metric, "mean", 3600.0))
+            self.metric, "mean", numpy.timedelta64(1, 'h')))
         self.assertEqual({
-            carbonara.SplitKey(numpy.datetime64('2014-12-21T00:00:00'), 300),
+            carbonara.SplitKey(numpy.datetime64('2014-12-21T00:00:00'),
+                               numpy.timedelta64(5, 'm')),
         }, self.storage._list_split_keys_for_metric(
-            self.metric, "mean", 300.0))
+            self.metric, "mean", numpy.timedelta64(5, 'm')))
 
     def test_rewrite_measures(self):
         # Create an archive policy that spans on several splits. Each split
@@ -320,10 +341,14 @@ class TestStorageDriver(tests_base.TestCase):
         self.trigger_processing()
 
         self.assertEqual({
-            carbonara.SplitKey(numpy.datetime64('2015-12-31T00:00:00'), 60),
-            carbonara.SplitKey(numpy.datetime64('2016-01-02T12:00:00'), 60),
-            carbonara.SplitKey(numpy.datetime64('2016-01-05T00:00:00'), 60),
-        }, self.storage._list_split_keys_for_metric(self.metric, "mean", 60.0))
+            carbonara.SplitKey(numpy.datetime64('2015-12-31T00:00:00'),
+                               numpy.timedelta64(1, 'm')),
+            carbonara.SplitKey(numpy.datetime64('2016-01-02T12:00:00'),
+                               numpy.timedelta64(1, 'm')),
+            carbonara.SplitKey(numpy.datetime64('2016-01-05T00:00:00'),
+                               numpy.timedelta64(1, 'm')),
+        }, self.storage._list_split_keys_for_metric(
+            self.metric, "mean", numpy.timedelta64(1, 'm')))
 
         if self.storage.WRITE_FULL:
             assertCompressedIfWriteFull = self.assertTrue
@@ -331,22 +356,36 @@ class TestStorageDriver(tests_base.TestCase):
             assertCompressedIfWriteFull = self.assertFalse
 
         data = self.storage._get_measures(
-            self.metric, carbonara.SplitKey(1451520000.0, 60.0), "mean")
+            self.metric, carbonara.SplitKey(
+                numpy.datetime64(1451520000, 's'),
+                numpy.timedelta64(1, 'm'),
+            ), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, carbonara.SplitKey(1451736000.0, 60.0), "mean")
+            self.metric, carbonara.SplitKey(
+                numpy.datetime64(1451736000, 's'),
+                numpy.timedelta64(60, 's'),
+            ), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, carbonara.SplitKey(1451952000.0, 60.0), "mean")
+            self.metric, carbonara.SplitKey(
+                numpy.datetime64(1451952000, 's'),
+                numpy.timedelta64(60, 's'),
+            ), "mean")
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
         self.assertEqual([
-            (utils.datetime_utc(2016, 1, 1, 12), 60.0, 69),
-            (utils.datetime_utc(2016, 1, 2, 13, 7), 60.0, 42),
-            (utils.datetime_utc(2016, 1, 4, 14, 9), 60.0, 4),
-            (utils.datetime_utc(2016, 1, 6, 15, 12), 60.0, 44),
-        ], self.storage.get_measures(self.metric, granularity=60.0))
+            (utils.datetime_utc(2016, 1, 1, 12),
+             numpy.timedelta64(1, 'm'), 69),
+            (utils.datetime_utc(2016, 1, 2, 13, 7),
+             numpy.timedelta64(1, 'm'), 42),
+            (utils.datetime_utc(2016, 1, 4, 14, 9),
+             numpy.timedelta64(1, 'm'), 4),
+            (utils.datetime_utc(2016, 1, 6, 15, 12),
+             numpy.timedelta64(1, 'm'), 44),
+        ], self.storage.get_measures(self.metric,
+                                     granularity=numpy.timedelta64(1, 'm')))
 
         # Now store brand new points that should force a rewrite of one of the
         # split (keep in mind the back window size in one hour here). We move
@@ -359,34 +398,58 @@ class TestStorageDriver(tests_base.TestCase):
         self.trigger_processing()
 
         self.assertEqual({
-            carbonara.SplitKey(numpy.datetime64('2016-01-10T00:00:00'), 60),
-            carbonara.SplitKey(numpy.datetime64('2016-01-02T12:00:00'), 60),
-            carbonara.SplitKey(numpy.datetime64('2015-12-31T00:00:00'), 60),
-            carbonara.SplitKey(numpy.datetime64('2016-01-05T00:00:00'), 60),
-        }, self.storage._list_split_keys_for_metric(self.metric, "mean", 60.0))
+            carbonara.SplitKey(numpy.datetime64('2016-01-10T00:00:00'),
+                               numpy.timedelta64(1, 'm')),
+            carbonara.SplitKey(numpy.datetime64('2016-01-02T12:00:00'),
+                               numpy.timedelta64(1, 'm')),
+            carbonara.SplitKey(numpy.datetime64('2015-12-31T00:00:00'),
+                               numpy.timedelta64(1, 'm')),
+            carbonara.SplitKey(numpy.datetime64('2016-01-05T00:00:00'),
+                               numpy.timedelta64(1, 'm')),
+        }, self.storage._list_split_keys_for_metric(
+            self.metric, "mean", numpy.timedelta64(1, 'm')))
         data = self.storage._get_measures(
-            self.metric, carbonara.SplitKey(1451520000.0, 60.0), "mean")
+            self.metric, carbonara.SplitKey(
+                numpy.datetime64(1451520000, 's'),
+                numpy.timedelta64(60, 's'),
+            ), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, carbonara.SplitKey(1451736000.0, 60.0), "mean")
+            self.metric, carbonara.SplitKey(
+                numpy.datetime64(1451736000, 's'),
+                numpy.timedelta64(60, 's'),
+            ), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, carbonara.SplitKey(1451952000.0, 60.0), "mean")
+            self.metric, carbonara.SplitKey(
+                numpy.datetime64(1451952000, 's'),
+                numpy.timedelta64(1, 'm'),
+            ), "mean")
         # Now this one is compressed because it has been rewritten!
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, carbonara.SplitKey(1452384000.0, 60.0), "mean")
+            self.metric, carbonara.SplitKey(
+                numpy.datetime64(1452384000, 's'),
+                numpy.timedelta64(60, 's'),
+            ), "mean")
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
         self.assertEqual([
-            (utils.datetime_utc(2016, 1, 1, 12), 60.0, 69),
-            (utils.datetime_utc(2016, 1, 2, 13, 7), 60.0, 42),
-            (utils.datetime_utc(2016, 1, 4, 14, 9), 60.0, 4),
-            (utils.datetime_utc(2016, 1, 6, 15, 12), 60.0, 44),
-            (utils.datetime_utc(2016, 1, 10, 16, 18), 60.0, 45),
-            (utils.datetime_utc(2016, 1, 10, 17, 12), 60.0, 46),
-        ], self.storage.get_measures(self.metric, granularity=60.0))
+            (utils.datetime_utc(2016, 1, 1, 12),
+             numpy.timedelta64(1, 'm'), 69),
+            (utils.datetime_utc(2016, 1, 2, 13, 7),
+             numpy.timedelta64(1, 'm'), 42),
+            (utils.datetime_utc(2016, 1, 4, 14, 9),
+             numpy.timedelta64(1, 'm'), 4),
+            (utils.datetime_utc(2016, 1, 6, 15, 12),
+             numpy.timedelta64(1, 'm'), 44),
+            (utils.datetime_utc(2016, 1, 10, 16, 18),
+             numpy.timedelta64(1, 'm'), 45),
+            (utils.datetime_utc(2016, 1, 10, 17, 12),
+             numpy.timedelta64(1, 'm'), 46),
+        ], self.storage.get_measures(self.metric,
+                                     granularity=numpy.timedelta64(1, 'm')))
 
     def test_rewrite_measures_oldest_mutable_timestamp_eq_next_key(self):
         """See LP#1655422"""
@@ -409,10 +472,14 @@ class TestStorageDriver(tests_base.TestCase):
         self.trigger_processing()
 
         self.assertEqual({
-            carbonara.SplitKey(numpy.datetime64('2015-12-31T00:00:00'), 60),
-            carbonara.SplitKey(numpy.datetime64('2016-01-02T12:00:00'), 60),
-            carbonara.SplitKey(numpy.datetime64('2016-01-05T00:00:00'), 60),
-        }, self.storage._list_split_keys_for_metric(self.metric, "mean", 60.0))
+            carbonara.SplitKey(numpy.datetime64('2015-12-31T00:00:00'),
+                               numpy.timedelta64(1, 'm')),
+            carbonara.SplitKey(numpy.datetime64('2016-01-02T12:00:00'),
+                               numpy.timedelta64(1, 'm')),
+            carbonara.SplitKey(numpy.datetime64('2016-01-05T00:00:00'),
+                               numpy.timedelta64(1, 'm')),
+        }, self.storage._list_split_keys_for_metric(
+            self.metric, "mean", numpy.timedelta64(1, 'm')))
 
         if self.storage.WRITE_FULL:
             assertCompressedIfWriteFull = self.assertTrue
@@ -420,22 +487,36 @@ class TestStorageDriver(tests_base.TestCase):
             assertCompressedIfWriteFull = self.assertFalse
 
         data = self.storage._get_measures(
-            self.metric, carbonara.SplitKey(1451520000.0, 60.0), "mean")
+            self.metric, carbonara.SplitKey(
+                numpy.datetime64(1451520000, 's'),
+                numpy.timedelta64(1, 'm'),
+            ), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, carbonara.SplitKey(1451736000.0, 60.0), "mean")
+            self.metric, carbonara.SplitKey(
+                numpy.datetime64(1451736000, 's'),
+                numpy.timedelta64(1, 'm'),
+            ), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, carbonara.SplitKey(1451952000.0, 60.0), "mean")
+            self.metric, carbonara.SplitKey(
+                numpy.datetime64(1451952000, 's'),
+                numpy.timedelta64(1, 'm')
+            ), "mean")
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
         self.assertEqual([
-            (utils.datetime_utc(2016, 1, 1, 12), 60.0, 69),
-            (utils.datetime_utc(2016, 1, 2, 13, 7), 60.0, 42),
-            (utils.datetime_utc(2016, 1, 4, 14, 9), 60.0, 4),
-            (utils.datetime_utc(2016, 1, 6, 15, 12), 60.0, 44),
-        ], self.storage.get_measures(self.metric, granularity=60.0))
+            (utils.datetime_utc(2016, 1, 1, 12),
+             numpy.timedelta64(1, 'm'), 69),
+            (utils.datetime_utc(2016, 1, 2, 13, 7),
+             numpy.timedelta64(1, 'm'), 42),
+            (utils.datetime_utc(2016, 1, 4, 14, 9),
+             numpy.timedelta64(1, 'm'), 4),
+            (utils.datetime_utc(2016, 1, 6, 15, 12),
+             numpy.timedelta64(1, 'm'), 44),
+        ], self.storage.get_measures(self.metric,
+                                     granularity=numpy.timedelta64(60, 's')))
 
         # Now store brand new points that should force a rewrite of one of the
         # split (keep in mind the back window size in one hour here). We move
@@ -450,33 +531,56 @@ class TestStorageDriver(tests_base.TestCase):
         self.trigger_processing()
 
         self.assertEqual({
-            carbonara.SplitKey(numpy.datetime64('2016-01-10T00:00:00'), 60),
-            carbonara.SplitKey(numpy.datetime64('2016-01-02T12:00:00'), 60),
-            carbonara.SplitKey(numpy.datetime64('2015-12-31T00:00:00'), 60),
-            carbonara.SplitKey(numpy.datetime64('2016-01-05T00:00:00'), 60),
-        }, self.storage._list_split_keys_for_metric(self.metric, "mean", 60.0))
+            carbonara.SplitKey(numpy.datetime64('2016-01-10T00:00:00'),
+                               numpy.timedelta64(1, 'm')),
+            carbonara.SplitKey(numpy.datetime64('2016-01-02T12:00:00'),
+                               numpy.timedelta64(1, 'm')),
+            carbonara.SplitKey(numpy.datetime64('2015-12-31T00:00:00'),
+                               numpy.timedelta64(1, 'm')),
+            carbonara.SplitKey(numpy.datetime64('2016-01-05T00:00:00'),
+                               numpy.timedelta64(1, 'm')),
+        }, self.storage._list_split_keys_for_metric(
+            self.metric, "mean", numpy.timedelta64(1, 'm')))
         data = self.storage._get_measures(
-            self.metric, carbonara.SplitKey(1451520000.0, 60.0), "mean")
+            self.metric, carbonara.SplitKey(
+                numpy.datetime64(1451520000, 's'),
+                numpy.timedelta64(1, 'm'),
+            ), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, carbonara.SplitKey(1451736000.0, 60.0), "mean")
+            self.metric, carbonara.SplitKey(
+                numpy.datetime64(1451736000, 's'),
+                numpy.timedelta64(1, 'm'),
+            ), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, carbonara.SplitKey(1451952000.0, 60.0), "mean")
+            self.metric, carbonara.SplitKey(
+                numpy.datetime64(1451952000, 's'),
+                numpy.timedelta64(60, 's')
+            ), "mean")
         # Now this one is compressed because it has been rewritten!
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, carbonara.SplitKey(1452384000.0, 60.0), "mean")
+            self.metric, carbonara.SplitKey(
+                numpy.datetime64(1452384000, 's'),
+                numpy.timedelta64(1, 'm'),
+            ), "mean")
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
         self.assertEqual([
-            (utils.datetime_utc(2016, 1, 1, 12), 60.0, 69),
-            (utils.datetime_utc(2016, 1, 2, 13, 7), 60.0, 42),
-            (utils.datetime_utc(2016, 1, 4, 14, 9), 60.0, 4),
-            (utils.datetime_utc(2016, 1, 6, 15, 12), 60.0, 44),
-            (utils.datetime_utc(2016, 1, 10, 0, 12), 60.0, 45),
-        ], self.storage.get_measures(self.metric, granularity=60.0))
+            (utils.datetime_utc(2016, 1, 1, 12),
+             numpy.timedelta64(1, 'm'), 69),
+            (utils.datetime_utc(2016, 1, 2, 13, 7),
+             numpy.timedelta64(1, 'm'), 42),
+            (utils.datetime_utc(2016, 1, 4, 14, 9),
+             numpy.timedelta64(1, 'm'), 4),
+            (utils.datetime_utc(2016, 1, 6, 15, 12),
+             numpy.timedelta64(1, 'm'), 44),
+            (utils.datetime_utc(2016, 1, 10, 0, 12),
+             numpy.timedelta64(1, 'm'), 45),
+        ], self.storage.get_measures(self.metric,
+                                     granularity=numpy.timedelta64(60, 's')))
 
     def test_rewrite_measures_corruption_missing_file(self):
         # Create an archive policy that spans on several splits. Each split
@@ -498,10 +602,14 @@ class TestStorageDriver(tests_base.TestCase):
         self.trigger_processing()
 
         self.assertEqual({
-            carbonara.SplitKey(numpy.datetime64('2015-12-31T00:00:00'), 60),
-            carbonara.SplitKey(numpy.datetime64('2016-01-02T12:00:00'), 60),
-            carbonara.SplitKey(numpy.datetime64('2016-01-05T00:00:00'), 60),
-        }, self.storage._list_split_keys_for_metric(self.metric, "mean", 60.0))
+            carbonara.SplitKey(numpy.datetime64('2015-12-31T00:00:00'),
+                               numpy.timedelta64(1, 'm')),
+            carbonara.SplitKey(numpy.datetime64('2016-01-02T12:00:00'),
+                               numpy.timedelta64(1, 'm')),
+            carbonara.SplitKey(numpy.datetime64('2016-01-05T00:00:00'),
+                               numpy.timedelta64(1, 'm')),
+        }, self.storage._list_split_keys_for_metric(
+            self.metric, "mean", numpy.timedelta64(1, 'm')))
 
         if self.storage.WRITE_FULL:
             assertCompressedIfWriteFull = self.assertTrue
@@ -509,27 +617,45 @@ class TestStorageDriver(tests_base.TestCase):
             assertCompressedIfWriteFull = self.assertFalse
 
         data = self.storage._get_measures(
-            self.metric, carbonara.SplitKey(1451520000.0, 60.0), "mean")
+            self.metric,
+            carbonara.SplitKey(
+                numpy.datetime64(1451520000, 's'),
+                numpy.timedelta64(1, 'm'),
+            ), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, carbonara.SplitKey(1451736000.0, 60.0), "mean")
+            self.metric, carbonara.SplitKey(
+                numpy.datetime64(1451736000, 's'),
+                numpy.timedelta64(1, 'm')
+            ), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, carbonara.SplitKey(1451952000.0, 60.0), "mean")
+            self.metric, carbonara.SplitKey(
+                numpy.datetime64(1451952000, 's'),
+                numpy.timedelta64(1, 'm'),
+            ), "mean")
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
         self.assertEqual([
-            (utils.datetime_utc(2016, 1, 1, 12), 60.0, 69),
-            (utils.datetime_utc(2016, 1, 2, 13, 7), 60.0, 42),
-            (utils.datetime_utc(2016, 1, 4, 14, 9), 60.0, 4),
-            (utils.datetime_utc(2016, 1, 6, 15, 12), 60.0, 44),
-        ], self.storage.get_measures(self.metric, granularity=60.0))
+            (utils.datetime_utc(2016, 1, 1, 12),
+             numpy.timedelta64(1, 'm'), 69),
+            (utils.datetime_utc(2016, 1, 2, 13, 7),
+             numpy.timedelta64(1, 'm'), 42),
+            (utils.datetime_utc(2016, 1, 4, 14, 9),
+             numpy.timedelta64(1, 'm'), 4),
+            (utils.datetime_utc(2016, 1, 6, 15, 12),
+             numpy.timedelta64(1, 'm'), 44),
+        ], self.storage.get_measures(self.metric,
+                                     granularity=numpy.timedelta64(60, 's')))
 
         # Test what happens if we delete the latest split and then need to
         # compress it!
         self.storage._delete_metric_measures(
-            self.metric, carbonara.SplitKey(1451952000.0, 60.0), 'mean')
+            self.metric, carbonara.SplitKey(
+                numpy.datetime64(1451952000, 's'),
+                numpy.timedelta64(1, 'm'),
+            ), 'mean')
 
         # Now store brand new points that should force a rewrite of one of the
         # split (keep in mind the back window size in one hour here). We move
@@ -561,10 +687,14 @@ class TestStorageDriver(tests_base.TestCase):
         self.trigger_processing()
 
         self.assertEqual({
-            carbonara.SplitKey(numpy.datetime64('2015-12-31T00:00:00'), 60),
-            carbonara.SplitKey(numpy.datetime64('2016-01-02T12:00:00'), 60),
-            carbonara.SplitKey(numpy.datetime64('2016-01-05T00:00:00'), 60),
-        }, self.storage._list_split_keys_for_metric(self.metric, "mean", 60.0))
+            carbonara.SplitKey(numpy.datetime64('2015-12-31T00:00:00'),
+                               numpy.timedelta64(1, 'm')),
+            carbonara.SplitKey(numpy.datetime64('2016-01-02T12:00:00'),
+                               numpy.timedelta64(1, 'm')),
+            carbonara.SplitKey(numpy.datetime64('2016-01-05T00:00:00'),
+                               numpy.timedelta64(1, 'm')),
+        }, self.storage._list_split_keys_for_metric(
+            self.metric, "mean", numpy.timedelta64(1, 'm')))
 
         if self.storage.WRITE_FULL:
             assertCompressedIfWriteFull = self.assertTrue
@@ -572,26 +702,43 @@ class TestStorageDriver(tests_base.TestCase):
             assertCompressedIfWriteFull = self.assertFalse
 
         data = self.storage._get_measures(
-            self.metric, carbonara.SplitKey(1451520000.0, 60.0), "mean")
+            self.metric, carbonara.SplitKey(
+                numpy.datetime64(1451520000, 's'),
+                numpy.timedelta64(60, 's'),
+            ), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, carbonara.SplitKey(1451736000.0, 60.0), "mean")
+            self.metric, carbonara.SplitKey(
+                numpy.datetime64(1451736000, 's'),
+                numpy.timedelta64(1, 'm'),
+            ), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, carbonara.SplitKey(1451952000.0, 60.0), "mean")
+            self.metric, carbonara.SplitKey(
+                numpy.datetime64(1451952000, 's'),
+                numpy.timedelta64(1, 'm'),
+            ), "mean")
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
         self.assertEqual([
-            (utils.datetime_utc(2016, 1, 1, 12), 60.0, 69),
-            (utils.datetime_utc(2016, 1, 2, 13, 7), 60.0, 42),
-            (utils.datetime_utc(2016, 1, 4, 14, 9), 60.0, 4),
-            (utils.datetime_utc(2016, 1, 6, 15, 12), 60.0, 44),
-        ], self.storage.get_measures(self.metric, granularity=60.0))
+            (utils.datetime_utc(2016, 1, 1, 12),
+             numpy.timedelta64(1, 'm'), 69),
+            (utils.datetime_utc(2016, 1, 2, 13, 7),
+             numpy.timedelta64(1, 'm'), 42),
+            (utils.datetime_utc(2016, 1, 4, 14, 9),
+             numpy.timedelta64(1, 'm'), 4),
+            (utils.datetime_utc(2016, 1, 6, 15, 12),
+             numpy.timedelta64(1, 'm'), 44),
+        ], self.storage.get_measures(self.metric,
+                                     granularity=numpy.timedelta64(1, 'm')))
 
         # Test what happens if we write garbage
         self.storage._store_metric_measures(
-            self.metric, carbonara.SplitKey(1451952000.0, 60.0), "mean",
+            self.metric, carbonara.SplitKey(
+                numpy.datetime64(1451952000, 's'),
+                numpy.timedelta64(1, 'm'),
+            ), "mean",
             b"oh really?")
 
         # Now store brand new points that should force a rewrite of one of the
@@ -612,10 +759,14 @@ class TestStorageDriver(tests_base.TestCase):
         self.trigger_processing()
 
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1), 86400.0, 55.5),
-            (utils.datetime_utc(2014, 1, 1, 12), 3600.0, 55.5),
-            (utils.datetime_utc(2014, 1, 1, 12), 300.0, 69),
-            (utils.datetime_utc(2014, 1, 1, 12, 5), 300.0, 42.0),
+            (utils.datetime_utc(2014, 1, 1),
+             numpy.timedelta64(1, 'D'), 55.5),
+            (utils.datetime_utc(2014, 1, 1, 12),
+             numpy.timedelta64(1, 'h'), 55.5),
+            (utils.datetime_utc(2014, 1, 1, 12),
+             numpy.timedelta64(5, 'm'), 69),
+            (utils.datetime_utc(2014, 1, 1, 12, 5),
+             numpy.timedelta64(5, 'm'), 42.0),
         ], self.storage.get_measures(self.metric))
 
         self.incoming.add_measures(self.metric, [
@@ -625,27 +776,42 @@ class TestStorageDriver(tests_base.TestCase):
         self.trigger_processing()
 
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1), 86400.0, 39.75),
-            (utils.datetime_utc(2014, 1, 1, 12), 3600.0, 39.75),
-            (utils.datetime_utc(2014, 1, 1, 12), 300.0, 69.0),
-            (utils.datetime_utc(2014, 1, 1, 12, 5), 300.0, 23.0),
-            (utils.datetime_utc(2014, 1, 1, 12, 10), 300.0, 44.0),
+            (utils.datetime_utc(2014, 1, 1),
+             numpy.timedelta64(1, 'D'), 39.75),
+            (utils.datetime_utc(2014, 1, 1, 12),
+             numpy.timedelta64(1, 'h'), 39.75),
+            (utils.datetime_utc(2014, 1, 1, 12),
+             numpy.timedelta64(5, 'm'), 69.0),
+            (utils.datetime_utc(2014, 1, 1, 12, 5),
+             numpy.timedelta64(5, 'm'), 23.0),
+            (utils.datetime_utc(2014, 1, 1, 12, 10),
+             numpy.timedelta64(5, 'm'), 44.0),
         ], self.storage.get_measures(self.metric))
 
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1), 86400.0, 69),
-            (utils.datetime_utc(2014, 1, 1, 12), 3600.0, 69.0),
-            (utils.datetime_utc(2014, 1, 1, 12), 300.0, 69.0),
-            (utils.datetime_utc(2014, 1, 1, 12, 5), 300.0, 42.0),
-            (utils.datetime_utc(2014, 1, 1, 12, 10), 300.0, 44.0),
+            (utils.datetime_utc(2014, 1, 1),
+             numpy.timedelta64(1, 'D'), 69),
+            (utils.datetime_utc(2014, 1, 1, 12),
+             numpy.timedelta64(1, 'h'), 69.0),
+            (utils.datetime_utc(2014, 1, 1, 12),
+             numpy.timedelta64(5, 'm'), 69.0),
+            (utils.datetime_utc(2014, 1, 1, 12, 5),
+             numpy.timedelta64(5, 'm'), 42.0),
+            (utils.datetime_utc(2014, 1, 1, 12, 10),
+             numpy.timedelta64(5, 'm'), 44.0),
         ], self.storage.get_measures(self.metric, aggregation='max'))
 
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1), 86400.0, 4),
-            (utils.datetime_utc(2014, 1, 1, 12), 3600.0, 4),
-            (utils.datetime_utc(2014, 1, 1, 12), 300.0, 69.0),
-            (utils.datetime_utc(2014, 1, 1, 12, 5), 300.0, 4.0),
-            (utils.datetime_utc(2014, 1, 1, 12, 10), 300.0, 44.0),
+            (utils.datetime_utc(2014, 1, 1),
+             numpy.timedelta64(1, 'D'), 4),
+            (utils.datetime_utc(2014, 1, 1, 12),
+             numpy.timedelta64(1, 'h'), 4),
+            (utils.datetime_utc(2014, 1, 1, 12),
+             numpy.timedelta64(5, 'm'), 69.0),
+            (utils.datetime_utc(2014, 1, 1, 12, 5),
+             numpy.timedelta64(5, 'm'), 4.0),
+            (utils.datetime_utc(2014, 1, 1, 12, 10),
+             numpy.timedelta64(5, 'm'), 44.0),
         ], self.storage.get_measures(self.metric, aggregation='min'))
 
     def test_add_and_get_measures(self):
@@ -658,77 +824,100 @@ class TestStorageDriver(tests_base.TestCase):
         self.trigger_processing()
 
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1), 86400.0, 39.75),
-            (utils.datetime_utc(2014, 1, 1, 12), 3600.0, 39.75),
-            (utils.datetime_utc(2014, 1, 1, 12), 300.0, 69.0),
-            (utils.datetime_utc(2014, 1, 1, 12, 5), 300.0, 23.0),
-            (utils.datetime_utc(2014, 1, 1, 12, 10), 300.0, 44.0),
+            (utils.datetime_utc(2014, 1, 1),
+             numpy.timedelta64(1, 'D'), 39.75),
+            (utils.datetime_utc(2014, 1, 1, 12),
+             numpy.timedelta64(1, 'h'), 39.75),
+            (utils.datetime_utc(2014, 1, 1, 12),
+             numpy.timedelta64(5, 'm'), 69.0),
+            (utils.datetime_utc(2014, 1, 1, 12, 5),
+             numpy.timedelta64(5, 'm'), 23.0),
+            (utils.datetime_utc(2014, 1, 1, 12, 10),
+             numpy.timedelta64(5, 'm'), 44.0),
         ], self.storage.get_measures(self.metric))
 
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1), 86400.0, 39.75),
-            (utils.datetime_utc(2014, 1, 1, 12), 3600.0, 39.75),
-            (utils.datetime_utc(2014, 1, 1, 12, 10), 300.0, 44.0),
+            (utils.datetime_utc(2014, 1, 1),
+             numpy.timedelta64(1, 'D'), 39.75),
+            (utils.datetime_utc(2014, 1, 1, 12),
+             numpy.timedelta64(1, 'h'), 39.75),
+            (utils.datetime_utc(2014, 1, 1, 12, 10),
+             numpy.timedelta64(5, 'm'), 44.0),
         ], self.storage.get_measures(
             self.metric,
-            from_timestamp=datetime.datetime(2014, 1, 1, 12, 10, 0)))
+            from_timestamp=datetime64(2014, 1, 1, 12, 10, 0)))
 
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1), 86400.0, 39.75),
-            (utils.datetime_utc(2014, 1, 1, 12), 3600.0, 39.75),
-            (utils.datetime_utc(2014, 1, 1, 12), 300.0, 69.0),
-            (utils.datetime_utc(2014, 1, 1, 12, 5), 300.0, 23.0),
+            (utils.datetime_utc(2014, 1, 1),
+             numpy.timedelta64(1, 'D'), 39.75),
+            (utils.datetime_utc(2014, 1, 1, 12),
+             numpy.timedelta64(1, 'h'), 39.75),
+            (utils.datetime_utc(2014, 1, 1, 12),
+             numpy.timedelta64(5, 'm'), 69.0),
+            (utils.datetime_utc(2014, 1, 1, 12, 5),
+             numpy.timedelta64(5, 'm'), 23.0),
         ], self.storage.get_measures(
             self.metric,
-            to_timestamp=datetime.datetime(2014, 1, 1, 12, 6, 0)))
+            to_timestamp=datetime64(2014, 1, 1, 12, 6, 0)))
 
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1), 86400.0, 39.75),
-            (utils.datetime_utc(2014, 1, 1, 12), 3600.0, 39.75),
-            (utils.datetime_utc(2014, 1, 1, 12, 10), 300.0, 44.0),
+            (utils.datetime_utc(2014, 1, 1),
+             numpy.timedelta64(1, 'D'), 39.75),
+            (utils.datetime_utc(2014, 1, 1, 12),
+             numpy.timedelta64(1, 'h'), 39.75),
+            (utils.datetime_utc(2014, 1, 1, 12, 10),
+             numpy.timedelta64(5, 'm'), 44.0),
         ], self.storage.get_measures(
             self.metric,
-            to_timestamp=datetime.datetime(2014, 1, 1, 12, 10, 10),
-            from_timestamp=datetime.datetime(2014, 1, 1, 12, 10, 10)))
+            to_timestamp=datetime64(2014, 1, 1, 12, 10, 10),
+            from_timestamp=datetime64(2014, 1, 1, 12, 10, 10)))
 
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1), 86400.0, 39.75),
-            (utils.datetime_utc(2014, 1, 1, 12), 3600.0, 39.75),
-            (utils.datetime_utc(2014, 1, 1, 12), 300.0, 69.0),
+            (utils.datetime_utc(2014, 1, 1),
+             numpy.timedelta64(1, 'D'), 39.75),
+            (utils.datetime_utc(2014, 1, 1, 12),
+             numpy.timedelta64(1, 'h'), 39.75),
+            (utils.datetime_utc(2014, 1, 1, 12),
+             numpy.timedelta64(5, 'm'), 69.0),
         ], self.storage.get_measures(
             self.metric,
-            from_timestamp=datetime.datetime(2014, 1, 1, 12, 0, 0),
-            to_timestamp=datetime.datetime(2014, 1, 1, 12, 0, 2)))
+            from_timestamp=datetime64(2014, 1, 1, 12, 0, 0),
+            to_timestamp=datetime64(2014, 1, 1, 12, 0, 2)))
 
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1), 86400.0, 39.75),
-            (utils.datetime_utc(2014, 1, 1, 12), 3600.0, 39.75),
-            (utils.datetime_utc(2014, 1, 1, 12), 300.0, 69.0),
+            (utils.datetime_utc(2014, 1, 1),
+             numpy.timedelta64(1, 'D'), 39.75),
+            (utils.datetime_utc(2014, 1, 1, 12),
+             numpy.timedelta64(1, 'h'), 39.75),
+            (utils.datetime_utc(2014, 1, 1, 12),
+             numpy.timedelta64(5, 'm'), 69.0),
         ], self.storage.get_measures(
             self.metric,
-            from_timestamp=iso8601.parse_date("2014-1-1 13:00:00+01:00"),
-            to_timestamp=datetime.datetime(2014, 1, 1, 12, 0, 2)))
+            from_timestamp=datetime64(2014, 1, 1, 12),
+            to_timestamp=datetime64(2014, 1, 1, 12, 0, 2)))
 
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1, 12), 3600.0, 39.75),
+            (utils.datetime_utc(2014, 1, 1, 12),
+             numpy.timedelta64(1, 'h'), 39.75),
         ], self.storage.get_measures(
             self.metric,
-            from_timestamp=datetime.datetime(2014, 1, 1, 12, 0, 0),
-            to_timestamp=datetime.datetime(2014, 1, 1, 12, 0, 2),
-            granularity=3600.0))
+            from_timestamp=datetime64(2014, 1, 1, 12, 0, 0),
+            to_timestamp=datetime64(2014, 1, 1, 12, 0, 2),
+            granularity=numpy.timedelta64(1, 'h')))
 
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1, 12), 300.0, 69.0),
+            (utils.datetime_utc(2014, 1, 1, 12),
+             numpy.timedelta64(5, 'm'), 69.0),
         ], self.storage.get_measures(
             self.metric,
-            from_timestamp=datetime.datetime(2014, 1, 1, 12, 0, 0),
-            to_timestamp=datetime.datetime(2014, 1, 1, 12, 0, 2),
-            granularity=300.0))
+            from_timestamp=datetime64(2014, 1, 1, 12, 0, 0),
+            to_timestamp=datetime64(2014, 1, 1, 12, 0, 2),
+            granularity=numpy.timedelta64(5, 'm')))
 
         self.assertRaises(storage.GranularityDoesNotExist,
                           self.storage.get_measures,
                           self.metric,
-                          granularity=42)
+                          granularity=numpy.timedelta64(42, 's'))
 
     def test_get_cross_metric_measures_unknown_metric(self):
         self.assertEqual([],
@@ -787,7 +976,7 @@ class TestStorageDriver(tests_base.TestCase):
         self.assertRaises(storage.GranularityDoesNotExist,
                           self.storage.get_cross_metric_measures,
                           [self.metric, metric2],
-                          granularity=12345.456)
+                          granularity=numpy.timedelta64(12345456, 'ms'))
 
     def test_add_and_get_cross_metric_measures_different_archives(self):
         metric2 = storage.Metric(uuid.uuid4(),
@@ -827,71 +1016,94 @@ class TestStorageDriver(tests_base.TestCase):
 
         values = self.storage.get_cross_metric_measures([self.metric, metric2])
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1, 0, 0, 0), 86400.0, 22.25),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 0), 3600.0, 22.25),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 0), 300.0, 39.0),
-            (utils.datetime_utc(2014, 1, 1, 12, 5, 0), 300.0, 12.5),
-            (utils.datetime_utc(2014, 1, 1, 12, 10, 0), 300.0, 24.0)
+            (utils.datetime_utc(2014, 1, 1, 0, 0, 0),
+             numpy.timedelta64(1, 'D'), 22.25),
+            (utils.datetime_utc(2014, 1, 1, 12, 0, 0),
+             numpy.timedelta64(1, 'h'), 22.25),
+            (utils.datetime_utc(2014, 1, 1, 12, 0, 0),
+             numpy.timedelta64(5, 'm'), 39.0),
+            (utils.datetime_utc(2014, 1, 1, 12, 5, 0),
+             numpy.timedelta64(5, 'm'), 12.5),
+            (utils.datetime_utc(2014, 1, 1, 12, 10, 0),
+             numpy.timedelta64(5, 'm'), 24.0)
         ], values)
 
         values = self.storage.get_cross_metric_measures([self.metric, metric2],
                                                         reaggregation='max')
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1, 0, 0, 0), 86400.0, 39.75),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 0), 3600.0, 39.75),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 0), 300.0, 69),
-            (utils.datetime_utc(2014, 1, 1, 12, 5, 0), 300.0, 23),
-            (utils.datetime_utc(2014, 1, 1, 12, 10, 0), 300.0, 44)
+            (utils.datetime_utc(2014, 1, 1, 0, 0, 0),
+             numpy.timedelta64(1, 'D'), 39.75),
+            (utils.datetime_utc(2014, 1, 1, 12, 0, 0),
+             numpy.timedelta64(1, 'h'), 39.75),
+            (utils.datetime_utc(2014, 1, 1, 12, 0, 0),
+             numpy.timedelta64(5, 'm'), 69),
+            (utils.datetime_utc(2014, 1, 1, 12, 5, 0),
+             numpy.timedelta64(5, 'm'), 23),
+            (utils.datetime_utc(2014, 1, 1, 12, 10, 0),
+             numpy.timedelta64(5, 'm'), 44)
         ], values)
 
         values = self.storage.get_cross_metric_measures(
             [self.metric, metric2],
-            from_timestamp=datetime.datetime(2014, 1, 1, 12, 10, 0))
+            from_timestamp=datetime64(2014, 1, 1, 12, 10, 0))
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1), 86400.0, 22.25),
-            (utils.datetime_utc(2014, 1, 1, 12), 3600.0, 22.25),
-            (utils.datetime_utc(2014, 1, 1, 12, 10, 0), 300.0, 24.0),
+            (utils.datetime_utc(2014, 1, 1),
+             numpy.timedelta64(1, 'D'), 22.25),
+            (utils.datetime_utc(2014, 1, 1, 12),
+             numpy.timedelta64(1, 'h'), 22.25),
+            (utils.datetime_utc(2014, 1, 1, 12, 10, 0),
+             numpy.timedelta64(5, 'm'), 24.0),
         ], values)
 
         values = self.storage.get_cross_metric_measures(
             [self.metric, metric2],
-            to_timestamp=datetime.datetime(2014, 1, 1, 12, 5, 0))
+            to_timestamp=datetime64(2014, 1, 1, 12, 5, 0))
 
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1, 0, 0, 0), 86400.0, 22.25),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 0), 3600.0, 22.25),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 0), 300.0, 39.0),
+            (utils.datetime_utc(2014, 1, 1, 0, 0, 0),
+             numpy.timedelta64(1, 'D'), 22.25),
+            (utils.datetime_utc(2014, 1, 1, 12, 0, 0),
+             numpy.timedelta64(1, 'h'), 22.25),
+            (utils.datetime_utc(2014, 1, 1, 12, 0, 0),
+             numpy.timedelta64(5, 'm'), 39.0),
         ], values)
 
         values = self.storage.get_cross_metric_measures(
             [self.metric, metric2],
-            from_timestamp=datetime.datetime(2014, 1, 1, 12, 10, 10),
-            to_timestamp=datetime.datetime(2014, 1, 1, 12, 10, 10))
+            from_timestamp=datetime64(2014, 1, 1, 12, 10, 10),
+            to_timestamp=datetime64(2014, 1, 1, 12, 10, 10))
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1), 86400.0, 22.25),
-            (utils.datetime_utc(2014, 1, 1, 12), 3600.0, 22.25),
-            (utils.datetime_utc(2014, 1, 1, 12, 10), 300.0, 24.0),
+            (utils.datetime_utc(2014, 1, 1),
+             numpy.timedelta64(1, 'D'), 22.25),
+            (utils.datetime_utc(2014, 1, 1, 12),
+             numpy.timedelta64(1, 'h'), 22.25),
+            (utils.datetime_utc(2014, 1, 1, 12, 10),
+             numpy.timedelta64(5, 'm'), 24.0),
         ], values)
 
         values = self.storage.get_cross_metric_measures(
             [self.metric, metric2],
-            from_timestamp=datetime.datetime(2014, 1, 1, 12, 0, 0),
-            to_timestamp=datetime.datetime(2014, 1, 1, 12, 0, 1))
+            from_timestamp=datetime64(2014, 1, 1, 12, 0, 0),
+            to_timestamp=datetime64(2014, 1, 1, 12, 0, 1))
 
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1), 86400.0, 22.25),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 0), 3600.0, 22.25),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 0), 300.0, 39.0),
+            (utils.datetime_utc(2014, 1, 1),
+             numpy.timedelta64(1, 'D'), 22.25),
+            (utils.datetime_utc(2014, 1, 1, 12, 0, 0),
+             numpy.timedelta64(1, 'h'), 22.25),
+            (utils.datetime_utc(2014, 1, 1, 12, 0, 0),
+             numpy.timedelta64(5, 'm'), 39.0),
         ], values)
 
         values = self.storage.get_cross_metric_measures(
             [self.metric, metric2],
-            from_timestamp=datetime.datetime(2014, 1, 1, 12, 0, 0),
-            to_timestamp=datetime.datetime(2014, 1, 1, 12, 0, 1),
-            granularity=300.0)
+            from_timestamp=datetime64(2014, 1, 1, 12, 0, 0),
+            to_timestamp=datetime64(2014, 1, 1, 12, 0, 1),
+            granularity=numpy.timedelta64(5, 'm'))
 
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 0), 300.0, 39.0),
+            (utils.datetime_utc(2014, 1, 1, 12, 0, 0),
+             numpy.timedelta64(5, 'm'), 39.0),
         ], values)
 
     def test_add_and_get_cross_metric_measures_with_holes(self):
@@ -913,11 +1125,16 @@ class TestStorageDriver(tests_base.TestCase):
 
         values = self.storage.get_cross_metric_measures([self.metric, metric2])
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1, 0, 0, 0), 86400.0, 18.875),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 0), 3600.0, 18.875),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 0), 300.0, 39.0),
-            (utils.datetime_utc(2014, 1, 1, 12, 5, 0), 300.0, 11.0),
-            (utils.datetime_utc(2014, 1, 1, 12, 10, 0), 300.0, 22.0)
+            (utils.datetime_utc(2014, 1, 1, 0, 0, 0),
+             numpy.timedelta64(1, 'D'), 18.875),
+            (utils.datetime_utc(2014, 1, 1, 12, 0, 0),
+             numpy.timedelta64(1, 'h'), 18.875),
+            (utils.datetime_utc(2014, 1, 1, 12, 0, 0),
+             numpy.timedelta64(5, 'm'), 39.0),
+            (utils.datetime_utc(2014, 1, 1, 12, 5, 0),
+             numpy.timedelta64(5, 'm'), 11.0),
+            (utils.datetime_utc(2014, 1, 1, 12, 10, 0),
+             numpy.timedelta64(5, 'm'), 22.0)
         ], values)
 
     def test_search_value(self):
@@ -941,10 +1158,14 @@ class TestStorageDriver(tests_base.TestCase):
         self.assertEqual(
             {metric2: [],
              self.metric: [
-                 (utils.datetime_utc(2014, 1, 1), 86400, 33),
-                 (utils.datetime_utc(2014, 1, 1, 12), 3600, 33),
-                 (utils.datetime_utc(2014, 1, 1, 12), 300, 69),
-                 (utils.datetime_utc(2014, 1, 1, 12, 10), 300, 42)]},
+                 (utils.datetime_utc(2014, 1, 1),
+                  numpy.timedelta64(1, 'D'), 33),
+                 (utils.datetime_utc(2014, 1, 1, 12),
+                  numpy.timedelta64(1, 'h'), 33),
+                 (utils.datetime_utc(2014, 1, 1, 12),
+                  numpy.timedelta64(5, 'm'), 69),
+                 (utils.datetime_utc(2014, 1, 1, 12, 10),
+                  numpy.timedelta64(5, 'm'), 42)]},
             self.storage.search_value(
                 [metric2, self.metric],
                 {u"≥": 30}))
@@ -970,9 +1191,12 @@ class TestStorageDriver(tests_base.TestCase):
         ])
         self.trigger_processing([str(m.id)])
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 0), 5.0, 1.0),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 5), 5.0, 1.0),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 10), 5.0, 1.0),
+            (utils.datetime_utc(2014, 1, 1, 12, 0, 0),
+             numpy.timedelta64(5, 's'), 1.0),
+            (utils.datetime_utc(2014, 1, 1, 12, 0, 5),
+             numpy.timedelta64(5, 's'), 1.0),
+            (utils.datetime_utc(2014, 1, 1, 12, 0, 10),
+             numpy.timedelta64(5, 's'), 1.0),
         ], self.storage.get_measures(m))
         # expand to more points
         self.index.update_archive_policy(
@@ -983,18 +1207,24 @@ class TestStorageDriver(tests_base.TestCase):
         ])
         self.trigger_processing([str(m.id)])
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 0), 5.0, 1.0),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 5), 5.0, 1.0),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 10), 5.0, 1.0),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 15), 5.0, 1.0),
+            (utils.datetime_utc(2014, 1, 1, 12, 0, 0),
+             numpy.timedelta64(5, 's'), 1.0),
+            (utils.datetime_utc(2014, 1, 1, 12, 0, 5),
+             numpy.timedelta64(5, 's'), 1.0),
+            (utils.datetime_utc(2014, 1, 1, 12, 0, 10),
+             numpy.timedelta64(5, 's'), 1.0),
+            (utils.datetime_utc(2014, 1, 1, 12, 0, 15),
+             numpy.timedelta64(5, 's'), 1.0),
         ], self.storage.get_measures(m))
         # shrink timespan
         self.index.update_archive_policy(
             name, [archive_policy.ArchivePolicyItem(granularity=5, points=2)])
         m = self.index.list_metrics(ids=[m.id])[0]
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 10), 5.0, 1.0),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 15), 5.0, 1.0),
+            (utils.datetime_utc(2014, 1, 1, 12, 0, 10),
+             numpy.timedelta64(5, 's'), 1.0),
+            (utils.datetime_utc(2014, 1, 1, 12, 0, 15),
+             numpy.timedelta64(5, 's'), 1.0),
         ], self.storage.get_measures(m))
 
     def test_resample_no_metric(self):
@@ -1002,10 +1232,10 @@ class TestStorageDriver(tests_base.TestCase):
         self.assertEqual([],
                          self.storage.get_measures(
                              self.metric,
-                             utils.datetime_utc(2014, 1, 1),
-                             utils.datetime_utc(2015, 1, 1),
-                             granularity=300,
-                             resample=3600))
+                             datetime64(2014, 1, 1),
+                             datetime64(2015, 1, 1),
+                             granularity=numpy.timedelta64(300, 's'),
+                             resample=numpy.timedelta64(1, 'h')))
 
 
 class TestMeasureQuery(tests_base.TestCase):

--- a/gnocchi/utils.py
+++ b/gnocchi/utils.py
@@ -160,12 +160,21 @@ def to_timespan(value):
         seconds = float(value)
     except Exception:
         try:
-            seconds = pd.to_timedelta(value).total_seconds()
+            seconds = pd.to_timedelta(value).to_timedelta64()
         except Exception:
             raise ValueError("Unable to parse timespan")
-    if seconds <= 0:
+    else:
+        seconds = numpy.timedelta64(int(seconds * 10e8), 'ns')
+    if seconds <= numpy.timedelta64(0, 'ns'):
         raise ValueError("Timespan must be positive")
-    return datetime.timedelta(seconds=seconds)
+    return seconds
+
+
+_ONE_SECOND = numpy.timedelta64(1, 's')
+
+
+def timespan_total_seconds(td):
+    return td / _ONE_SECOND
 
 
 def utcnow():


### PR DESCRIPTION
carbonara: use numpy native types for computing
tests: fix gabbi test title
carbonara: simplify unserialize
carbonara: use sampling from SplitKey
storage: return SplitKey objects when listing split keys
utils: fix to_timestamps when value list is empty