### PR TITLE
doc: Enable warning as error

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,7 @@ deps = .[test,postgresql,file,doc]
 setenv = GNOCCHI_TEST_STORAGE_DRIVER=file
          GNOCCHI_TEST_INDEXER_DRIVER=postgresql
 commands = doc8 --ignore-path doc/source/rest.rst doc/source
-           pifpaf -g GNOCCHI_INDEXER_URL run postgresql -- python setup.py build_sphinx
+           pifpaf -g GNOCCHI_INDEXER_URL run postgresql -- python setup.py build_sphinx -W
 
 [testenv:docs-gnocchi.xyz]
 deps = .[file,postgresql,test,doc]


### PR DESCRIPTION
This change adds -W to sphinx-build and fixes the only warning we have.

The goals is to be able the enable it later on the multi versions build.