### PR TITLE
Allow to rename archive policies

### DIFF
--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -249,6 +249,15 @@ not retroactively calculated as backfill to accommodate the new |timespan|:
    |Granularities| cannot be changed to a different rate. Also, |granularities|
    cannot be added or dropped from a policy.
 
+Existing |archive policies| can be renamed:
+
+{{ scenarios['rename-archive-policy']['doc'] }}
+
+.. note::
+
+    The `name` and `definition` parameters can both be specified to update and
+    rename an archive policy within the same PATCH request.
+
 It is possible to delete an |archive policy| if it is not used by any |metric|:
 
 {{ scenarios['delete-archive-policy']['doc'] }}

--- a/doc/source/rest.yaml
+++ b/doc/source/rest.yaml
@@ -63,6 +63,35 @@
       ]
     }
 
+- name: create-archive-policy-to-rename
+  request: |
+    POST /v1/archive_policy HTTP/1.1
+    Content-Type: application/json
+
+    {
+      "name": "very-short",
+      "back_window": 0,
+      "definition": [
+        {
+          "granularity": "0.001s",
+          "timespan": "1 hour"
+        },
+        {
+          "points": 48,
+          "timespan": "1 day"
+        }
+      ]
+    }
+
+- name: rename-archive-policy
+  request: |
+    PATCH /v1/archive_policy/{{ scenarios['create-archive-policy-to-rename']['response'].json['name'] }} HTTP/1.1
+    Content-Type: application/json
+
+    {
+      "name": "not-so-short"
+    }
+
 - name: create-archive-policy-to-delete
   request: |
     POST /v1/archive_policy HTTP/1.1

--- a/gnocchi/indexer/alembic/versions/815b184585a5_use_cascade_update_for_metric_table_s_.py
+++ b/gnocchi/indexer/alembic/versions/815b184585a5_use_cascade_update_for_metric_table_s_.py
@@ -1,0 +1,43 @@
+# Copyright 2017 The Gnocchi Developers
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+"""Use cascade update for metric table's ap foreign key
+
+Revision ID: 815b184585a5
+Revises: 1e1a63d3d186
+Create Date: 2017-09-25 17:38:23.954423
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '815b184585a5'
+down_revision = '1e1a63d3d186'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint("fk_metric_ap_name_ap_name",
+                       "metric",
+                       type_="foreignkey")
+    op.create_foreign_key("fk_metric_ap_name_ap_name",
+                          "metric", "archive_policy",
+                          ["archive_policy_name"],
+                          ["name"],
+                          ondelete='RESTRICT',
+                          onupdate="CASCADE")

--- a/gnocchi/indexer/sqlalchemy_base.py
+++ b/gnocchi/indexer/sqlalchemy_base.py
@@ -175,7 +175,8 @@ class Metric(Base, GnocchiBase, storage.Metric):
         sqlalchemy.ForeignKey(
             'archive_policy.name',
             ondelete="RESTRICT",
-            name="fk_metric_ap_name_ap_name"),
+            name="fk_metric_ap_name_ap_name",
+            onupdate="CASCADE"),
         nullable=False)
     archive_policy = sqlalchemy.orm.relationship(ArchivePolicy, lazy="joined")
     creator = sqlalchemy.Column(sqlalchemy.String(255))

--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -251,23 +251,35 @@ class ArchivePolicyController(rest.RestController):
             abort(404, indexer.NoSuchArchivePolicy(self.archive_policy))
         enforce("update archive policy", ap)
 
-        body = deserialize_and_validate(voluptuous.Schema({
-            voluptuous.Required("definition"):
-                voluptuous.All([{
+        accepted_schemas = [
+            voluptuous.Schema({
+                voluptuous.Required("name"): six.text_type,
+                voluptuous.Optional("definition"): voluptuous.All([{
                     "granularity": Timespan,
                     "points": PositiveNotNullInt,
-                    "timespan": Timespan}], voluptuous.Length(min=1)),
-            }))
+                    "timespan": Timespan}], voluptuous.Length(min=1))
+            }),
+            voluptuous.Schema({
+                voluptuous.Optional("name"): six.text_type,
+                voluptuous.Required("definition"): voluptuous.All([{
+                    "granularity": Timespan,
+                    "points": PositiveNotNullInt,
+                    "timespan": Timespan}], voluptuous.Length(min=1))
+            })]
+        body = deserialize_and_validate(voluptuous.Any(*accepted_schemas))
         # Validate the data
+        # If no new definition was passed, use the current one
         try:
             ap_items = [archive_policy.ArchivePolicyItem(**item) for item in
-                        body['definition']]
+                        body.get('definition', ap.definition)]
         except ValueError as e:
             abort(400, e)
 
         try:
             return pecan.request.indexer.update_archive_policy(
-                self.archive_policy, ap_items)
+                self.archive_policy,
+                ap_items,
+                new_name=body.get("name"))
         except indexer.UnsupportedArchivePolicyChange as e:
             abort(400, e)
 

--- a/gnocchi/tests/functional/gabbits/archive.yaml
+++ b/gnocchi/tests/functional/gabbits/archive.yaml
@@ -292,6 +292,80 @@ tests:
       response_strings:
           - Archive policy large already exists
 
+# Create another one, rename it and delete it
+
+    - name: create to_rename policy
+      POST: /v1/archive_policy
+      request_headers:
+          # User admin
+          authorization: "basic YWRtaW46"
+      data:
+          name: to_rename
+          definition:
+              - granularity: 1 second
+                points: 20
+              - granularity: 2 second
+      response_headers:
+          location: $SCHEME://$NETLOC/v1/archive_policy/to_rename
+      status: 201
+
+    - name: rename archive policy with existing name
+      PATCH: /v1/archive_policy/to_rename
+      request_headers:
+          # User admin
+          authorization: "basic YWRtaW46"
+      data:
+          name: medium
+      status: 400
+      response_strings:
+          - "Archive policy medium already exists."
+
+    - name: rename archive policy
+      PATCH: $LAST_URL
+      request_headers:
+          # User admin
+          authorization: "basic YWRtaW46"
+      data:
+          name: renamed
+      status: 200
+      response_json_paths:
+          $.name: renamed
+          $.definition[0].granularity: "0:00:01"
+          $.definition[0].points: 20
+          $.definition[0].timespan: "0:00:20"
+          $.definition[1].granularity: "0:00:02"
+          $.definition[1].points: null
+          $.definition[1].timespan: null
+
+    - name: confirm rename
+      GET: $LAST_URL
+      status: 404
+
+    - name: rename and update archive policy
+      PATCH: /v1/archive_policy/renamed
+      request_headers:
+          # User admin
+          authorization: "basic YWRtaW46"
+      data:
+          name: renamed_twice
+          definition:
+              - granularity: 1 second
+                points: 50
+              - granularity: 2 second
+      status: 200
+      response_json_paths:
+          $.name: renamed_twice
+          $.definition[0].granularity: "0:00:01"
+          $.definition[0].points: 50
+          $.definition[0].timespan: "0:00:50"
+
+    - name: delete renamed policy
+      DELETE: /v1/archive_policy/renamed_twice
+      request_headers:
+        # User admin
+        authorization: "basic YWRtaW46"
+      status: 204
+
 # Create a unicode named policy
 
     - name: post unicode policy name


### PR DESCRIPTION
Archive policies can be renamed by issuing
a PATCH request containing the new name.
The definition of an ap can also be patched
along with the name within the same request.