### PR TITLE
Remove worker_sync_rate option

### DIFF
--- a/gnocchi/opts.py
+++ b/gnocchi/opts.py
@@ -129,12 +129,6 @@ def list_opts():
                        required=True,
                        help="How many seconds to wait between "
                        "cleaning of expired data"),
-            cfg.IntOpt('worker_sync_rate',
-                       default=30,
-                       help="Frequency to detect when metricd workers join or "
-                            "leave system (in seconds). A shorter rate, may "
-                            "improve rebalancing but create more coordination "
-                            "load"),
             cfg.IntOpt('processing_replicas',
                        default=3,
                        min=1,


### PR DESCRIPTION
If you poll e.g every 60s, there's no need to get the member list and update
the partitioner every 30s. Actually the partitioner status should be updated
just before requesting the stack, that'll be perfect.

So let's do that!