### PR TITLE
Add support for sack notification on incoming driver

### DIFF
--- a/gnocchi/cli/metricd.py
+++ b/gnocchi/cli/metricd.py
@@ -143,7 +143,7 @@ class MetricProcessor(MetricProcessBase):
                       'partitioning. Retrying: %s', e)
             raise tenacity.TryAgain(e)
 
-    def _get_tasks(self):
+    def _get_sacks_to_process(self):
         try:
             self.coord.run_watchers()
             if (not self._tasks or
@@ -161,7 +161,7 @@ class MetricProcessor(MetricProcessBase):
     def _run_job(self):
         m_count = 0
         s_count = 0
-        for s in self._get_tasks():
+        for s in self._get_sacks_to_process():
             # TODO(gordc): support delay release lock so we don't
             # process a sack right after another process
             lock = self.incoming.get_sack_lock(self.coord, s)

--- a/gnocchi/cli/metricd.py
+++ b/gnocchi/cli/metricd.py
@@ -47,8 +47,12 @@ class MetricProcessBase(cotyledon.Service):
         self.conf = conf
         self.startup_delay = worker_id
         self.interval_delay = interval_delay
+        self._wake_up = threading.Event()
         self._shutdown = threading.Event()
         self._shutdown_done = threading.Event()
+
+    def wakeup(self):
+        self._wake_up.set()
 
     def _configure(self):
         self.store = retry_on_exception(storage.get_driver, self.conf)
@@ -63,11 +67,13 @@ class MetricProcessBase(cotyledon.Service):
         while not self._shutdown.is_set():
             with utils.StopWatch() as timer:
                 self._run_job()
-            self._shutdown.wait(max(0, self.interval_delay - timer.elapsed()))
+            self._wake_up.wait(max(0, self.interval_delay - timer.elapsed()))
+            self._wake_up.clear()
         self._shutdown_done.set()
 
     def terminate(self):
         self._shutdown.set()
+        self.wakeup()
         LOG.info("Waiting ongoing metric processing to finish")
         self._shutdown_done.wait()
         self.close_services()

--- a/gnocchi/common/redis.py
+++ b/gnocchi/common/redis.py
@@ -28,7 +28,7 @@ except ImportError:
 from gnocchi import utils
 
 
-SEP = ':'
+SEP = b':'
 
 CLIENT_ARGS = frozenset([
     'db',

--- a/gnocchi/incoming/__init__.py
+++ b/gnocchi/incoming/__init__.py
@@ -173,6 +173,11 @@ class IncomingDriver(object):
     def get_sack_name(self, sack):
         return self.get_sack_prefix() % sack
 
+    @staticmethod
+    def iter_on_sacks_to_process():
+        """Return an iterable of sack that got new measures to process."""
+        raise exceptions.NotImplementedError
+
 
 def get_driver(conf):
     """Return configured incoming driver only

--- a/gnocchi/storage/redis.py
+++ b/gnocchi/storage/redis.py
@@ -30,7 +30,7 @@ OPTS = [
 class RedisStorage(storage.StorageDriver):
     WRITE_FULL = True
 
-    STORAGE_PREFIX = "timeseries"
+    STORAGE_PREFIX = b"timeseries"
     FIELD_SEP = '_'
 
     def __init__(self, conf, coord=None):
@@ -41,7 +41,7 @@ class RedisStorage(storage.StorageDriver):
         return "%s: %s" % (self.__class__.__name__, self._client)
 
     def _metric_key(self, metric):
-        return redis.SEP.join([self.STORAGE_PREFIX, str(metric.id)])
+        return redis.SEP.join([self.STORAGE_PREFIX, str(metric.id).encode()])
 
     @staticmethod
     def _unaggregated_field(version=3):

--- a/gnocchi/tests/base.py
+++ b/gnocchi/tests/base.py
@@ -361,7 +361,7 @@ class TestCase(BaseTestCase):
 
         if self.conf.storage.driver == 'redis':
             # Create one prefix per test
-            self.storage.STORAGE_PREFIX = str(uuid.uuid4())
+            self.storage.STORAGE_PREFIX = str(uuid.uuid4()).encode()
 
         if self.conf.incoming.driver == 'redis':
             self.incoming.SACK_PREFIX = str(uuid.uuid4())

--- a/gnocchi/tests/test_incoming.py
+++ b/gnocchi/tests/test_incoming.py
@@ -1,0 +1,65 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright © 2017 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+import threading
+import uuid
+
+import numpy
+
+from gnocchi import incoming
+from gnocchi import storage
+from gnocchi.tests import base as tests_base
+
+
+class TestIncomingDriver(tests_base.TestCase):
+    def setUp(self):
+        super(TestIncomingDriver, self).setUp()
+        # A lot of tests wants a metric, create one
+        self.metric = storage.Metric(
+            uuid.uuid4(),
+            self.archive_policies["low"])
+
+    def test_iter_on_sacks_to_process(self):
+        if (self.incoming.iter_on_sacks_to_process ==
+           incoming.IncomingDriver.iter_on_sacks_to_process):
+            self.skipTest("Incoming driver does not implement "
+                          "iter_on_sacks_to_process")
+
+        found = threading.Event()
+
+        sack_to_find = self.incoming.sack_for_metric(self.metric.id)
+
+        def _iter_on_sacks_to_process():
+            for sack in self.incoming.iter_on_sacks_to_process():
+                self.assertIsInstance(sack, int)
+                if sack == sack_to_find:
+                    found.set()
+                    break
+
+        finder = threading.Thread(target=_iter_on_sacks_to_process)
+        finder.daemon = True
+        finder.start()
+
+        # Try for 30s to get a notification about this sack
+        for _ in range(30):
+            if found.wait(timeout=1):
+                break
+            # NOTE(jd) Retry to send measures. It cannot be done only once as
+            # there might be a race condition between the threads
+            self.incoming.add_measures(self.metric, [
+                storage.Measure(numpy.datetime64("2014-01-01 12:00:01"), 69),
+            ])
+        else:
+            self.fail("Notification for metric not received")

--- a/gnocchi/utils.py
+++ b/gnocchi/utils.py
@@ -290,6 +290,11 @@ class StopWatch(object):
         self._state = self._STOPPED
         return self
 
+    def reset(self):
+        """Stop and re-start the watch."""
+        self.stop()
+        return self.start()
+
 
 def get_driver_class(namespace, conf):
     """Return the storage driver class.


### PR DESCRIPTION
incoming: add iter_on_sacks_to_process support for Redis
Add notification mechanism in incoming driver to be used by metricd worker
cli: add a wakeup() method to stop process waiting if needed
cli: rename _get_tasks to _get_sacks_to_process