### PR TITLE
Pull request for swift-retry-only-metricd

### DIFF
--- a/gnocchi/cli.py
+++ b/gnocchi/cli.py
@@ -191,7 +191,7 @@ class MetricProcessor(MetricProcessBase):
     def __init__(self, worker_id, conf):
         super(MetricProcessor, self).__init__(
             worker_id, conf, conf.metricd.metric_processing_delay)
-        self.coord, __ = utils.get_coordinator_and_start(
+        self.coord = utils.get_coordinator_and_start(
             conf.storage.coordination_url)
         self._tasks = []
         self.group_state = None

--- a/gnocchi/cli.py
+++ b/gnocchi/cli.py
@@ -70,7 +70,6 @@ def upgrade():
     conf = service.prepare_service(conf=conf, log_to_std=True)
     if not conf.skip_index:
         index = indexer.get_driver(conf)
-        index.connect()
         LOG.info("Upgrading indexer %s", index)
         index.upgrade()
     if not conf.skip_storage:
@@ -87,7 +86,6 @@ def upgrade():
             and not index.list_archive_policy_rules()):
         if conf.skip_index:
             index = indexer.get_driver(conf)
-            index.connect()
         for name, ap in six.iteritems(archive_policy.DEFAULT_ARCHIVE_POLICIES):
             index.create_archive_policy(ap)
         index.create_archive_policy_rule("default", "*", "low")
@@ -131,7 +129,6 @@ class MetricProcessBase(cotyledon.Service):
         self.store = storage.get_driver(self.conf)
         self.incoming = incoming.get_driver(self.conf)
         self.index = indexer.get_driver(self.conf)
-        self.index.connect()
 
     def run(self):
         self._configure()
@@ -201,7 +198,6 @@ class MetricProcessor(MetricProcessBase):
         self.store = storage.get_driver(self.conf, self.coord)
         self.incoming = incoming.get_driver(self.conf)
         self.index = indexer.get_driver(self.conf)
