### PR TITLE
carbonara: use sampling from SplitKey

### DIFF
--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 #
-# Copyright © 2016 Red Hat, Inc.
+# Copyright © 2016-2017 Red Hat, Inc.
 # Copyright © 2014-2015 eNovance
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -410,7 +410,7 @@ class SplitKey(object):
         else:
             self.key = float(value)
 
-        self._carbonara_sampling = float(sampling)
+        self.sampling = sampling
 
     @classmethod
     def from_timestamp_and_sampling(cls, timestamp, sampling):
@@ -425,8 +425,8 @@ class SplitKey(object):
         :return: A `SplitKey` object.
         """
         return self.__class__(
-            self.key + self._carbonara_sampling * self.POINTS_PER_SPLIT,
-            self._carbonara_sampling)
+            self.key + self.sampling * self.POINTS_PER_SPLIT,
+            self.sampling)
 
     next = __next__
 
@@ -462,7 +462,7 @@ class SplitKey(object):
     def __repr__(self):
         return "<%s: %s / %fs>" % (self.__class__.__name__,
                                    repr(self.key),
-                                   self._carbonara_sampling)
+                                   self.sampling)
 
 
 class AggregatedTimeSerie(TimeSerie):

--- a/gnocchi/storage/ceph.py
+++ b/gnocchi/storage/ceph.py
@@ -56,10 +56,9 @@ class CephStorage(_carbonara.CarbonaraBasedStorage):
         super(CephStorage, self).stop()
 
     @staticmethod
-    def _get_object_name(metric, timestamp_key, aggregation, granularity,
-                         version=3):
+    def _get_object_name(metric, key, aggregation, version=3):
         name = str("gnocchi_%s_%s_%s_%s" % (
-            metric.id, timestamp_key, aggregation, granularity))
+            metric.id, key, aggregation, key.sampling))
         return name + '_v%s' % version if version else name
 
     def _object_exists(self, name):
@@ -76,10 +75,9 @@ class CephStorage(_carbonara.CarbonaraBasedStorage):
         else:
             self.ioctx.write_full(name, b"")
 
-    def _store_metric_measures(self, metric, timestamp_key, aggregation,
-                               granularity, data, offset=None, version=3):
-        name = self._get_object_name(metric, timestamp_key,
-                                     aggregation, granularity, version)
+    def _store_metric_measures(self, metric, key, aggregation,
+                               data, offset=None, version=3):
+        name = self._get_object_name(metric, key, aggregation, version)
         if offset is None:
             self.ioctx.write_full(name, data)
         else:
@@ -89,10 +87,8 @@ class CephStorage(_carbonara.CarbonaraBasedStorage):
             self.ioctx.operate_write_op(
                 op, self._build_unaggregated_timeserie_path(metric, 3))
 
-    def _delete_metric_measures(self, metric, timestamp_key, aggregation,
-                                granularity, version=3):
-        name = self._get_object_name(metric, timestamp_key,
-                                     aggregation, granularity, version)
+    def _delete_metric_measures(self, metric, key, aggregation, version=3):
+        name = self._get_object_name(metric, key, aggregation, version)
 
         try:
             self.ioctx.remove_object(name)
@@ -139,11 +135,9 @@ class CephStorage(_carbonara.CarbonaraBasedStorage):
             # It's possible that the object does not exists
             pass
 
-    def _get_measures(self, metric, timestamp_key, aggregation, granularity,
-                      version=3):
+    def _get_measures(self, metric, key, aggregation, version=3):
         try:
-            name = self._get_object_name(metric, timestamp_key,
-                                         aggregation, granularity, version)
+            name = self._get_object_name(metric, key, aggregation, version)
             return self._get_object_content(name)
         except rados.ObjectNotFound:
             if self._object_exists(

--- a/gnocchi/storage/file.py
+++ b/gnocchi/storage/file.py
@@ -66,9 +66,9 @@ class FileStorage(_carbonara.CarbonaraBasedStorage):
                             "agg_" + aggregation)
 
     def _build_metric_path_for_split(self, metric, aggregation,
-                                     timestamp_key, granularity, version=3):
+                                     key, version=3):
         path = os.path.join(self._build_metric_path(metric, aggregation),
-                            str(timestamp_key) + "_" + str(granularity))
+                            str(key) + "_" + str(key.sampling))
         return path + '_v%s' % version if version else path
 
     def _create_metric(self, metric):
@@ -115,17 +115,15 @@ class FileStorage(_carbonara.CarbonaraBasedStorage):
                 keys.add(meta[0])
         return keys
 
-    def _delete_metric_measures(self, metric, timestamp_key, aggregation,
-                                granularity, version=3):
+    def _delete_metric_measures(self, metric, key, aggregation, version=3):
         os.unlink(self._build_metric_path_for_split(
-            metric, aggregation, timestamp_key, granularity, version))
+            metric, aggregation, key, version))
 
-    def _store_metric_measures(self, metric, timestamp_key, aggregation,
-                               granularity, data, offset=None, version=3):
+    def _store_metric_measures(self, metric, key, aggregation,
+                               data, offset=None, version=3):
         self._atomic_file_store(
-            self._build_metric_path_for_split(metric, aggregation,
-                                              timestamp_key, granularity,
-                                              version),
+            self._build_metric_path_for_split(
+                metric, aggregation, key, version),
             data)
 
     def _delete_metric(self, metric):
@@ -138,10 +136,9 @@ class FileStorage(_carbonara.CarbonaraBasedStorage):
                 # measures)
                 raise
 
-    def _get_measures(self, metric, timestamp_key, aggregation, granularity,
-                      version=3):
+    def _get_measures(self, metric, key, aggregation, version=3):
         path = self._build_metric_path_for_split(
-            metric, aggregation, timestamp_key, granularity, version)
+            metric, aggregation, key, version)
         try:
             with open(path, 'rb') as aggregation_file:
                 return aggregation_file.read()

--- a/gnocchi/storage/s3.py
+++ b/gnocchi/storage/s3.py
@@ -87,8 +87,8 @@ class S3Storage(_carbonara.CarbonaraBasedStorage):
                 raise
 
     @staticmethod
-    def _object_name(split_key, aggregation, granularity, version=3):
-        name = '%s_%s_%s' % (aggregation, granularity, split_key)
+    def _object_name(split_key, aggregation, version=3):
+        name = '%s_%s_%s' % (aggregation, split_key.sampling, split_key)
         return name + '_v%s' % version if version else name
 
     @staticmethod
@@ -113,20 +113,20 @@ class S3Storage(_carbonara.CarbonaraBasedStorage):
                 wait=self._consistency_wait,
                 stop=self._consistency_stop)(_head)
 
-    def _store_metric_measures(self, metric, timestamp_key, aggregation,
-                               granularity, data, offset=0, version=3):
+    def _store_metric_measures(self, metric, key, aggregation,
+                               data, offset=0, version=3):
         self._put_object_safe(
             Bucket=self._bucket_name,
             Key=self._prefix(metric) + self._object_name(
-                timestamp_key, aggregation, granularity, version),
+                key, aggregation, version),
             Body=data)
 
-    def _delete_metric_measures(self, metric, timestamp_key, aggregation,
-                                granularity, version=3):
+    def _delete_metric_measures(self, metric, key, aggregation,
+                                version=3):
         self.s3.delete_object(
             Bucket=self._bucket_name,
             Key=self._prefix(metric) + self._object_name(
-                timestamp_key, aggregation, granularity, version))
+                key, aggregation, version))
 
     def _delete_metric(self, metric):
         bucket = self._bucket_name
@@ -149,13 +149,12 @@ class S3Storage(_carbonara.CarbonaraBasedStorage):
             s3.bulk_delete(self.s3, bucket,
                            [c['Key'] for c in response.get('Contents', ())])
 
-    def _get_measures(self, metric, timestamp_key, aggregation, granularity,
-                      version=3):
+    def _get_measures(self, metric, key, aggregation, version=3):
         try:
             response = self.s3.get_object(
                 Bucket=self._bucket_name,
                 Key=self._prefix(metric) + self._object_name(
-                    timestamp_key, aggregation, granularity, version))
+                    key, aggregation, version))
         except botocore.exceptions.ClientError as e:
             if e.response['Error'].get('Code') == 'NoSuchKey':
                 try:

--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -229,7 +229,9 @@ class TestStorageDriver(tests_base.TestCase):
         for call in c.mock_calls:
             # policy is 60 points and split is 48. should only update 2nd half
             args = call[1]
-            if args[0] == m_sql and args[2] == 'mean' and args[3] == 60.0:
+            if (args[0] == m_sql
+               and args[2] == 'mean'
+               and args[1].sampling == 60.0):
                 count += 1
         self.assertEqual(1, count)
 
@@ -324,13 +326,13 @@ class TestStorageDriver(tests_base.TestCase):
             assertCompressedIfWriteFull = self.assertFalse
 
         data = self.storage._get_measures(
-            self.metric, '1451520000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451520000.0, 60.0), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1451736000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451736000.0, 60.0), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1451952000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451952000.0, 60.0), "mean")
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
@@ -358,17 +360,17 @@ class TestStorageDriver(tests_base.TestCase):
             carbonara.SplitKey(1451952000.0, 60),
         }, self.storage._list_split_keys_for_metric(self.metric, "mean", 60.0))
         data = self.storage._get_measures(
-            self.metric, '1451520000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451520000.0, 60.0), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1451736000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451736000.0, 60.0), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1451952000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451952000.0, 60.0), "mean")
         # Now this one is compressed because it has been rewritten!
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1452384000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1452384000.0, 60.0), "mean")
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
@@ -413,13 +415,13 @@ class TestStorageDriver(tests_base.TestCase):
             assertCompressedIfWriteFull = self.assertFalse
 
         data = self.storage._get_measures(
-            self.metric, '1451520000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451520000.0, 60.0), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1451736000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451736000.0, 60.0), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1451952000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451952000.0, 60.0), "mean")
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
@@ -449,17 +451,17 @@ class TestStorageDriver(tests_base.TestCase):
             carbonara.SplitKey(1451952000.0, 60),
         }, self.storage._list_split_keys_for_metric(self.metric, "mean", 60.0))
         data = self.storage._get_measures(
-            self.metric, '1451520000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451520000.0, 60.0), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1451736000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451736000.0, 60.0), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1451952000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451952000.0, 60.0), "mean")
         # Now this one is compressed because it has been rewritten!
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1452384000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1452384000.0, 60.0), "mean")
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
@@ -502,13 +504,13 @@ class TestStorageDriver(tests_base.TestCase):
             assertCompressedIfWriteFull = self.assertFalse
 
         data = self.storage._get_measures(
-            self.metric, '1451520000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451520000.0, 60.0), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1451736000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451736000.0, 60.0), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1451952000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451952000.0, 60.0), "mean")
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
@@ -521,9 +523,8 @@ class TestStorageDriver(tests_base.TestCase):
 
         # Test what happens if we delete the latest split and then need to
         # compress it!
-        self.storage._delete_metric_measures(self.metric,
-                                             '1451952000.0',
-                                             'mean', 60.0)
+        self.storage._delete_metric_measures(
+            self.metric, carbonara.SplitKey(1451952000.0, 60.0), 'mean')
 
         # Now store brand new points that should force a rewrite of one of the
         # split (keep in mind the back window size in one hour here). We move
@@ -566,13 +567,13 @@ class TestStorageDriver(tests_base.TestCase):
             assertCompressedIfWriteFull = self.assertFalse
 
         data = self.storage._get_measures(
-            self.metric, '1451520000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451520000.0, 60.0), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1451736000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451736000.0, 60.0), "mean")
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, '1451952000.0', "mean", 60.0)
+            self.metric, carbonara.SplitKey(1451952000.0, 60.0), "mean")
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
@@ -585,7 +586,8 @@ class TestStorageDriver(tests_base.TestCase):
 
         # Test what happens if we write garbage
         self.storage._store_metric_measures(
-            self.metric, '1451952000.0', "mean", 60.0, b"oh really?")
+            self.metric, carbonara.SplitKey(1451952000.0, 60.0), "mean",
+            b"oh really?")
 
         # Now store brand new points that should force a rewrite of one of the
         # split (keep in mind the back window size in one hour here). We move


### PR DESCRIPTION
SplitKey already carries the sampling, so let's use it rather than passing it
around each time.
This also avoids passing the SplitKey as a simple string and pass the object
around, which is more solid.