### PR TITLE
transformation: allow to do math

### DIFF
--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -138,7 +138,8 @@ Or we can apply absolute to the values and then negate them for example.
 
 {{ scenarios['get-measures-transform']['doc'] }}
 
-Supported transformations are `absolute`, `negative` and `resample(sampling-in-second)`.
+Supported transformations are `math(v - 100 /10)`, `absolute`, `negative` and
+`resample(sampling-in-second)`.
 
 .. note::
 

--- a/doc/source/rest.yaml
+++ b/doc/source/rest.yaml
@@ -271,7 +271,7 @@
   request: GET /v1/metric/{{ scenarios['create-metric']['response'].json['id'] }}/measures?granularity=1 HTTP/1.1
 
 - name: get-measures-transform
-  request: GET /v1/metric/{{ scenarios['create-metric']['response'].json['id'] }}/measures?transform=absolute:negative HTTP/1.1
+  request: GET /v1/metric/{{ scenarios['create-metric']['response'].json['id'] }}/measures?transform=absolute:math(v%20*%20-1) HTTP/1.1
 
 - name: get-measures-refresh
   request: GET /v1/metric/{{ scenarios['create-metric']['response'].json['id'] }}/measures?refresh=true HTTP/1.1

--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -26,6 +26,7 @@ import struct
 import time
 
 import lz4.block
+import numexpr
 import numpy
 import numpy.lib.recfunctions
 from scipy import ndimage
@@ -554,7 +555,13 @@ class AggregatedTimeSerie(TimeSerie):
         sampling = self.sampling
 
         for trans in transform:
-            if trans.method == "absolute":
+            if trans.method == "math":
+                # NOTE(sileht): We pass v into both dict to ensure evaluator
+                # don't use locals() and globals()
+                values = numexpr.evaluate(trans.args[0],
+                                          local_dict={"v": values},
+                                          global_dict={"v": values})
+            elif trans.method == "absolute":
                 values = numpy.abs(values)
 
             elif trans.method == "negative":

--- a/gnocchi/tests/functional/gabbits/metric.yaml
+++ b/gnocchi/tests/functional/gabbits/metric.yaml
@@ -221,6 +221,18 @@ tests:
           - ["2015-03-06T14:34:00+00:00", 60.0, -14.0]
           - ["2015-03-06T14:35:00+00:00", 60.0, -10.0]
 
+    - name: get measurements from metric and resample, negative and math(v * -1 + 100)
+      GET: /v1/metric/$HISTORY['list valid metrics'].$RESPONSE['$[0].id']/measures?refresh=true&transform=resample(60):math(v%20*%20-1%20%2B%20100)&granularity=1
+      response_json_paths:
+        $:
+          - ["2015-03-06T14:33:00+00:00", 60.0, 56.9]
+          - ["2015-03-06T14:34:00+00:00", 60.0, 86.0]
+          - ["2015-03-06T14:35:00+00:00", 60.0, 90.0]
+
+    - name: get measurements from metric and resample, negative and invalid math
+      GET: /v1/metric/$HISTORY['list valid metrics'].$RESPONSE['$[0].id']/measures?refresh=true&transform=resample(60):math(what)&granularity=1
+      status: 400
+
     - name: push negative measurements to metric again
       POST: /v1/metric/$HISTORY['list valid metrics'].$RESPONSE['$[0].id']/measures
       data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ daiquiri
 pyparsing>=2.2.0
 lz4>=0.9.0
 tooz>=1.38
+numexpr


### PR DESCRIPTION
This change introduces a math() transformer to do simple
mathematics on each points of the timeserie.

It uses numexpr library of pydata project.

Closes-bug: #342