### PR TITLE
Fix doc word inconsistency

### DIFF
--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -26,7 +26,7 @@ Glossary
    Granularity
      The time between two aggregates in an aggregated time series of a metric.
 
-   Timeseries
+   Time series
      A list of aggregates ordered by time.
 
    Aggregation method

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -102,7 +102,7 @@ Gnocchi vs Graphite
 
 `Graphite <http://graphite.readthedocs.org/en/latest/>`_ is essentially a data
 metric storage composed of flat files (Whisper), and focuses on rendering those
-timeseries. Each timeseries stored is composed of points that are stored
+time series. Each time series stored is composed of points that are stored
 regularly and are related to the current date and time.
 
 In comparison, Gnocchi offers much more scalability, a better file format and

--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -597,7 +597,7 @@ on whether boundary values are set ('start' and 'stop') and if 'needed_overlap'
 is set.
 
 When a boundary is set, Gnocchi expects that we have certain percent of
-timestamps common between timeseries. This percent is controlled by
+timestamps common between time series. This percent is controlled by
 needed_overlap, which by default expects 100% overlap. If this percent is not
 reached, an error is returned.
 
@@ -605,12 +605,12 @@ reached, an error is returned.
 
    If no boundaries are set, Gnocchi requires 100% overlap across all series
 
-The ability to fill in points missing from a subset of timeseries is supported
+The ability to fill in points missing from a subset of time series is supported
 by specifying a `fill` value. Valid fill values include any valid float or
 `null` which will compute aggregation with only the points that exist. The
 `fill` parameter will not backfill timestamps which contain no points in any
-of the timeseries. Only timestamps which have datapoints in at least one of
-the timeseries is returned.
+of the time series. Only timestamps which have datapoints in at least one of
+the time series is returned.
 
 .. note::
 


### PR DESCRIPTION
related #340 
Both 'timeseries' and 'time series' are used. And after some research,
I found that 'time series' is used more frequently.
All 'timeseries' are changed to 'time series'.