### PR TITLE
carbonara: correctly handle all frombuffer errors

### DIFF
--- a/gnocchi/storage/_carbonara.py
+++ b/gnocchi/storage/_carbonara.py
@@ -102,7 +102,7 @@ class CarbonaraBasedStorage(storage.StorageDriver):
         try:
             return carbonara.BoundTimeSerie.unserialize(
                 raw_measures, block_size, back_window)
-        except ValueError:
+        except carbonara.InvalidData:
             raise CorruptionError(
                 "Data corruption detected for %s "
                 "unaggregated timeserie" % metric.id)


### PR DESCRIPTION
Only a few `numpy.frombuffer` calls are covered by `try/except ValueError`
blocks, whereas they should all be covered and raise InvalidData in case of
error.