### PR TITLE
BoundedSerie: don't truncate on init

### DIFF
--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -283,7 +283,6 @@ class BoundTimeSerie(TimeSerie):
         super(BoundTimeSerie, self).__init__(ts)
         self.block_size = block_size
         self.back_window = back_window
-        self._truncate()
 
     @classmethod
     def from_data(cls, timestamps=None, values=None,

--- a/gnocchi/tests/test_carbonara.py
+++ b/gnocchi/tests/test_carbonara.py
@@ -45,12 +45,11 @@ class TestBoundTimeSerie(base.BaseTestCase):
 
     def test_block_size(self):
         ts = carbonara.BoundTimeSerie.from_data(
-            [datetime64(2014, 1, 1, 12, 0, 0),
-             datetime64(2014, 1, 1, 12, 0, 4),
+            [datetime64(2014, 1, 1, 12, 0, 5),
              datetime64(2014, 1, 1, 12, 0, 9)],
-            [3, 5, 6],
+            [5, 6],
             block_size=numpy.timedelta64(5, 's'))
-        self.assertEqual(1, len(ts))
+        self.assertEqual(2, len(ts))
         ts.set_values([(datetime64(2014, 1, 1, 12, 0, 10), 3),
                        (datetime64(2014, 1, 1, 12, 0, 11), 4)])
         self.assertEqual(2, len(ts))
@@ -70,10 +69,9 @@ class TestBoundTimeSerie(base.BaseTestCase):
 
     def test_block_size_unordered(self):
         ts = carbonara.BoundTimeSerie.from_data(
-            [datetime64(2014, 1, 1, 12, 0, 0),
-             datetime64(2014, 1, 1, 12, 0, 5),
+            [datetime64(2014, 1, 1, 12, 0, 5),
              datetime64(2014, 1, 1, 12, 0, 9)],
-            [10, 5, 23],
+            [5, 23],
             block_size=numpy.timedelta64(5, 's'))
         self.assertEqual(2, len(ts))
         ts.set_values([(datetime64(2014, 1, 1, 12, 0, 11), 3),


### PR DESCRIPTION
there is no scenario in normal workflow which requires us to
truncate on init. when loading, the boundedserie should already
be truncated when it was saved. truncating on init seems to
only support a corrupted scenario.

this improves unserialise perf by ~30x... or ~6x compared to v4.0
disclaimer: improvement is so high mainly because _truncate has
to truncate a lot in the benchmark path.