### PR TITLE
rest: add test for ACL enforcement for non-admin on metric list

### DIFF
--- a/gnocchi/tests/test_rest.py
+++ b/gnocchi/tests/test_rest.py
@@ -297,6 +297,18 @@ class MetricTest(RestTest):
         with self.app.use_another_user():
             self.app.get("/v1/metric/%s" % metric_id)
 
+    def test_list_metric_with_another_user(self):
+        metric_created = self.app.post_json(
+            "/v1/metric",
+            params={"archive_policy_name": "medium"},
+            status=201)
+
+        metric_id = metric_created.json["id"]
+
+        with self.app.use_another_user():
+            metric_list = self.app.get("/v1/metric")
+            self.assertNotIn(metric_id, [m["id"] for m in metric_list.json])
+
     def test_get_metric_with_another_user(self):
         result = self.app.post_json("/v1/metric",
                                     params={"archive_policy_name": "medium"},


### PR DESCRIPTION
This cherry picks commit 2be95704a18229e4d05e57dd3e96de489a16e61d from master
with just test that makes sure ACL rules are OK for metric listing.