### PR TITLE
storage: return SplitKey objects when listing split keys

### DIFF
--- a/gnocchi/storage/_carbonara.py
+++ b/gnocchi/storage/_carbonara.py
@@ -16,6 +16,7 @@
 # under the License.
 import collections
 import datetime
+import functools
 import itertools
 import operator
 
@@ -117,9 +118,15 @@ class CarbonaraBasedStorage(storage.StorageDriver):
                                granularity, data, offset=None, version=3):
         raise NotImplementedError
 
-    @staticmethod
-    def _list_split_keys_for_metric(metric, aggregation, granularity,
+    def _list_split_keys_for_metric(self, metric, aggregation, granularity,
                                     version=3):
+        return set(map(
+            functools.partial(carbonara.SplitKey, sampling=granularity),
+            self._list_split_keys(
+                metric, aggregation, granularity, version)))
+
+    @staticmethod
+    def _list_split_keys(metric, aggregation, granularity, version=3):
         raise NotImplementedError
 
     @staticmethod
@@ -190,20 +197,18 @@ class CarbonaraBasedStorage(storage.StorageDriver):
             raise storage.GranularityDoesNotExist(metric, granularity)
 
         if from_timestamp:
-            from_timestamp = str(
-                carbonara.SplitKey.from_timestamp_and_sampling(
-                    from_timestamp, granularity))
+            from_timestamp = carbonara.SplitKey.from_timestamp_and_sampling(
+                from_timestamp, granularity)
 
         if to_timestamp:
-            to_timestamp = str(
-                carbonara.SplitKey.from_timestamp_and_sampling(
-                    to_timestamp, granularity))
+            to_timestamp = carbonara.SplitKey.from_timestamp_and_sampling(
+                to_timestamp, granularity)
 
         timeseries = list(filter(
             lambda x: x is not None,
             self._map_in_thread(
                 self._get_measures_and_unserialize,
-                ((metric, key, aggregation, granularity)
+                ((metric, str(key), aggregation, granularity)
                  for key in sorted(all_keys)
                  if ((not from_timestamp or key >= from_timestamp)
                      and (not to_timestamp or key <= to_timestamp))))
@@ -284,13 +289,12 @@ class CarbonaraBasedStorage(storage.StorageDriver):
             oldest_point_to_keep = ts.last - datetime.timedelta(
                 seconds=archive_policy_def.timespan)
             oldest_key_to_keep = ts.get_split_key(oldest_point_to_keep)
-            oldest_key_to_keep_s = str(oldest_key_to_keep)
             for key in list(existing_keys):
                 # NOTE(jd) Only delete if the key is strictly inferior to
                 # the timestamp; we don't delete any timeserie split that
                 # contains our timestamp, so we prefer to keep a bit more
                 # than deleting too much
-                if key < oldest_key_to_keep_s:
+                if key < oldest_key_to_keep:
                     self._delete_metric_measures(
                         metric, key, aggregation,
                         archive_policy_def.granularity)
@@ -303,10 +307,9 @@ class CarbonaraBasedStorage(storage.StorageDriver):
         # means we already wrote some splits at some point – so this is not the
         # first time we treat this timeserie.
         if need_rewrite:
-            previous_oldest_mutable_key = str(ts.get_split_key(
-                previous_oldest_mutable_timestamp))
-            oldest_mutable_key = str(ts.get_split_key(
-                oldest_mutable_timestamp))
+            previous_oldest_mutable_key = ts.get_split_key(
+                previous_oldest_mutable_timestamp)
+            oldest_mutable_key = ts.get_split_key(oldest_mutable_timestamp)
 
             if previous_oldest_mutable_key != oldest_mutable_key:
                 for key in existing_keys:
@@ -317,8 +320,7 @@ class CarbonaraBasedStorage(storage.StorageDriver):
                         # NOTE(jd) Rewrite it entirely for fun (and later for
                         # compression). For that, we just pass None as split.
                         self._store_timeserie_split(
-                            metric, carbonara.SplitKey(
-                                float(key), archive_policy_def.granularity),
+                            metric, key,
                             None, aggregation, archive_policy_def,
                             oldest_mutable_timestamp)
 

--- a/gnocchi/storage/ceph.py
+++ b/gnocchi/storage/ceph.py
@@ -152,8 +152,7 @@ class CephStorage(_carbonara.CarbonaraBasedStorage):
             else:
                 raise storage.MetricDoesNotExist(metric)
 
-    def _list_split_keys_for_metric(self, metric, aggregation, granularity,
-                                    version=3):
+    def _list_split_keys(self, metric, aggregation, granularity, version=3):
         with rados.ReadOpCtx() as op:
             omaps, ret = self.ioctx.get_omap_vals(op, "", "", -1)
             try:

--- a/gnocchi/storage/file.py
+++ b/gnocchi/storage/file.py
@@ -68,7 +68,7 @@ class FileStorage(_carbonara.CarbonaraBasedStorage):
     def _build_metric_path_for_split(self, metric, aggregation,
                                      timestamp_key, granularity, version=3):
         path = os.path.join(self._build_metric_path(metric, aggregation),
-                            timestamp_key + "_" + str(granularity))
+                            str(timestamp_key) + "_" + str(granularity))
         return path + '_v%s' % version if version else path
 
     def _create_metric(self, metric):
@@ -101,8 +101,7 @@ class FileStorage(_carbonara.CarbonaraBasedStorage):
                 raise storage.MetricDoesNotExist(metric)
             raise
 
-    def _list_split_keys_for_metric(self, metric, aggregation, granularity,
-                                    version=3):
+    def _list_split_keys(self, metric, aggregation, granularity, version=3):
         try:
             files = os.listdir(self._build_metric_path(metric, aggregation))
         except OSError as e:

--- a/gnocchi/storage/redis.py
+++ b/gnocchi/storage/redis.py
@@ -50,7 +50,7 @@ class RedisStorage(_carbonara.CarbonaraBasedStorage):
     @classmethod
     def _aggregated_field_for_split(cls, aggregation, timestamp_key,
                                     granularity, version=3):
-        path = cls.FIELD_SEP.join([timestamp_key, aggregation,
+        path = cls.FIELD_SEP.join([str(timestamp_key), aggregation,
                                    str(granularity)])
         return path + '_v%s' % version if version else path
 
@@ -71,8 +71,7 @@ class RedisStorage(_carbonara.CarbonaraBasedStorage):
             raise storage.MetricDoesNotExist(metric)
         return data
 
-    def _list_split_keys_for_metric(self, metric, aggregation, granularity,
-                                    version=3):
+    def _list_split_keys(self, metric, aggregation, granularity, version=3):
         key = self._metric_key(metric)
         if not self._client.exists(key):
             raise storage.MetricDoesNotExist(metric)

--- a/gnocchi/storage/s3.py
+++ b/gnocchi/storage/s3.py
@@ -169,8 +169,7 @@ class S3Storage(_carbonara.CarbonaraBasedStorage):
             raise
         return response['Body'].read()
 
-    def _list_split_keys_for_metric(self, metric, aggregation, granularity,
-                                    version=3):
+    def _list_split_keys(self, metric, aggregation, granularity, version=3):
         bucket = self._bucket_name
         keys = set()
         response = {}

--- a/gnocchi/storage/swift.py
+++ b/gnocchi/storage/swift.py
@@ -145,8 +145,7 @@ class SwiftStorage(_carbonara.CarbonaraBasedStorage):
             raise
         return contents
 
-    def _list_split_keys_for_metric(self, metric, aggregation, granularity,
-                                    version=3):
+    def _list_split_keys(self, metric, aggregation, granularity, version=3):
         container = self._container_name(metric)
         try:
             headers, files = self.swift.get_container(

--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -283,13 +283,13 @@ class TestStorageDriver(tests_base.TestCase):
             (utils.datetime_utc(2015, 1, 1, 12), 300.0, 69),
         ], self.storage.get_measures(self.metric))
 
-        self.assertEqual({"1244160000.0"},
+        self.assertEqual({carbonara.SplitKey("1244160000.0", 86400)},
                          self.storage._list_split_keys_for_metric(
                              self.metric, "mean", 86400.0))
-        self.assertEqual({"1412640000.0"},
+        self.assertEqual({carbonara.SplitKey("1412640000.0", 3600)},
                          self.storage._list_split_keys_for_metric(
                              self.metric, "mean", 3600.0))
-        self.assertEqual({"1419120000.0"},
+        self.assertEqual({carbonara.SplitKey("1419120000.0", 300)},
                          self.storage._list_split_keys_for_metric(
                              self.metric, "mean", 300.0))
 
@@ -312,10 +312,11 @@ class TestStorageDriver(tests_base.TestCase):
         ])
         self.trigger_processing()
 
-        splits = {'1451520000.0', '1451736000.0', '1451952000.0'}
-        self.assertEqual(splits,
-                         self.storage._list_split_keys_for_metric(
-                             self.metric, "mean", 60.0))
+        self.assertEqual({
+            carbonara.SplitKey(1451520000.0, 60),
+            carbonara.SplitKey(1451736000.0, 60),
+            carbonara.SplitKey(1451952000.0, 60),
+        }, self.storage._list_split_keys_for_metric(self.metric, "mean", 60.0))
 
         if self.storage.WRITE_FULL:
             assertCompressedIfWriteFull = self.assertTrue
@@ -350,10 +351,12 @@ class TestStorageDriver(tests_base.TestCase):
         ])
         self.trigger_processing()
 
-        self.assertEqual({'1452384000.0', '1451736000.0',
-                          '1451520000.0', '1451952000.0'},
-                         self.storage._list_split_keys_for_metric(
-                             self.metric, "mean", 60.0))
+        self.assertEqual({
+            carbonara.SplitKey(1452384000.0, 60),
+            carbonara.SplitKey(1451736000.0, 60),
+            carbonara.SplitKey(1451520000.0, 60),
+            carbonara.SplitKey(1451952000.0, 60),
+        }, self.storage._list_split_keys_for_metric(self.metric, "mean", 60.0))
         data = self.storage._get_measures(
             self.metric, '1451520000.0', "mean", 60.0)
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
@@ -398,10 +401,11 @@ class TestStorageDriver(tests_base.TestCase):
         ])
         self.trigger_processing()
 
-        splits = {'1451520000.0', '1451736000.0', '1451952000.0'}
-        self.assertEqual(splits,
-                         self.storage._list_split_keys_for_metric(
-                             self.metric, "mean", 60.0))
+        self.assertEqual({
+            carbonara.SplitKey(1451520000.0, 60),
+            carbonara.SplitKey(1451736000.0, 60),
+            carbonara.SplitKey(1451952000.0, 60),
+        }, self.storage._list_split_keys_for_metric(self.metric, "mean", 60.0))
 
         if self.storage.WRITE_FULL:
             assertCompressedIfWriteFull = self.assertTrue
@@ -438,10 +442,12 @@ class TestStorageDriver(tests_base.TestCase):
         ])
         self.trigger_processing()
 
