### PR TITLE
cli: retry less aggressively if metricd can't connect to storage

### DIFF
--- a/gnocchi/cli.py
+++ b/gnocchi/cli.py
@@ -83,6 +83,7 @@ class MetricProcessBase(cotyledon.Service):
         self._shutdown = threading.Event()
         self._shutdown_done = threading.Event()
 
+    @utils.retry
     def _configure(self):
         self.store = storage.get_driver(self.conf)
         self.index = indexer.get_driver(self.conf)


### PR DESCRIPTION
Right now if the indexer or storage is not reachable/functioning, the process
crashes and cotyledon restarts it without any delay, which causes hammering the
e.g. storage.

This leverages the retry.utils decorator to retry in a less aggressive manner
to reconnect to storage.