### PR TITLE
don't blindly truncate on init

### DIFF
--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -547,7 +547,8 @@ class AggregatedTimeSerie(TimeSerie):
     COMPRESSED_SERIAL_LEN = struct.calcsize("<Hd")
     COMPRESSED_TIMESPAMP_LEN = struct.calcsize("<H")
 
-    def __init__(self, sampling, aggregation_method, ts=None, max_size=None):
+    def __init__(self, sampling, aggregation_method, ts=None, max_size=None,
+                 truncate=True):
         """A time serie that is downsampled.
 
         Used to represent the downsampled timeserie for a single
@@ -558,7 +559,8 @@ class AggregatedTimeSerie(TimeSerie):
         self.sampling = sampling
         self.max_size = max_size
         self.aggregation_method = aggregation_method
-        self._truncate(quick=True)
+        if truncate:
+            self._truncate()
 
     def resample(self, sampling):
         return AggregatedTimeSerie.from_grouped_serie(
@@ -567,10 +569,14 @@ class AggregatedTimeSerie(TimeSerie):
     @classmethod
     def from_data(cls, sampling, aggregation_method, timestamps,
                   values, max_size=None):
+        # TODO(gordc): we don't truncate here but we might want to.
+        # specifically, when we store_timeserie_split, we merge with existing
+        # serie but we don't truncate so we might merge stuff that is beyond
+        # policy (not visible because we follow policy and truncate on GET)
         return cls(sampling=sampling,
                    aggregation_method=aggregation_method,
                    ts=make_timeseries(timestamps, values),
-                   max_size=max_size)
+                   max_size=max_size, truncate=False)
 
     @staticmethod
     def _get_agg_method(aggregation_method):
@@ -616,12 +622,12 @@ class AggregatedTimeSerie(TimeSerie):
 
     @classmethod
     def from_grouped_serie(cls, grouped_serie, sampling, aggregation_method,
-                           max_size=None):
+                           max_size=None, truncate=False):
         agg_name, q = cls._get_agg_method(aggregation_method)
         return cls(sampling, aggregation_method,
                    ts=cls._resample_grouped(grouped_serie, agg_name,
                                             q),
-                   max_size=max_size)
+                   max_size=max_size, truncate=truncate)
 
     def __eq__(self, other):
         return (isinstance(other, AggregatedTimeSerie)
@@ -752,12 +758,11 @@ class AggregatedTimeSerie(TimeSerie):
         offset = int((first - start.key) / offset_div) * self.PADDED_SERIAL_LEN
         return offset, payload
 
-    def _truncate(self, quick=False):
+    def _truncate(self):
         """Truncate the timeserie."""
         if self.max_size is not None:
             # Remove empty points if any that could be added by aggregation
-            self.ts = (self.ts[-self.max_size:] if quick
-                       else self.ts.dropna()[-self.max_size:])
+            self.ts = self.ts[-self.max_size:]
 
     @staticmethod
     def _resample_grouped(grouped_serie, agg_name, q=None):

--- a/gnocchi/tests/test_carbonara.py
+++ b/gnocchi/tests/test_carbonara.py
@@ -174,7 +174,7 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
         if derived:
             grouped = grouped.derived()
         return carbonara.AggregatedTimeSerie.from_grouped_serie(
-            grouped, sampling, agg, max_size=max_size)
+            grouped, sampling, agg, max_size=max_size, truncate=True)
 
     def test_derived_mean(self):
         ts = carbonara.TimeSerie.from_tuples(
@@ -395,7 +395,7 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
         existing = agg_dict.get('return')
         agg_dict['return'] = carbonara.AggregatedTimeSerie.from_grouped_serie(
             grouped, agg_dict['sampling'], agg_dict['agg'],
-            max_size=agg_dict.get('size'))
+            max_size=agg_dict.get('size'), truncate=True)
         if existing:
             existing.merge(agg_dict['return'])
             agg_dict['return'] = existing
@@ -1096,14 +1096,14 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
             existing = tsc1.get('return')
             tsc1['return'] = carbonara.AggregatedTimeSerie.from_grouped_serie(
                 grouped, tsc1['sampling'], tsc1['agg'],
-                max_size=tsc1['size'])
+                max_size=tsc1['size'], truncate=True)
             if existing:
                 existing.merge(tsc1['return'])
             grouped = ts.group_serie(tsc12['sampling'])
             existing = tsc12.get('return')
             tsc12['return'] = carbonara.AggregatedTimeSerie.from_grouped_serie(
                 grouped, tsc12['sampling'], tsc12['agg'],
-                max_size=tsc12['size'])
+                max_size=tsc12['size'], truncate=True)
             if existing:
                 existing.merge(tsc12['return'])
 
@@ -1112,14 +1112,14 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
             existing = tsc2.get('return')
             tsc2['return'] = carbonara.AggregatedTimeSerie.from_grouped_serie(
                 grouped, tsc2['sampling'], tsc2['agg'],
-                max_size=tsc2['size'])
+                max_size=tsc2['size'], truncate=True)
             if existing:
                 existing.merge(tsc2['return'])
             grouped = ts.group_serie(tsc22['sampling'])
             existing = tsc22.get('return')
             tsc22['return'] = carbonara.AggregatedTimeSerie.from_grouped_serie(
                 grouped, tsc22['sampling'], tsc22['agg'],
-                max_size=tsc22['size'])
+                max_size=tsc22['size'], truncate=True)
             if existing:
                 existing.merge(tsc22['return'])
 


### PR DESCRIPTION
we don't need to truncate for most scenarios.

- from_grouped_serie doesn't need to be truncated because it's
based on bound_series which definitely doesn't need to be truncated
- from_data is used to grab from storage but there is no point
truncating here as don't check max_size when doing so. (we may want to)
- from_timeseries needs to truncate as that's what used to return
results