### PR TITLE
Block daiquiri===1.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ WebOb>=1.4.1
 Paste
 PasteDeploy
 monotonic
-daiquiri
+daiquiri!=1.2.0


### PR DESCRIPTION
ceilometer gate is broken and reports:
 ++ /opt/stack/new/ceilometer/devstack/plugin.sh:install_gnocchi:223 :   gnocchi-upgrade
 Traceback (most recent call last):
   File "/usr/local/bin/gnocchi-upgrade", line 6, in <module>
     from gnocchi.cli import upgrade
   File "/opt/stack/new/devstack/src/gnocchi/gnocchi/cli.py", line 26, in <module>
     import daiquiri
   File "/usr/local/lib/python2.7/dist-packages/daiquiri/__init__.py", line 19, in <module>
     from daiquiri import output
   File "/usr/local/lib/python2.7/dist-packages/daiquiri/output.py", line 232, in <module>
     preconfigured['journal'] = Journal()
   File "/usr/local/lib/python2.7/dist-packages/daiquiri/output.py", line 180, in __init__
     super(Journal, self).__init__(handlers.JournalHandler(program_name),
   File "/usr/local/lib/python2.7/dist-packages/daiquiri/handlers.py", line 65, in __init__
     super(SyslogHandler, self).__init__()
 TypeError: super(type, obj): obj must be an instance or subtype of type

It's actually a typo of daiquiri in 1.2.0. So it must block the version.