### PR TITLE
Add #!/usr/bin/python to gnocchi-api

### DIFF
--- a/gnocchi/rest/gnocchi-api
+++ b/gnocchi/rest/gnocchi-api
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at


### PR DESCRIPTION
Otherwise
Aug 26 01:04:04 rhev-a24c-01 systemd: openstack-gnocchi-api.service:
 Failed at step EXEC spawning /usr/bin/gnocchi-api: Exec format error

The unit file is like

[Service]
ExecStart=/usr/bin/gnocchi-api -- --log-file /var/log/gnocchi/api.log
