### PR TITLE
Fix circular dependency on import

### DIFF
--- a/gnocchi/rest/app.py
+++ b/gnocchi/rest/app.py
@@ -31,7 +31,6 @@ from gnocchi import exceptions
 from gnocchi import incoming as gnocchi_incoming
 from gnocchi import indexer as gnocchi_indexer
 from gnocchi import json
-from gnocchi import service
 from gnocchi import storage as gnocchi_storage
 
 
@@ -150,7 +149,3 @@ def app_factory(global_config, **local_conf):
     global APPCONFIGS
     appconfig = APPCONFIGS.get(global_config.get('configkey'))
     return _setup_app(root=local_conf.get('root'), **appconfig)
-
-
-def build_wsgi_app():
-    return load_app(service.prepare_service())

--- a/gnocchi/rest/gnocchi-api
+++ b/gnocchi/rest/gnocchi-api
@@ -16,4 +16,5 @@ if __name__ == '__main__':
     sys.exit(cli.api())
 else:
     from gnocchi.rest import app
-    application = app.build_wsgi_app()
+    from gnocchi import service
+    application = app.load_app(service.prepare_service())

--- a/gnocchi/rest/wsgi.py
+++ b/gnocchi/rest/wsgi.py
@@ -12,4 +12,5 @@
 # limitations under the License.
 """This file is loaded by gnocchi-api when executing uwsgi"""
 from gnocchi.rest import app
-application = app.build_wsgi_app()
+from gnocchi import service
+application = app.load_app(service.prepare_service())


### PR DESCRIPTION
gnocchi.rest.app imports gnocchi.service
gnocchi.service imports gnocchi.opts
gnocchi.opts imports gnocchi.rest.app

Break that cycle so gnocchi.rest.app stops importing gnocchi.service

Closes #294