-        self.assertEqual({'1452384000.0', '1451736000.0',
-                          '1451520000.0', '1451952000.0'},
-                         self.storage._list_split_keys_for_metric(
-                             self.metric, "mean", 60.0))
+        self.assertEqual({
+            carbonara.SplitKey(1452384000.0, 60),
+            carbonara.SplitKey(1451736000.0, 60),
+            carbonara.SplitKey(1451520000.0, 60),
+            carbonara.SplitKey(1451952000.0, 60),
+        }, self.storage._list_split_keys_for_metric(self.metric, "mean", 60.0))
         data = self.storage._get_measures(
             self.metric, '1451520000.0', "mean", 60.0)
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
@@ -484,10 +490,11 @@ class TestStorageDriver(tests_base.TestCase):
         ])
         self.trigger_processing()
 
-        splits = {'1451520000.0', '1451736000.0', '1451952000.0'}
-        self.assertEqual(splits,
-                         self.storage._list_split_keys_for_metric(
-                             self.metric, "mean", 60.0))
+        self.assertEqual({
+            carbonara.SplitKey(1451520000.0, 60),
+            carbonara.SplitKey(1451736000.0, 60),
+            carbonara.SplitKey(1451952000.0, 60),
+        }, self.storage._list_split_keys_for_metric(self.metric, "mean", 60.0))
 
         if self.storage.WRITE_FULL:
             assertCompressedIfWriteFull = self.assertTrue
@@ -547,10 +554,11 @@ class TestStorageDriver(tests_base.TestCase):
         ])
         self.trigger_processing()
 
-        splits = {'1451520000.0', '1451736000.0', '1451952000.0'}
-        self.assertEqual(splits,
-                         self.storage._list_split_keys_for_metric(
-                             self.metric, "mean", 60.0))
+        self.assertEqual({
+            carbonara.SplitKey(1451520000.0, 60),
+            carbonara.SplitKey(1451736000.0, 60),
+            carbonara.SplitKey(1451952000.0, 60),
+        }, self.storage._list_split_keys_for_metric(self.metric, "mean", 60.0))
 
         if self.storage.WRITE_FULL:
             assertCompressedIfWriteFull = self.assertTrue


### PR DESCRIPTION
This avoids comparing strings and keep it to timestamp comparison everywhere.