### PR TITLE
incoming: return directly a Numpy array of measures

### DIFF
--- a/gnocchi/incoming/_carbonara.py
+++ b/gnocchi/incoming/_carbonara.py
@@ -75,6 +75,15 @@ class CarbonaraBasedStorage(incoming.StorageDriver):
     _SERIALIZE_DTYPE = [('timestamps', '<datetime64[ns]'),
                         ('values', '<d')]
 
+    def _make_measures_array(self):
+        return numpy.array([], dtype=self._SERIALIZE_DTYPE)
+
+    @staticmethod
+    def _array_concatenate(arrays):
+        if arrays:
+            return numpy.concatenate(arrays)
+        return arrays
+
     def _unserialize_measures(self, measure_id, data):
         try:
             return numpy.frombuffer(data, dtype=self._SERIALIZE_DTYPE)

--- a/gnocchi/incoming/ceph.py
+++ b/gnocchi/incoming/ceph.py
@@ -17,6 +17,7 @@ import datetime
 import json
 import uuid
 
+import numpy
 import six
 
 from gnocchi.common import ceph
@@ -196,7 +197,6 @@ class CephStorage(_carbonara.CarbonaraBasedStorage):
         sack = self.sack_for_metric(metric.id)
         key_prefix = self.MEASURE_PREFIX + "_" + str(metric.id)
 
-        measures = []
         processed_keys = []
         with rados.ReadOpCtx() as op:
             omaps, ret = self.ioctx.get_omap_vals(op, "", key_prefix, -1)
@@ -214,8 +214,10 @@ class CephStorage(_carbonara.CarbonaraBasedStorage):
                 # Object has been deleted, so this is just a stalled entry
                 # in the OMAP listing, ignore
                 return
+
+        measures = self._make_measures_array()
         for k, v in omaps:
-            measures.extend(self._unserialize_measures(k, v))
+            measures = numpy.append(measures, self._unserialize_measures(k, v))
             processed_keys.append(k)
 
         yield measures

--- a/gnocchi/incoming/file.py
+++ b/gnocchi/incoming/file.py
@@ -20,6 +20,7 @@ import shutil
 import tempfile
 import uuid
 
+import numpy
 import six
 
 from gnocchi.incoming import _carbonara
@@ -171,11 +172,12 @@ class FileStorage(_carbonara.CarbonaraBasedStorage):
     @contextlib.contextmanager
     def process_measure_for_metric(self, metric):
         files = self._list_measures_container_for_metric_id(metric.id)
-        measures = []
+        measures = self._make_measures_array()
         for f in files:
             abspath = self._build_measure_path(metric.id, f)
             with open(abspath, "rb") as e:
-                measures.extend(self._unserialize_measures(f, e.read()))
+                measures = numpy.append(
+                    measures, self._unserialize_measures(f, e.read()))
 
         yield measures
 

--- a/gnocchi/incoming/redis.py
+++ b/gnocchi/incoming/redis.py
@@ -100,12 +100,11 @@ class RedisStorage(_carbonara.CarbonaraBasedStorage):
         item_len = self._client.llen(key)
         # lrange is inclusive on both ends, decrease to grab exactly n items
         item_len = item_len - 1 if item_len else item_len
-        measures = []
-        for i, data in enumerate(self._client.lrange(key, 0, item_len)):
-            measures.extend(self._unserialize_measures(
-                '%s-%s' % (metric.id, i), data))
 
-        yield measures
+        yield self._array_concatenate([
+            self._unserialize_measures('%s-%s' % (metric.id, i), data)
+            for i, data in enumerate(self._client.lrange(key, 0, item_len))
+        ])
 
         # ltrim is inclusive, bump 1 to remove up to and including nth item
         self._client.ltrim(key, item_len + 1, -1)

--- a/gnocchi/incoming/s3.py
+++ b/gnocchi/incoming/s3.py
@@ -19,6 +19,7 @@ import datetime
 import json
 import uuid
 
+import numpy
 import six
 
 from gnocchi.common import s3
@@ -165,13 +166,15 @@ class S3Storage(_carbonara.CarbonaraBasedStorage):
         sack = self.sack_for_metric(metric.id)
         files = self._list_measure_files_for_metric_id(sack, metric.id)
 
-        measures = []
+        measures = self._make_measures_array()
         for f in files:
             response = self.s3.get_object(
                 Bucket=self._bucket_name_measures,
                 Key=f)
-            measures.extend(
-                self._unserialize_measures(f, response['Body'].read()))
+            measures = numpy.append(
+                measures,
+                self._unserialize_measures(f, response['Body'].read())
+            )
 
         yield measures
 

--- a/gnocchi/incoming/swift.py
+++ b/gnocchi/incoming/swift.py
@@ -106,12 +106,13 @@ class SwiftStorage(_carbonara.CarbonaraBasedStorage):
         sack_name = self.get_sack_name(sack)
         files = self._list_measure_files_for_metric_id(sack, metric.id)
 
-        measures = []
-        for f in files:
-            headers, data = self.swift.get_object(sack_name, f['name'])
-            measures.extend(self._unserialize_measures(f['name'], data))
-
-        yield measures
+        yield self._array_concatenate([
+            self._unserialize_measures(
+                f['name'],
+                self.swift.get_object(sack_name, f['name'])[1],
+            )
+            for f in files
+        ])
 
         # Now clean objects
         swift.bulk_delete(self.swift, sack_name, files)


### PR DESCRIPTION
This read the incoming measures as a Numpy array ready to be sent to Carbonara,
rather than a list that needs a cast.