### PR TITLE
cli: retry less aggressively if metricd can't connect to storage

### DIFF
--- a/gnocchi/cli.py
+++ b/gnocchi/cli.py
@@ -99,6 +99,7 @@ class MetricProcessBase(cotyledon.Service):
         self._shutdown = threading.Event()
         self._shutdown_done = threading.Event()
 
+    @utils.retry
     def _configure(self):
         self.store = retry_on_exception(storage.get_driver, self.conf)
         self.index = retry_on_exception(indexer.get_driver, self.conf)


### PR DESCRIPTION
Right now if the indexer or storage is not reachable/functioning, the process
crashes and cotyledon restarts it without any delay, which causes hammering the
e.g. storage.

This leverages the retry.utils decorator to retry in a less aggressive manner
to reconnect to storage.