### PR TITLE
Add an ISSUE_TEMPLATE for users opening GitHub issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,10 @@
+Before reporting an issue on Gnocchi, please be sure to provide all necessary
+information.
+
+### Which version of Gnocchi are you using
+
+### How to reproduce your problem
+
+### What is the result that you get
+
+### What is result that you expected


### PR DESCRIPTION
This will make sure they are reminded to provide accurate and complete
information.