### PR TITLE
load api modules only when needed.

### DIFF
--- a/gnocchi/opts.py
+++ b/gnocchi/opts.py
@@ -18,7 +18,6 @@ import pkg_resources
 import uuid
 
 from oslo_config import cfg
-from oslo_middleware import cors
 
 import gnocchi.archive_policy
 import gnocchi.indexer
@@ -196,6 +195,7 @@ def list_opts():
 
 
 def set_defaults():
+    from oslo_middleware import cors
     cfg.set_defaults(cors.CORS_OPTS,
                      allow_headers=[
                          'Authorization',

--- a/gnocchi/rest/gnocchi-api
+++ b/gnocchi/rest/gnocchi-api
@@ -17,6 +17,6 @@ if __name__ == '__main__':
     from gnocchi.cli import api
     sys.exit(api.api())
 else:
+    from gnocchi.cli import api
     from gnocchi.rest import app
-    from gnocchi import service
-    application = app.load_app(service.prepare_service())
+    application = app.load_app(api.prepare_service())

--- a/gnocchi/rest/wsgi.py
+++ b/gnocchi/rest/wsgi.py
@@ -11,6 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """This file is loaded by gnocchi-api when executing uwsgi"""
+from gnocchi.cli import api
 from gnocchi.rest import app
-from gnocchi import service
-application = app.load_app(service.prepare_service())
+application = app.load_app(api.prepare_service())

--- a/gnocchi/service.py
+++ b/gnocchi/service.py
@@ -15,12 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-import os
 
 import daiquiri
 from oslo_config import cfg
 from oslo_db import options as db_options
-from oslo_policy import opts as policy_opts
 import pbr.version
 from six.moves.urllib import parse as urlparse
 
@@ -36,10 +34,8 @@ def prepare_service(args=None, conf=None,
                     log_to_std=False, logging_level=None):
     if conf is None:
         conf = cfg.ConfigOpts()
-    opts.set_defaults()
     # FIXME(jd) Use the pkg_entry info to register the options of these libs
     db_options.set_defaults(conf)
-    policy_opts.set_defaults(conf)
 
     # Register our own Gnocchi options
     for group, options in opts.list_opts():
@@ -102,14 +98,6 @@ def prepare_service(args=None, conf=None,
             conf.set_default("coordination_url",
                              urlparse.urlunparse(parsed),
                              "storage")
-
-    cfg_path = conf.oslo_policy.policy_file
-    if not os.path.isabs(cfg_path):
-        cfg_path = conf.find_file(cfg_path)
-    if cfg_path is None or not os.path.exists(cfg_path):
-        cfg_path = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                                'rest', 'policy.json'))
-    conf.set_default('policy_file', cfg_path, group='oslo_policy')
 
     conf.log_opt_values(LOG, logging.DEBUG)
 

--- a/gnocchi/tests/base.py
+++ b/gnocchi/tests/base.py
@@ -39,6 +39,7 @@ from gnocchi import incoming
 from gnocchi import indexer
 from gnocchi import service
 from gnocchi import storage
+from gnocchi.tests import utils
 
 
 class SkipNotImplementedMeta(type):
@@ -271,7 +272,7 @@ class TestCase(BaseTestCase):
         super(TestCase, self).setUpClass()
 
         self.conf = service.prepare_service(
-            [],
+            [], conf=utils.prepare_conf(),
             default_config_files=[],
             logging_level=logging.DEBUG)
 

--- a/gnocchi/tests/functional/fixtures.py
+++ b/gnocchi/tests/functional/fixtures.py
@@ -80,7 +80,7 @@ class ConfigFixture(fixture.GabbiFixture):
             dcf = None
         else:
             dcf = []
-        conf = service.prepare_service([],
+        conf = service.prepare_service([], conf=utils.prepare_conf(),
                                        default_config_files=dcf)
         if not os.getenv("GNOCCHI_TEST_DEBUG"):
             daiquiri.setup(outputs=[])

--- a/gnocchi/tests/utils.py
+++ b/gnocchi/tests/utils.py
@@ -11,9 +11,21 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+from oslo_config import cfg
+from oslo_policy import opts as policy_opts
 import six
+
+from gnocchi import opts
 
 
 def list_all_incoming_metrics(incoming):
     return set.union(*[incoming.list_metric_with_measures_to_process(i)
                        for i in six.moves.range(incoming.NUM_SACKS)])
+
+
+def prepare_conf():
+    conf = cfg.ConfigOpts()
+
+    opts.set_defaults()
+    policy_opts.set_defaults(conf)
+    return conf


### PR DESCRIPTION
we should only load and setup policy and CORS when preparing
the API service.