### PR TITLE
rest: fix ACL enforcement for non-admin on metric list

### DIFF
--- a/gnocchi/rest/__init__.py
+++ b/gnocchi/rest/__init__.py
@@ -556,6 +556,7 @@ class MetricsController(rest.RestController):
                 pecan.request.headers)
             if provided_creator and creator != provided_creator:
                 abort(403, "Insufficient privileges to filter by user/project")
+            provided_creator = creator
         attr_filter = {}
         if provided_creator is not None:
             attr_filter['creator'] = provided_creator

--- a/gnocchi/tests/gabbi/gabbits/base.yaml
+++ b/gnocchi/tests/gabbi/gabbits/base.yaml
@@ -77,6 +77,9 @@ tests:
 - name: list the one metric
   GET: /v1/metric
   status: 200
+  request_headers:
+    x-user-id: 93180da9-7c15-40d3-a050-a374551e52ee
+    x-project-id: 99d13f22-3618-4288-82b8-6512ded77e4f
   response_json_paths:
       $[0].archive_policy.name: test1
 

--- a/gnocchi/tests/test_rest.py
+++ b/gnocchi/tests/test_rest.py
@@ -307,6 +307,18 @@ class MetricTest(RestTest):
         with self.app.use_another_user():
             self.app.get("/v1/metric/%s" % metric_id)
 
+    def test_list_metric_with_another_user(self):
+        metric_created = self.app.post_json(
+            "/v1/metric",
+            params={"archive_policy_name": "medium"},
+            status=201)
+
+        metric_id = metric_created.json["id"]
+
+        with self.app.use_another_user():
+            metric_list = self.app.get("/v1/metric")
+            self.assertNotIn(metric_id, [m["id"] for m in metric_list.json])
+
     def test_get_metric_with_another_user(self):
         result = self.app.post_json("/v1/metric",
                                     params={"archive_policy_name": "medium"},


### PR DESCRIPTION
The current metric listing on /v1/metric does not enforce correctly the
attribute filtering on the creator field when the user is non-admin.

That means the attr_filter is empty and a non-admin can actually list all
metrics for all users.

This fixes that by setting the filter correctly.

(cherry picked from commit 2be95704a18229e4d05e57dd3e96de489a16e61d)