### PR TITLE
indexer: fix ne operator

### DIFF
--- a/gnocchi/indexer/sqlalchemy.py
+++ b/gnocchi/indexer/sqlalchemy.py
@@ -1215,7 +1215,11 @@ class QueryTransformer(object):
                             raise indexer.QueryValueError(value, field_name)
                         break
 
-        return op(attr, value)
+        if op == operator.ne and value is not None:
+            return operator.or_(operator.eq(attr, None),
+                                op(attr, value))
+        else:
+            return op(attr, value)
 
     @classmethod
     def build_filter(cls, engine, table, tree):

--- a/gnocchi/tests/functional/gabbits/search.yaml
+++ b/gnocchi/tests/functional/gabbits/search.yaml
@@ -74,3 +74,24 @@ tests:
       data: {}
       response_json_paths:
         $.`len`: 2
+
+    - name: post generic resource with project/user
+      POST: /v1/resource/generic
+      data:
+          id: 95573760-b085-4e69-9280-91f66fc3ed3c
+          started_at: "2014-01-03T02:02:02.000000"
+      status: 201
+
+    - name: search empty query again
+      POST: /v1/search/resource/generic
+      data: {}
+      response_json_paths:
+        $.`len`: 3
+
+    - name: search all resource not foobar
+      POST: /v1/search/resource/generic
+      data:
+        ne:
+          project_id: foobar
+      response_json_paths:
+        $.`len`: 3

--- a/gnocchi/tests/test_indexer.py
+++ b/gnocchi/tests/test_indexer.py
@@ -730,6 +730,37 @@ class TestIndexerDriver(tests_base.TestCase):
             attribute_filter={"=": {"project_id": 'bad-project'}})
         self.assertEqual(0, len(resources))
 
+    def test_list_resources_with_no_project(self):
+        r1 = uuid.uuid4()
+        r2 = uuid.uuid4()
+        user = str(uuid.uuid4())
+        project = str(uuid.uuid4())
+        creator = user + ":" + project
+        g1 = self.index.create_resource('generic', r1, creator, user, project)
+        g2 = self.index.create_resource('generic', r2, creator, None, None)
+
+        # Get null value
+        resources = self.index.list_resources(
+            'generic',
+            attribute_filter={"and": [
+                {"=": {"creator": creator}},
+                {"!=": {"project_id": project}}
+            ]})
+        self.assertEqual(1, len(resources))
+        self.assertEqual(g2, resources[0])
+
+        # Get null and filled values
+        resources = self.index.list_resources(
+            'generic',
+            attribute_filter={"and": [
+                {"=": {"creator": creator}},
+                {"!=": {"project_id": "foobar"}}
+            ]},
+            sorts=["project_id:asc-nullsfirst"])
+        self.assertEqual(2, len(resources))
+        self.assertEqual(g2, resources[0])
+        self.assertEqual(g1, resources[1])
+
     def test_list_resources_by_duration(self):
         r1 = uuid.uuid4()
         user = str(uuid.uuid4())


### PR DESCRIPTION
When we use the ne operator, row with NULL values are not returned by
mysql or postgresql.

This change fixes the sql query to return them.

Closes #224

(cherry picked from commit 051b11abb41b239a1873e4009d0a6625795f1f76)