### PR TITLE
rest: don't allow empty in

### DIFF
--- a/gnocchi/indexer/sqlalchemy.py
+++ b/gnocchi/indexer/sqlalchemy.py
@@ -1104,6 +1104,7 @@ class SQLAlchemyIndexer(indexer.IndexerDriver):
 
 
 class QueryTransformer(object):
+
     unary_operators = {
         u"not": sqlalchemy.not_,
     }

--- a/gnocchi/rest/__init__.py
+++ b/gnocchi/rest/__init__.py
@@ -1240,8 +1240,12 @@ def _ResourceSearchSchema():
                     u"in",
                 ): voluptuous.All(
                     voluptuous.Length(min=1, max=1),
-                    {"id": [_ResourceUUID],
-                     six.text_type: [ResourceSearchSchemaAttributeValue]}
+                    {"id": voluptuous.All(
+                        [_ResourceUUID],
+                        voluptuous.Length(min=1)),
+                     six.text_type: voluptuous.All(
+                         [ResourceSearchSchemaAttributeValue],
+                         voluptuous.Length(min=1))}
                 ),
                 voluptuous.Any(
                     u"and", u"∨",

--- a/gnocchi/rest/__init__.py
+++ b/gnocchi/rest/__init__.py
@@ -124,13 +124,18 @@ def deserialize(expected_content_types=None):
     return params
 
 
-def deserialize_and_validate(schema, required=True,
-                             expected_content_types=None):
+def validate(schema, data, required=True):
     try:
-        return voluptuous.Schema(schema, required=required)(
-            deserialize(expected_content_types=expected_content_types))
+        return voluptuous.Schema(schema, required=required)(data)
     except voluptuous.Error as e:
         abort(400, "Invalid input: %s" % e)
+
+
+def deserialize_and_validate(schema, required=True,
+                             expected_content_types=None):
+    return validate(schema,
+                    deserialize(expected_content_types=expected_content_types),
+                    required)
 
 
 def PositiveOrNullInt(value):
@@ -1196,8 +1201,7 @@ class QueryStringSearchAttrFilter(object):
     @classmethod
     def parse(cls, query):
         attr_filter = cls._parse(query)
-        return voluptuous.Schema(ResourceSearchSchema,
-                                 required=True)(attr_filter)
+        return validate(ResourceSearchSchema, attr_filter, required=True)
 
 
 def ResourceSearchSchema(v):

--- a/gnocchi/tests/functional/gabbits/resource.yaml
+++ b/gnocchi/tests/functional/gabbits/resource.yaml
@@ -724,9 +724,9 @@ tests:
       data:
           in:
              id: []
-      status: 200
-      response_json_paths:
-        $.deleted: 0
+      status: 400
+      response_strings:
+        - length of value must be at least 1
 
     - name: delete something empty b
       desc: use  empty filter for delete

--- a/gnocchi/tests/functional/gabbits/search.yaml
+++ b/gnocchi/tests/functional/gabbits/search.yaml
@@ -121,6 +121,21 @@ tests:
       response_json_paths:
         $.`len`: 2
 
+    - name: search empty in_
+      POST: /v1/search/resource/generic
+      data:
+        in:
+          id: []
+      status: 400
+      response_strings:
+        - length of value must be at least 1
+
+    - name: search empty in_ query string
+      POST: /v1/search/resource/generic?filter=id%20in%20%5B%5D
+      status: 400
+      response_strings:
+        - length of value must be at least 1
+
     - name: search empty query
       POST: /v1/search/resource/generic
       data: {}


### PR DESCRIPTION
Currently we can write {"id": []}. This query doesn't make sense it will
always return an empty list and it's obviously a input error.

This change returns 400 is this case.