### PR TITLE
rest: fix ACL enforcement for non-admin on metric list

### DIFF
--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -615,6 +615,7 @@ class MetricsController(rest.RestController):
                 pecan.request)
             if provided_creator and creator != provided_creator:
                 abort(403, "Insufficient privileges to filter by user/project")
+            provided_creator = creator
         attr_filter = {}
         if provided_creator is not None:
             attr_filter['creator'] = provided_creator

--- a/gnocchi/tests/functional/gabbits/metric-list.yaml
+++ b/gnocchi/tests/functional/gabbits/metric-list.yaml
@@ -89,7 +89,7 @@ tests:
     - name: list metrics
       GET: /v1/metric
       response_json_paths:
-          $.`len`: 4
+          $.`len`: 2
 
     - name: list metrics by id
       GET: /v1/metric?id=$HISTORY['create metric 1'].$RESPONSE['id']
@@ -100,6 +100,9 @@ tests:
 
     - name: list metrics by name
       GET: /v1/metric?name=disk.io.rate
+      request_headers:
+        # User admin
+        authorization: "basic YWRtaW46"
       response_json_paths:
           $.`len`: 2
           $[0].name: disk.io.rate
@@ -116,6 +119,9 @@ tests:
 
     - name: list metrics by archive_policy
       GET: /v1/metric?archive_policy_name=first_archive&sort=name:desc
+      request_headers:
+        # User admin
+        authorization: "basic YWRtaW46"
       response_json_paths:
           $.`len`: 3
           $[0].name: disk.io.rate

--- a/gnocchi/tests/test_rest.py
+++ b/gnocchi/tests/test_rest.py
@@ -315,6 +315,18 @@ class MetricTest(RestTest):
         with self.app.use_another_user():
             self.app.get("/v1/metric/%s" % metric_id)
 
+    def test_list_metric_with_another_user(self):
+        metric_created = self.app.post_json(
+            "/v1/metric",
+            params={"archive_policy_name": "medium"},
+            status=201)
+
+        metric_id = metric_created.json["id"]
+
+        with self.app.use_another_user():
+            metric_list = self.app.get("/v1/metric")
+            self.assertNotIn(metric_id, [m["id"] for m in metric_list.json])
+
     def test_get_metric_with_another_user(self):
         result = self.app.post_json("/v1/metric",
                                     params={"archive_policy_name": "medium"},


### PR DESCRIPTION
The current metric listing on /v1/metric does not enforce correctly the
attribute filtering on the creator field when the user is non-admin.

That means the attr_filter is empty and a non-admin can actually list all
metrics for all users.

This fixes that by setting the filter correctly.