### PR TITLE
Simplify dependencies by requiring Carbonara

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,5 @@ PasteDeploy
 monotonic
 daiquiri
 pyparsing>=2.2.0
+lz4>=0.9.0
+tooz>=1.38

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,26 +36,14 @@ postgresql =
 s3 =
     boto3
     botocore>=1.5
-    lz4>=0.9.0
-    tooz>=1.38
 redis =
     redis>=2.10.0 # MIT
-    lz4>=0.9.0
-    tooz>=1.38
 swift =
     python-swiftclient>=3.1.0
-    lz4>=0.9.0
-    tooz>=1.38
-ceph =
-    lz4>=0.9.0
-    tooz>=1.38
 ceph_recommended_lib =
     cradox>=1.2.0
 ceph_alternative_lib =
     python-rados>=10.1.0 # not available on pypi
-file =
-    lz4>=0.9.0
-    tooz>=1.38
 doc =
     sphinx<1.6.0
     sphinx_rtd_theme
@@ -77,7 +65,6 @@ test =
     testtools>=0.9.38
     WebTest>=2.0.16
     doc8
-    tooz>=1.38
     keystonemiddleware>=4.0.0
     wsgi_intercept>=1.4.1
 test-swift =


### PR DESCRIPTION
Since all drivers are based on Carbonara and there's no (more) plan to not do
that, this patch simplifies dependency by requiring tooz and lz4 as base
requirements.