### PR TITLE
Doc - add note regarding metric modification

### DIFF
--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -39,6 +39,12 @@ To create a |metric|, the following API request should be used:
 
 {{ scenarios['create-metric']['doc'] }}
 
+.. note::
+
+  Once the |metric| is created, the |archive policy| attribute is fixed and
+  unchangeable. The definition of the |archive policy| can be changed through
+  the :ref:`archive_policy endpoint<archive-policy-patch>` though.
+
 Once created, you can retrieve the |metric| information:
 
 {{ scenarios['get-metric']['doc'] }}
@@ -237,6 +243,8 @@ used to retrieve the details of the |archive policy| later:
 It is also possible to list |archive policies|:
 
 {{ scenarios['list-archive-policy']['doc'] }}
+
+.. _archive-policy-patch:
 
 Existing |archive policies| can be modified to retain more or less data
 depending on requirements. If the policy coverage is expanded, |aggregates| are


### PR DESCRIPTION
close #386 
  In api usage, add note that it is not possible to modify
  metric after creation.