### PR TITLE
supporting rolling aggregates

### DIFF
--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -139,7 +139,8 @@ Or we can apply absolute to the values and then negate them for example.
 
 {{ scenarios['get-measures-transform']['doc'] }}
 
-Supported transformations are `absolute`, `negative` and `resample(sampling-in-second)`.
+Supported transformations are `absolute`, `negative`,
+`rolling(aggregation-method, window-size)` and `resample(sampling-in-second)`.
 
 .. note::
 

--- a/gnocchi/rest/transformation.py
+++ b/gnocchi/rest/transformation.py
@@ -49,9 +49,10 @@ timespan = timespan.setParseAction(lambda t: utils.to_timespan(t[0]))
 absolute = transform("absolute")
 negative = transform("negative")
 resample = transform("resample", timespan)
+rolling = transform("rolling", pp.Word(pp.alphas), pp.Word(pp.nums))
 
 transform = pp.delimitedList(
-    absolute | negative | resample,
+    absolute | negative | resample | rolling,
     delim=":")
 
 parse = functools.partial(transform.parseString, parseAll=True)

--- a/gnocchi/tests/functional/gabbits/metric.yaml
+++ b/gnocchi/tests/functional/gabbits/metric.yaml
@@ -242,6 +242,18 @@ tests:
           - ["2015-03-06T14:36:15+00:00", 1.0, 16.0]
           - ["2015-03-06T14:37:15+00:00", 1.0, 23.0]
 
+    - name: rolling-mean transform
+      GET: /v1/metric/$HISTORY['list valid metrics'].$RESPONSE['$[0].id']/measures?transform=rolling(mean,2)
+      status: 200
+      response_json_paths:
+        $:
+          - ["2015-03-06T14:34:12+00:00", 1.0, 27.55]
+          - ["2015-03-06T14:34:15+00:00", 1.0, 14.0]
+          - ["2015-03-06T14:35:12+00:00", 1.0, 12.5]
+          - ["2015-03-06T14:35:15+00:00", 1.0, 10.0]
+          - ["2015-03-06T14:36:15+00:00", 1.0, -2.5]
+          - ["2015-03-06T14:37:15+00:00", 1.0, -19.5]
+
     - name: get measurements from metric and two transforms
       GET: /v1/metric/$HISTORY['list valid metrics'].$RESPONSE['$[0].id']/measures?transform=absolute:negative
       response_json_paths:
@@ -273,6 +285,14 @@ tests:
       status: 400
       response_strings:
         - 'transform and resample are exclusive'
+
+    - name: get rolling bad aggregate
+      GET: /v1/metric/$HISTORY['list valid metrics'].$RESPONSE['$[0].id']/measures?transform=rolling(blah,2)
+      status: 400
+
+    - name: get rolling-mean missing window
+      GET: /v1/metric/$HISTORY['list valid metrics'].$RESPONSE['$[0].id']/measures?transform=rolling(mean)
+      status: 400
 
     - name: create valid metric two
       POST: /v1/metric

--- a/gnocchi/tests/test_transformation.py
+++ b/gnocchi/tests/test_transformation.py
@@ -36,7 +36,8 @@ class TestTransformParser(base.BaseTestCase):
             "resample(5):resample(10)": [("resample",
                                           (numpy.timedelta64(5, 's'),)),
                                          ("resample",
-                                          (numpy.timedelta64(10, 's'),))]
+                                          (numpy.timedelta64(10, 's'),))],
+            "rolling(mean, 2)": [("rolling", ("mean", '2'))],
         }
         for expr, expected in expressions.items():
             try:
@@ -67,7 +68,8 @@ class TestTransformParser(base.BaseTestCase):
             "resample(, 1.3)",
             "resample(a)",
             "resample(1.5, 1.3)",
-
+            "rolling(mean)",
+            "rolling(mean, mean)",
         ]
         for expr in expressions:
             self.assertRaises(transformation.TransformationParserError,

--- a/releasenotes/notes/support-rolling-transfrom-a12ab4fb4aa8168f.yaml
+++ b/releasenotes/notes/support-rolling-transfrom-a12ab4fb4aa8168f.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Added support for defining 'rolling' transform. This provides ability to
+    compute the mean, min, max, stdev and various other computations across
+    a rolling or moving window of a specified size.


### PR DESCRIPTION
this implements rolling aggregates which works similar to how
pandas rolling works but more trivial. this differs from deprecated
moving_average by correctly matching points to trailing timestamp
rather than leading timestamp.

it does not return the NaN values that result in shift in values.

#186 