### PR TITLE
ceph: correctly delete the unaggregated timeserie

### DIFF
--- a/gnocchi/storage/ceph.py
+++ b/gnocchi/storage/ceph.py
@@ -292,8 +292,9 @@ class CephStorage(_carbonara.CarbonaraBasedStorage):
         else:
             for xattr, _ in xattrs:
                 self.ioctx.aio_remove(xattr)
-        for name in ('container', 'none'):
-            self.ioctx.aio_remove("gnocchi_%s_%s" % (metric.id, name))
+
+        self.ioctx.aio_remove("gnocchi_%s_container" % metric.id)
+        self._delete_unaggregated_timeserie(metric)
 
     def _get_measures(self, metric, timestamp_key, aggregation, granularity,
                       version=3):


### PR DESCRIPTION
The path name that is built is the old pre-v3 name, which should not existed
since it has been migrated. Use the right method to delete the unaggregated
timeseries.