### PR TITLE
doc: Enable warning as error

### DIFF
--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -6,7 +6,7 @@ Authentication
 ==============
 
 By default, the authentication is configured to the "basic" mode. You need to
-provide an `Authorization' header in your HTTP requests with a valid username
+provide an `Authorization` header in your HTTP requests with a valid username
 (the password is not used). The "admin" password is granted all privileges,
 whereas any other username is recognize as having standard permissions.
 

--- a/tox.ini
+++ b/tox.ini
@@ -135,7 +135,7 @@ deps = .[test,postgresql,file,doc]
 setenv = GNOCCHI_TEST_STORAGE_DRIVER=file
          GNOCCHI_TEST_INDEXER_DRIVER=postgresql
 commands = doc8 --ignore-path doc/source/rest.rst doc/source
-           pifpaf -g GNOCCHI_INDEXER_URL run postgresql -- python setup.py build_sphinx
+           pifpaf -g GNOCCHI_INDEXER_URL run postgresql -- python setup.py build_sphinx -W
 
 [testenv:docs-gnocchi.xyz]
 deps = .[file,postgresql,test,doc]


### PR DESCRIPTION
This change adds -W to sphinx-build and fixes warnings we have.

The goals is to be able the enable it later on the multi versions build.