### PR TITLE
Only retry connection to external components in metricd

### DIFF
--- a/gnocchi/cli.py
+++ b/gnocchi/cli.py
@@ -83,6 +83,13 @@ def statsd():
     statsd_service.start()
 
 
+# Retry with exponential backoff for up to 1 minute
+_wait_exponential = tenacity.wait_exponential(multiplier=0.5, max=60)
+
+
+retry_on_exception = tenacity.Retrying(wait=_wait_exponential)
+
+
 class MetricProcessBase(cotyledon.Service):
     def __init__(self, worker_id, conf, interval_delay=0):
         super(MetricProcessBase, self).__init__(worker_id)
@@ -93,8 +100,8 @@ class MetricProcessBase(cotyledon.Service):
         self._shutdown_done = threading.Event()
 
     def _configure(self):
-        self.store = storage.get_driver(self.conf)
-        self.index = indexer.get_driver(self.conf)
+        self.store = retry_on_exception(storage.get_driver, self.conf)
+        self.index = retry_on_exception(indexer.get_driver, self.conf)
         self.index.connect()
 
     def run(self):
@@ -157,8 +164,6 @@ class MetricScheduler(MetricProcessBase):
     def __init__(self, worker_id, conf, queue):
         super(MetricScheduler, self).__init__(
             worker_id, conf, conf.metricd.metric_processing_delay)
-        self._coord, self._my_id = utils.get_coordinator_and_start(
-            conf.storage.coordination_url)
         self.queue = queue
         self.previously_scheduled_metrics = set()
         self.workers = conf.metricd.workers
@@ -190,9 +195,15 @@ class MetricScheduler(MetricProcessBase):
             self.block_index = 0
             self.block_size = self.block_size_default
 
-    @utils.retry
+    @tenacity.retry(
+        wait=_wait_exponential,
+        # Never retry except when explicitly asked by raising TryAgain
+        retry=tenacity.retry_never)
     def _configure(self):
         super(MetricScheduler, self)._configure()
+        self._coord, self._my_id = retry_on_exception(
+            utils.get_coordinator_and_start,
+            self.conf.storage.coordination_url)
         try:
             cap = msgpack.dumps({'workers': self.workers})
             join_req = self._coord.join_group(self.GROUP_ID, cap)

--- a/gnocchi/storage/common/swift.py
+++ b/gnocchi/storage/common/swift.py
@@ -24,13 +24,14 @@ except ImportError:
     swift_utils = None
 
 from gnocchi import storage
-from gnocchi import utils
 
 LOG = log.getLogger(__name__)
 
 
-@utils.retry
-def _get_connection(conf):
+def get_connection(conf):
+    if swclient is None:
+        raise RuntimeError("python-swiftclient unavailable")
+
     return swclient.Connection(
         auth_version=conf.swift_auth_version,
         authurl=conf.swift_authurl,
@@ -42,13 +43,6 @@ def _get_connection(conf):
         os_options={'endpoint_type': conf.swift_endpoint_type,
                     'user_domain_name': conf.swift_user_domain_name},
         retries=0)
-
-
-def get_connection(conf):
-    if swclient is None:
-        raise RuntimeError("python-swiftclient unavailable")
-
-    return _get_connection(conf)
 
 
 POST_HEADERS = {'Accept': 'application/json', 'Content-Type': 'text/plain'}

--- a/gnocchi/utils.py
+++ b/gnocchi/utils.py
@@ -27,7 +27,6 @@ from oslo_log import log
 from oslo_utils import timeutils
 import pandas as pd
 import six
-import tenacity
 from tooz import coordination
 
 
@@ -68,28 +67,10 @@ def UUID(value):
         raise ValueError(e)
 
 
-# Retry with exponential backoff for up to 1 minute
-retry = tenacity.retry(
-    wait=tenacity.wait_exponential(multiplier=0.5, max=60),
-    # Never retry except when explicitly asked by raising TryAgain
-    retry=tenacity.retry_never,
-    reraise=True)
-
-
-# TODO(jd) Move this to tooz?
-@retry
-def _enable_coordination(coord):
-    try:
-        coord.start(start_heart=True)
-    except Exception as e:
-        LOG.error("Unable to start coordinator: %s", e)
-        raise tenacity.TryAgain(e)
-
-
 def get_coordinator_and_start(url):
     my_id = str(uuid.uuid4())
     coord = coordination.get_coordinator(url, my_id)
-    _enable_coordination(coord)
+    coord.start(start_heart=True)
     return coord, my_id
 
 


### PR DESCRIPTION
Currently storage such as Swift will retry forever to connect on __init__.
Actually, the only process that wants to retry indefinitely is metricd. The API
will keep the client connected forever if it does not raise a 500 error soon
enough.

This patches make sure that the only part retrying for ever is metricd: the
rest (e.g. the API) will fail fast if anything bad happens.

Fixes #194

(cherry picked from commit a64fe4e0f271e5075b4922135e8b2bae293f1f76)