### PR TITLE
Allow to rename archive policy rules

### DIFF
--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -302,6 +302,10 @@ It is possible to delete an |archive policy| rule:
 
 {{ scenarios['delete-archive-policy-rule']['doc'] }}
 
+It is possible to rename an archive policy rule:
+
+{{ scenarios['rename-archive-policy-rule']['doc'] }}
+
 Resources
 =========
 

--- a/doc/source/rest.yaml
+++ b/doc/source/rest.yaml
@@ -147,6 +147,25 @@
 - name: delete-archive-policy-rule
   request: DELETE /v1/archive_policy_rule/{{ scenarios['create-archive-policy-rule-to-delete']['response'].json['name'] }} HTTP/1.1
 
+- name: create-archive-policy-rule-to-rename
+  request: |
+    POST /v1/archive_policy_rule HTTP/1.1
+    Content-Type: application/json
+
+    {
+      "name": "test_rule_rename",
+      "metric_pattern": "disk.io.*",
+      "archive_policy_name": "low"
+    }
+
+- name: rename-archive-policy-rule
+  request: |
+    PATCH /v1/archive_policy_rule/{{ scenarios['create-archive-policy-rule-to-rename']['response'].json['name'] }} HTTP/1.1
+    Content-Type: application/json
+
+    {
+      "name": "new_name"
+    }
 
 - name: get-metric
   request: GET /v1/metric/{{ scenarios['create-metric']['response'].json['id'] }} HTTP/1.1

--- a/gnocchi/indexer/__init__.py
+++ b/gnocchi/indexer/__init__.py
@@ -169,6 +169,16 @@ class NoArchivePolicyRuleMatch(IndexerException):
         self.metric_name = metric_name
 
 
+class UnsupportedArchivePolicyRuleChange(IndexerException):
+    """Error raised when modifying archive policy rule if not supported."""
+    def __init__(self, archive_policy_rule, message):
+        super(UnsupportedArchivePolicyRuleChange, self).__init__(
+            "Archive policy rule %s does not support change: %s" %
+            (archive_policy_rule, message))
+        self.archive_policy_rule = archive_policy_rule
+        self.message = message
+
+
 class NamedMetricAlreadyExists(IndexerException):
     """Error raised when a named metric already exists."""
     def __init__(self, metric):
@@ -318,6 +328,10 @@ class IndexerDriver(object):
 
     @staticmethod
     def create_archive_policy_rule(name, metric_pattern, archive_policy_name):
+        raise exceptions.NotImplementedError
+
+    @staticmethod
+    def update_archive_policy_rule(name, new_name):
         raise exceptions.NotImplementedError
 
     @staticmethod

--- a/gnocchi/indexer/sqlalchemy.py
+++ b/gnocchi/indexer/sqlalchemy.py
@@ -645,6 +645,21 @@ class SQLAlchemyIndexer(indexer.IndexerDriver):
             raise indexer.ArchivePolicyRuleAlreadyExists(name)
         return apr
 
+    def update_archive_policy_rule(self, name, new_name):
+        apr = self.get_archive_policy_rule(name)
+        if not apr:
+            raise indexer.NoSuchArchivePolicyRule(name)
+        apr.name = new_name
+        try:
+            with self.facade.writer() as session:
+                session.add(apr)
+        except exception.DBDuplicateEntry:
+            raise indexer.UnsupportedArchivePolicyRuleChange(
+                name,
+                'Archive policy rule %s already exists.'
+                % new_name)
+        return apr
+
     @retry_on_deadlock
     def create_metric(self, id, creator, archive_policy_name,
                       name=None, unit=None, resource_id=None):

--- a/gnocchi/rest/policy.json
+++ b/gnocchi/rest/policy.json
@@ -28,6 +28,7 @@
     "create archive policy rule": "role:admin",
     "get archive policy rule": "",
     "list archive policy rule": "",
+    "update archive policy rule": "role:admin",
     "delete archive policy rule": "role:admin",
 
     "create metric": "",

--- a/gnocchi/tests/functional/gabbits/archive-rule.yaml
+++ b/gnocchi/tests/functional/gabbits/archive-rule.yaml
@@ -158,6 +158,47 @@ tests:
         authorization: "basic YWRtaW46"
       status: 400
 
+# rename an archive policy rule
+
+    - name: rename archive policy rule with missing name
+      PATCH: /v1/archive_policy_rule/test_rule3
+      request_headers:
+        # User admin
+        authorization: "basic YWRtaW46"
+      status: 400
+
+    - name: rename archive policy rule
+      PATCH: /v1/archive_policy_rule/test_rule3
+      request_headers:
+        # User admin
+        authorization: "basic YWRtaW46"
+      data:
+          name: test_rule3_renamed
+      status: 200
+
+    - name: get renamed archive policy rule
+      GET: /v1/archive_policy_rule/test_rule3_renamed
+      status: 200
+      response_json_paths:
+        $.metric_pattern: disk.*
+        $.archive_policy_name: low
+        $.name: test_rule3_renamed
+
+    - name: old archive policy rule doesn't exist
+      GET: /v1/archive_policy_rule/test_rule3
+      status: 404
+
+    - name: rename archive policy rule with existing name
+      PATCH: /v1/archive_policy_rule/test_rule2
+      request_headers:
+        # User admin
+        authorization: "basic YWRtaW46"
+      data:
+          name: test_rule3_renamed
+      status: 400
+      response_strings:
+          - 'Archive policy rule test_rule3_renamed already exists.'
+
 # delete rule as non admin
 
     - name: delete archive policy rule non admin
@@ -182,7 +223,7 @@ tests:
 
 
     - name: delete archive policy rule3
-      DELETE: /v1/archive_policy_rule/test_rule3
+      DELETE: /v1/archive_policy_rule/test_rule3_renamed
       request_headers:
         # User admin
         authorization: "basic YWRtaW46"

--- a/releasenotes/notes/add_update_archive_policy_rule-c2ac6b989a3138db.yaml
+++ b/releasenotes/notes/add_update_archive_policy_rule-c2ac6b989a3138db.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - Possibility to rename an archive policy.


### PR DESCRIPTION
It is now possible to change the name of an archive policy rule.

Closes #374