### PR TITLE
Add Gordon Chung to .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+gord chung <gord@live.ca>


### PR DESCRIPTION
This dude uses two different names in the git log, confusing git-log and other
tools as there was two different authors.