### PR TITLE
doc: enable logging

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -137,6 +137,7 @@ basepython = python2.7
 #        .[postgresql,doc]
 # setenv = GNOCCHI_STORAGE_DEPS=file
 deps = .[test,file,postgresql,doc]
+setenv = GNOCCHI_TEST_DEBUG=1
 commands = doc8 --ignore-path doc/source/rest.rst,doc/source/comparison-table.rst doc/source
            pifpaf -g GNOCCHI_INDEXER_URL run postgresql -- python setup.py build_sphinx -W
 


### PR DESCRIPTION
By default, daiquiri output is hidden. The side effect is
that some sphinx error are not printed.

This change fixes that.