### PR TITLE
Doc: update deprecated grafana plugin source

### DIFF
--- a/doc/source/grafana.rst
+++ b/doc/source/grafana.rst
@@ -5,7 +5,7 @@ Grafana support
 `Grafana`_ has support for Gnocchi through a plugin. It can be installed with
 grafana-cli::
 
-     sudo grafana-cli plugins install sileht-gnocchi-datasource
+     sudo grafana-cli plugins install gnocchixyz-gnocchi-datasource
 
 `Source`_ and `Documentation`_ are also available.
 


### PR DESCRIPTION
Update installation documentation to use the new version of the grafana plugin