### PR TITLE
Pull request for fix-ap-size-tool

### DIFF
--- a/tools/gnocchi-archive-policy-size.py
+++ b/tools/gnocchi-archive-policy-size.py
@@ -23,8 +23,8 @@ from gnocchi import utils
 WORST_CASE_BYTES_PER_POINT = 8.04
 
 
-if (len(sys.argv) - 1) % 2 != 0:
-    print("Usage: %s <granularity> <timespan> ... <granularity> <timespan>"
+if (len(sys.argv) - 2) % 2 != 0:
+    print("Usage: %s <number of agg methods> <granularity> <timespan> ..."
           % sys.argv[0])
     sys.exit(1)
 
@@ -38,12 +38,15 @@ def sizeof_fmt(num, suffix='B'):
 
 
 size = 0
-for g, t in utils.grouper(sys.argv[1:], 2):
+agg_methods = int(sys.argv[1])
+for g, t in utils.grouper(sys.argv[2:], 2):
     granularity = utils.to_timespan(g)
     timespan = utils.to_timespan(t)
     points = timespan / granularity
     cursize = points * WORST_CASE_BYTES_PER_POINT
     size += cursize
     print("%s over %s = %d points = %s" % (g, t, points, sizeof_fmt(cursize)))
+
+size *= agg_methods
 
 print("Total: " + sizeof_fmt(size))

--- a/tools/gnocchi-archive-policy-size.py
+++ b/tools/gnocchi-archive-policy-size.py
@@ -41,7 +41,7 @@ size = 0
 for g, t in utils.grouper(sys.argv[1:], 2):
     granularity = utils.to_timespan(g)
     timespan = utils.to_timespan(t)
-    points = timespan.total_seconds() / granularity.total_seconds()
+    points = timespan / granularity
     cursize = points * WORST_CASE_BYTES_PER_POINT
     size += cursize
     print("%s over %s = %d points = %s" % (g, t, points, sizeof_fmt(cursize)))


### PR DESCRIPTION
Force to specify the number of agg methods in archive policy size tool
Fix gnocchi-archive-policy-size with recent Numpy switch