### PR TITLE
storage: fix metric processing scheduling inefficiency

### DIFF
--- a/gnocchi/storage/_carbonara.py
+++ b/gnocchi/storage/_carbonara.py
@@ -358,8 +358,20 @@ class CarbonaraBasedStorage(storage.StorageDriver):
     def _delete_metric(metric):
         raise NotImplementedError
 
+    def list_metric_with_measures_to_process(self, size, part, full=False):
+        metrics = map(operator.itemgetter(0),
+                      # Sort by the number of measures, bigger first (reverse)
+                      sorted(
+                          self._list_metric_with_measures_to_process(),
+                          key=operator.itemgetter(1),
+                          reverse=True))
+        if full:
+            return set(metrics)
+        return set(list(metrics)[size * part:size * (part + 1)])
+
     @staticmethod
-    def list_metric_with_measures_to_process(size, part, full=False):
+    def _list_metric_with_measures_to_process():
+        """Return an ordered list of metrics that needs to be processed."""
         raise NotImplementedError
 
     @staticmethod

--- a/gnocchi/storage/ceph.py
+++ b/gnocchi/storage/ceph.py
@@ -201,13 +201,13 @@ class CephStorage(_carbonara.CarbonaraBasedStorage):
         object_prefix = self.MEASURE_PREFIX + "_" + str(metric_id)
         return len(list(self._list_object_names_to_process(object_prefix)))
 
-    def list_metric_with_measures_to_process(self, size, part, full=False):
-        names = self._list_object_names_to_process()
-        if full:
-            objs_it = names
-        else:
-            objs_it = itertools.islice(names, size * part, size * (part + 1))
-        return set([name.split("_")[1] for name in objs_it])
+    def _list_metric_with_measures_to_process(self):
+        # Sort measures objects per metric id
+        names = sorted(o.split("_")[1]
+                       for o in self._list_object_names_to_process())
+        # Group per metric id and store len() of the number of measures
+        return ((metric, len(list(measures)))
+                for metric, measures in itertools.groupby(names))
 
     def _delete_unprocessed_measures_for_metric_id(self, metric_id):
         object_prefix = self.MEASURE_PREFIX + "_" + str(metric_id)

--- a/gnocchi/storage/file.py
+++ b/gnocchi/storage/file.py
@@ -146,11 +146,12 @@ class FileStorage(_carbonara.CarbonaraBasedStorage):
         return (len(metric_details.keys()), sum(metric_details.values()),
                 metric_details if details else None)
 
-    def list_metric_with_measures_to_process(self, size, part, full=False):
-        if full:
-            return set(os.listdir(self.measure_path))
-        return set(
-            os.listdir(self.measure_path)[size * part:size * (part + 1)])
+    def _list_metric_with_measures_to_process(self):
+        # NOTE(jd) Ceph and Swift driver order those by the number of metrics.
+        # It's too costly to do that with file driver since it would need to
+        # list every directory. Just don't do it and use the standard OS
+        # sorting of the metric list
+        return ((d, 0) for d in os.listdir(self.measure_path))
 
     def _list_measures_container_for_metric_id(self, metric_id):
         try:

--- a/gnocchi/storage/swift.py
+++ b/gnocchi/storage/swift.py
@@ -16,6 +16,7 @@
 from collections import defaultdict
 import contextlib
 import datetime
+import itertools
 import uuid
 
 from oslo_config import cfg
@@ -146,17 +147,12 @@ class SwiftStorage(_carbonara.CarbonaraBasedStorage):
         measures = int(headers.get('x-container-object-count'))
         return nb_metrics, measures, metric_details if details else None
 
-    def list_metric_with_measures_to_process(self, size, part, full=False):
-        limit = None
-        if not full:
-            limit = size * (part + 1)
+    def _list_metric_with_measures_to_process(self):
         headers, files = self.swift.get_container(self.MEASURE_PREFIX,
-                                                  delimiter='/',
-                                                  full_listing=full,
-                                                  limit=limit)
-        if not full:
-            files = files[size * part:]
-        return set(f['subdir'][:-1] for f in files if 'subdir' in f)
+                                                  full_listing=True)
+        names = sorted(f['name'].split("/", 1)[0] for f in files)
+        return ((metric, len(list(measures)))
+                for metric, measures in itertools.groupby(names))
 
     def _list_measure_files_for_metric_id(self, metric_id):
         headers, files = self.swift.get_container(


### PR DESCRIPTION
metricd scheduler learns about which metrics to process by calling
`list_metric_with_measures_to_process(size, part)`.

The problem currently is that list_metric_with_measures_to_process() uses
(size, part) to poke holes into a list of _measures_, which are very likely to
be ordered by the name of the measure file (true at least for file and ceph
drivers). That means that if the backlog is something like:

[ metric1_measure1, metric1_measure2, … metric2_measure1, metric2_measure2, …]

and if metric1 has e.g. 100k measures to be processed, then all schedulers will
poke holes starting from the beginning of the backlog:

 scheduler1 backlog:
  [ metric1_measure1, metric1_measure2, … metric1_measure256 ]

 scheduler2 backlog:
  [ metric1_measure257, metric1_measure258, … metric1_measure512 ]

which is then boiled down to:

  scheduler1 metric to process: metric1
  scheduler2 metric to process: metric1

this is completely inefficient as they might be tons of metrics to process but
all scheduler are focusing on the same first metric.

This patch tries to fix that by using the full measure listing, boiling down
the list of metric that needs to be processed, sorting it, and *then* poking
holes in that backlog (so the backlog is not about measures, but about metrics
this time). This is way more efficient as it would solve the case described
above.

The only downside is that the Swift driver, which was the only one not doing a
full measure listing on each call, has now to do a full listing too. But it
should be a trade-off worth it.