### PR TITLE
Fix fake metricd used in gabbi

### DIFF
--- a/gnocchi/tests/functional/fixtures.py
+++ b/gnocchi/tests/functional/fixtures.py
@@ -179,8 +179,12 @@ class MetricdThread(threading.Thread):
     def run(self):
         while self.flag:
             metrics = utils.list_all_incoming_metrics(self.incoming)
-            self.storage.process_background_tasks(
-                self.index, self.incoming, metrics)
+            metrics = self.index.list_metrics(ids=metrics)
+            for metric in metrics:
+                self.storage.refresh_metric(self.index,
+                                            self.incoming,
+                                            metric,
+                                            timeout=None)
             time.sleep(0.1)
 
     def stop(self):


### PR DESCRIPTION
storage.process_background_tasks() was originally locks each metrics it
processes. But since we move to the sack system the locks are handled by
the caller.

So, the fake-metricd thread of gabbi does not lock metric is process
anymore. This can lead to race when an API call use refresh=true and
metricd also try to process the same metric.

This change fixes that by also using refresh_metric in the fake metricd
used in gabbi tests.

Closes-bug: #244