### PR TITLE
ceph: order unprocessed measures before processing

### DIFF
--- a/gnocchi/storage/ceph.py
+++ b/gnocchi/storage/ceph.py
@@ -202,10 +202,12 @@ class CephStorage(_carbonara.CarbonaraBasedStorage):
         return len(list(self._list_object_names_to_process(object_prefix)))
 
     def list_metric_with_measures_to_process(self, size, part, full=False):
-        names = self._list_object_names_to_process()
         if full:
-            objs_it = names
+            objs_it = self._list_object_names_to_process()
         else:
+            names = sorted(
+                self._list_object_names_to_process(),
+                key=lambda x: x.split('_', 3)[-1])
             objs_it = itertools.islice(names, size * part, size * (part + 1))
         return set([name.split("_")[1] for name in objs_it])
 


### PR DESCRIPTION
This change adjusts the way in which Gnocchi with Ceph storage obtains
unprocessed measures for processing. Previously unprocessed measures can
enter a condition where specific metrics are favored which causes some
metrics with unprocessed measures to continuously grow. This continuous
growth of the backlog stored in a Ceph omap object in the form of keys
and a small 16-byte object will eventually cause an OSD to fail. By
sorting the order of unprocessed measures by date timestamp, we gain
three things:

1. Efficiency in that once "realtime" capacity of Gnocchi is exceeded, more
   measures are processed per processing of a metric
2. No more starved metrics, which grow unbounded in backlog until a failure
3. Scalability of Gnocchi before failures is extended above "realtime"
   processing capacity