-        self.index.connect()
 
         # create fallback in case paritioning fails or assigned no tasks
         self.fallback_tasks = list(
@@ -304,7 +300,6 @@ def metricd_tester(conf):
     # want to avoid issues with profiler and os.fork(), that
     # why we don't use the MetricdServiceManager.
     index = indexer.get_driver(conf)
-    index.connect()
     s = storage.get_driver(conf)
     inc = incoming.get_driver(conf)
     metrics = set()

--- a/gnocchi/common/swift.py
+++ b/gnocchi/common/swift.py
@@ -22,13 +22,14 @@ except ImportError:
     swift_utils = None
 
 from gnocchi import storage
-from gnocchi import utils
 
 LOG = daiquiri.getLogger(__name__)
 
 
-@utils.retry
-def _get_connection(conf):
+def get_connection(conf):
+    if swclient is None:
+        raise RuntimeError("python-swiftclient unavailable")
+
     return swclient.Connection(
         auth_version=conf.swift_auth_version,
         authurl=conf.swift_authurl,
@@ -40,13 +41,6 @@ def _get_connection(conf):
         os_options={'endpoint_type': conf.swift_endpoint_type,
                     'user_domain_name': conf.swift_user_domain_name},
         retries=0)
-
-
-def get_connection(conf):
-    if swclient is None:
-        raise RuntimeError("python-swiftclient unavailable")
-
-    return _get_connection(conf)
 
 
 POST_HEADERS = {'Accept': 'application/json', 'Content-Type': 'text/plain'}

--- a/gnocchi/indexer/__init__.py
+++ b/gnocchi/indexer/__init__.py
@@ -265,10 +265,6 @@ class IndexerDriver(object):
         pass
 
     @staticmethod
-    def connect():
-        pass
-
-    @staticmethod
     def disconnect():
         pass
 

--- a/gnocchi/indexer/alembic/env.py
+++ b/gnocchi/indexer/alembic/env.py
@@ -65,7 +65,6 @@ def run_migrations_online():
     """
     conf = config.conf
     indexer = sqlalchemy.SQLAlchemyIndexer(conf)
-    indexer.connect()
     with indexer.facade.writer_connection() as connectable:
 
         with connectable.connect() as connection:

--- a/gnocchi/rest/app.py
+++ b/gnocchi/rest/app.py
@@ -107,7 +107,6 @@ def load_app(conf, indexer=None, storage=None, incoming=None,
         incoming = gnocchi_incoming.get_driver(conf)
     if not indexer:
         indexer = gnocchi_indexer.get_driver(conf)
-        indexer.connect()
 
     # Build the WSGI app
     cfg_path = conf.api.paste_config

--- a/gnocchi/statsd.py
+++ b/gnocchi/statsd.py
@@ -38,7 +38,6 @@ class Stats(object):
         self.conf = conf
         self.incoming = incoming.get_driver(self.conf)
         self.indexer = indexer.get_driver(self.conf)
-        self.indexer.connect()
         try:
             self.indexer.create_resource('generic',
                                          self.conf.statsd.resource_id,

--- a/gnocchi/storage/_carbonara.py
+++ b/gnocchi/storage/_carbonara.py
@@ -63,9 +63,8 @@ class CarbonaraBasedStorage(storage.StorageDriver):
             self._map_in_thread = self._map_no_thread
         else:
             self._map_in_thread = self._map_in_futures_threads
-        self.coord, __ = (
-            (coord, None) if coord else
-            utils.get_coordinator_and_start(conf.coordination_url))
+        self.coord = (coord if coord else
+                      utils.get_coordinator_and_start(conf.coordination_url))
         self.shared_coord = bool(coord)
 
     def stop(self):

--- a/gnocchi/tests/base.py
+++ b/gnocchi/tests/base.py
@@ -290,7 +290,6 @@ class TestCase(BaseTestCase):
                                    group="storage")
 
         self.index = indexer.get_driver(self.conf)
-        self.index.connect()
 
         # NOTE(jd) So, some driver, at least SQLAlchemy, can't create all
         # their tables in a single transaction even with the

--- a/gnocchi/tests/functional/fixtures.py
+++ b/gnocchi/tests/functional/fixtures.py
@@ -119,7 +119,6 @@ class ConfigFixture(fixture.GabbiFixture):
             'indexer')
 
         index = indexer.get_driver(conf)
-        index.connect()
         index.upgrade()
 
         # Set pagination to a testable value

--- a/gnocchi/tests/indexer/sqlalchemy/test_migrations.py
+++ b/gnocchi/tests/indexer/sqlalchemy/test_migrations.py
@@ -47,7 +47,6 @@ class ModelsMigrationsSync(
                 self.conf.indexer.url),
             'indexer')
         self.index = indexer.get_driver(self.conf)
-        self.index.connect()
         self.index.upgrade(nocreate=True)
         self.addCleanup(self._drop_database)
 

--- a/gnocchi/utils.py
+++ b/gnocchi/utils.py
@@ -90,10 +90,9 @@ def _enable_coordination(coord):
 
 
 def get_coordinator_and_start(url):
-    my_id = str(uuid.uuid4()).encode()
-    coord = coordination.get_coordinator(url, my_id)
+    coord = coordination.get_coordinator(url, str(uuid.uuid4()).encode())
     _enable_coordination(coord)
-    return coord, my_id
+    return coord
 
 
 unix_universal_start64 = numpy.datetime64("1970")

--- a/gnocchi/utils.py
+++ b/gnocchi/utils.py
@@ -29,7 +29,6 @@ import numpy
 import pandas as pd
 import six
 from stevedore import driver
-import tenacity
 from tooz import coordination
 
 
@@ -71,27 +70,9 @@ def UUID(value):
         raise ValueError(e)
 
 
-# Retry with exponential backoff for up to 1 minute
-retry = tenacity.retry(
-    wait=tenacity.wait_exponential(multiplier=0.5, max=60),
-    # Never retry except when explicitly asked by raising TryAgain
-    retry=tenacity.retry_never,
-    reraise=True)
-
-
-# TODO(jd) Move this to tooz?
-@retry
-def _enable_coordination(coord):
-    try:
-        coord.start(start_heart=True)
-    except Exception as e:
-        LOG.error("Unable to start coordinator: %s", e)
-        raise tenacity.TryAgain(e)
-
-
 def get_coordinator_and_start(url):
     coord = coordination.get_coordinator(url, str(uuid.uuid4()).encode())
-    _enable_coordination(coord)
+    coord.start(start_heart=True)
     return coord
 
 

--- a/tools/measures_injector.py
+++ b/tools/measures_injector.py
@@ -37,7 +37,6 @@ def injector():
     ])
     conf = service.prepare_service(conf=conf)
     index = indexer.get_driver(conf)
-    index.connect()
     s = storage.get_driver(conf)
 
     def todo():


### PR DESCRIPTION
indexer: remove connect() method
Only retry connection to external components in metricd
utils: do not return coordinator id
cli: limit scope of error catching
cli: use MetricProcessBase _configure method to get drivers