### PR TITLE
Pull request for stable-3.1-task-per-worker

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -67,6 +67,25 @@ using `pip` (see :ref:`installation`), you can set `api.auth_mode` to
 .. _`Paste Deployment`: http://pythonpaste.org/deploy/
 .. _`OpenStack Keystone`: http://launchpad.net/keystone
 
+Configuring metricd
+-------------------
+
+The `gnocchi-metricd` daemon regularly polls the storage backend for new
+measures to process and processes them, spreading the workload across all its
+workers using the coordination backend.
+
+Each polling is run after `metricd_processing_delay` seconds and grabs
+`tasks_per_worker` metrics to process. These two values are configurable.
+
+The shorter `metricd_processing_delay` is, the less lag you will have in your
+computed metrics, but the more the workers will hit the storage backend often.
+
+The value of `tasks_per_worker` is the number of metrics that will be grabbed
+for processing on each polling. That means it should be big enough to keep a
+metricd busy for `metricd_processing_delay` seconds. Depending on the speed of
+your processor, that can might be increased if you see that your workers are
+often idle while the backlog is not empty.
+
 
 Driver notes
 ============

--- a/gnocchi/cli.py
+++ b/gnocchi/cli.py
@@ -158,12 +158,12 @@ class MetricScheduler(MetricProcessBase):
     MAX_OVERLAP = 0.3
     GROUP_ID = "gnocchi-scheduler"
     SYNC_RATE = 30
-    TASKS_PER_WORKER = 16
     BLOCK_SIZE = 4
 
     def __init__(self, worker_id, conf, queue):
         super(MetricScheduler, self).__init__(
             worker_id, conf, conf.metricd.metric_processing_delay)
+        self.TASKS_PER_WORKER = conf.metricd.tasks_per_worker
         self.queue = queue
         self.previously_scheduled_metrics = set()
         self.workers = conf.metricd.workers

--- a/gnocchi/opts.py
+++ b/gnocchi/opts.py
@@ -84,6 +84,11 @@ def list_opts():
                        required=True,
                        help="How many seconds to wait between "
                        "cleaning of expired data"),
+            cfg.IntOpt('tasks_per_worker',
+                       default=16,
+                       min=1,
+                       help="How many tasks to assign each metricd worker "
+                       "when scheduling measures processing jobs"),
         )),
         ("api", (
             cfg.StrOpt('paste_config',

--- a/gnocchi/opts.py
+++ b/gnocchi/opts.py
@@ -65,7 +65,7 @@ def list_opts():
                        help='Number of workers for Gnocchi metric daemons. '
                        'By default the available number of CPU is used.'),
             cfg.IntOpt('metric_processing_delay',
-                       default=60,
+                       default=30,
                        required=True,
                        deprecated_group='storage',
                        help="How many seconds to wait between "
@@ -85,7 +85,7 @@ def list_opts():
                        help="How many seconds to wait between "
                        "cleaning of expired data"),
             cfg.IntOpt('tasks_per_worker',
-                       default=16,
+                       default=256,
                        min=1,
                        help="How many tasks to assign each metricd worker "
                        "when scheduling measures processing jobs"),


### PR DESCRIPTION
Change default processing delay and tasks per worker
metricd: expose tasks_per_worker as a config option