### PR TITLE
enforce boundaries on overlap

### DIFF
--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -550,13 +550,11 @@ is set.
 When a boundary is set, Gnocchi expects that we have certain percent of
 timestamps common between timeseries. This percent is controlled by
 needed_overlap, which by default expects 100% overlap. If this percent is not
-reached, an error is returned. If no boundaries are set, Gnocchi aggregates and
-returns only the last contiguous range of common datapoints.
+reached, an error is returned.
 
 .. note::
 
-   Not setting a boundary may result in an extremely sparse result.
-   Additionally, it may not accurately reflect 'needed_overlap' value, if set.
+   If no boundaries are set, Gnocchi requires 100% overlap across all series
 
 The ability to fill in points missing from a subset of timeseries is supported
 by specifying a `fill` value. Valid fill values include any valid float or

--- a/gnocchi/rest/__init__.py
+++ b/gnocchi/rest/__init__.py
@@ -1642,6 +1642,9 @@ class AggregationController(rest.RestController):
             needed_overlap = float(needed_overlap)
         except ValueError:
             abort(400, 'needed_overlap must be a number')
+        if needed_overlap != 100.0 and start is None and stop is None:
+            abort(400, 'start and/or stop must be provided if specifying '
+                  'needed_overlap')
 
         if start is not None:
             try:

--- a/gnocchi/tests/functional/gabbits/aggregation.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregation.yaml
@@ -162,6 +162,13 @@ tests:
       response_strings:
         - Granularity '42.0' for metric
 
+    - name: get measure aggregates no boundary custom overlap
+      desc: https://github.com/gnocchixyz/gnocchi/issues/17
+      GET: /v1/aggregation/metric?metric=$HISTORY['get metric list'].$RESPONSE['$[0].id']&metric=$HISTORY['get metric list'].$RESPONSE['$[1].id']&needed_overlap=50
+      status: 400
+      response_strings:
+        - start and/or stop must be provided if specifying needed_overlap
+
 # Aggregation by resource and metric_name
 
     - name: post a resource

--- a/gnocchi/tests/test_rest.py
+++ b/gnocchi/tests/test_rest.py
@@ -1654,17 +1654,22 @@ class ResourceTest(RestTest):
             + "/metric/foo?aggregation=max",
             params={"=": {"name": name}},
             expect_errors=True)
+        self.assertEqual(400, result.status_code, result.text)
+        self.assertIn("No overlap", result.text)
 
+        result = self.app.post_json(
+            "/v1/aggregation/resource/" + self.resource_type
+            + "/metric/foo?aggregation=max&needed_overlap=5&start=2013-01-01",
+            params={"=": {"name": name}},
+            expect_errors=True)
         self.assertEqual(400, result.status_code, result.text)
         self.assertIn("No overlap", result.text)
 
         result = self.app.post_json(
             "/v1/aggregation/resource/"
             + self.resource_type + "/metric/foo?aggregation=min"
-            + "&needed_overlap=0",
-            params={"=": {"name": name}},
-            expect_errors=True)
-
+            + "&needed_overlap=0&start=2013-01-01T00:00:00%2B00:00",
+            params={"=": {"name": name}})
         self.assertEqual(200, result.status_code, result.text)
         measures = json.loads(result.text)
         self.assertEqual([['2013-01-01T00:00:00+00:00', 86400.0, 8.0],

--- a/releasenotes/notes/mandatory-boundaries-for-overlap-af28dc1e0946c500.yaml
+++ b/releasenotes/notes/mandatory-boundaries-for-overlap-af28dc1e0946c500.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    When specifying `needed_overlap` while aggregating across metrics without
+    bounds, the result did not necessarily honour the required overlap
+    provided. Aggregation without bounds now requires 100% overlap; an error is
+    raised otherwise


### PR DESCRIPTION
if no boundary is set, the returned series does not necessarily
honour the overlap value. change behaviour so we require a boundary
if overlap is not 100%.

Fixes: #17