### PR TITLE
fix syslog_log_facility option spelling

### DIFF
--- a/gnocchi/service.py
+++ b/gnocchi/service.py
@@ -61,7 +61,7 @@ def prepare_service(args=None, conf=None,
 
     if conf.use_syslog:
         outputs.append(
-            daiquiri.output.Syslog(facility=conf.syslog_log_faciltity))
+            daiquiri.output.Syslog(facility=conf.syslog_log_facility))
 
     if conf.use_journal:
         outputs.append(daiquiri.output.Journal())


### PR DESCRIPTION
(cherry picked from commit 687cff173ac1da583b4ce0f8d959b4f30507cd50)