### PR TITLE
carbonara: simplify unserialize

### DIFF
--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -573,10 +573,15 @@ class AggregatedTimeSerie(TimeSerie):
         return six.indexbytes(serialized_data, 0) == ord("c")
 
     @classmethod
-    def unserialize(cls, data, start, agg_method, sampling):
+    def unserialize(cls, data, key, agg_method):
+        """Unserialize an aggregated timeserie.
+
+        :param data: Raw data buffer.
+        :param key: A :class:`SplitKey` key.
+        :param agg_method: The aggregation method of this timeseries.
+        """
         x, y = [], []
 
-        start = float(start)
         if data:
             if cls.is_compressed(data):
                 # Compressed format
@@ -590,7 +595,7 @@ class AggregatedTimeSerie(TimeSerie):
                     y = numpy.frombuffer(timestamps_raw, dtype='<H')
                 except ValueError:
                     raise InvalidData()
-                y = numpy.cumsum(y * sampling) + start
+                y = numpy.cumsum(y * key.sampling) + key.key
 
                 values_raw = uncompressed[
                     nb_points*cls.COMPRESSED_TIMESPAMP_LEN:]
@@ -604,13 +609,13 @@ class AggregatedTimeSerie(TimeSerie):
                 except ValueError:
                     raise InvalidData()
                 index = numpy.nonzero(everything['b'])[0]
-                y = index * sampling + start
+                y = index * key.sampling + key.key
                 x = everything['v'][index]
 
             y = y.astype(numpy.float64, copy=False) * 10e8
             y = y.astype('datetime64[ns]', copy=False)
             y = pandas.to_datetime(y)
-        return cls.from_data(sampling, agg_method, y, x)
+        return cls.from_data(key.sampling, agg_method, y, x)
 
     def get_split_key(self, timestamp=None):
         """Return the split key for a particular timestamp.
@@ -780,7 +785,7 @@ class AggregatedTimeSerie(TimeSerie):
 
             t0 = time.time()
             for i in six.moves.range(serialize_times):
-                cls.unserialize(s, key, 'mean', sampling)
+                cls.unserialize(s, key, 'mean')
             t1 = time.time()
             print("  Unserialization speed: %.2f MB/s"
                   % (((points * 2 * 8)
@@ -797,7 +802,7 @@ class AggregatedTimeSerie(TimeSerie):
 
             t0 = time.time()
             for i in six.moves.range(serialize_times):
-                cls.unserialize(s, key, 'mean', sampling)
+                cls.unserialize(s, key, 'mean')
             t1 = time.time()
             print("  Uncompression speed: %.2f MB/s"
                   % (((points * 2 * 8)

--- a/gnocchi/storage/_carbonara.py
+++ b/gnocchi/storage/_carbonara.py
@@ -161,7 +161,7 @@ class CarbonaraBasedStorage(storage.StorageDriver):
         data = self._get_measures(metric, key, aggregation)
         try:
             return carbonara.AggregatedTimeSerie.unserialize(
-                data, key, aggregation, key.sampling)
+                data, key, aggregation)
         except carbonara.InvalidData:
             LOG.error("Data corruption detected for %s "
                       "aggregated `%s' timeserie, granularity `%s' "

--- a/gnocchi/tests/test_carbonara.py
+++ b/gnocchi/tests/test_carbonara.py
@@ -177,7 +177,7 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
         key = ts.get_split_key()
         o, s = ts.serialize(key)
         saved_ts = carbonara.AggregatedTimeSerie.unserialize(
-            s, key, '74pct', ts.sampling)
+            s, key, '74pct')
 
         ts = carbonara.TimeSerie.from_tuples(
             [(datetime.datetime(2014, 1, 1, 12, 0, 0), 3),
@@ -850,8 +850,7 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
         o, s = ts['return'].serialize(key)
         self.assertEqual(ts['return'],
                          carbonara.AggregatedTimeSerie.unserialize(
-                             s, key,
-                             'mean', 0.5))
+                             s, key, 'mean'))
 
     def test_no_truncation(self):
         ts = {'sampling': 60, 'agg': 'mean'}


### PR DESCRIPTION
The start/key argument is always a SplitKey object, so there's no need to pass
any sampling around. Just simplify the signature.