### PR TITLE
Fix old doc build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -149,6 +149,7 @@ deps = {[testenv:docs]deps}
 # for 3.x doc
        oslotest
        oslosphinx
+       retrying
 commands =
     pifpaf -g GNOCCHI_INDEXER_URL run postgresql -- sphinx-versioning build doc/source doc/build/html
 


### PR DESCRIPTION
The rest page of the stable branch is missing

We remove retrying from our deps, but miss to put it in docs-gnocchi.xyz

This change fixes that.