### PR TITLE
numpy instead of pandas cross-metric

### DIFF
--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -617,14 +617,14 @@ Also, aggregation across |metrics| have different behavior depending
 on whether boundary values are set ('start' and 'stop') and if 'needed_overlap'
 is set.
 
-When a boundary is set, Gnocchi expects that we have certain percent of
-timestamps common between time series. This percent is controlled by
-needed_overlap, which by default expects 100% overlap. If this percent is not
-reached, an error is returned.
+Gnocchi expects that we have a certain percent of timestamps common between
+time series. This percent is controlled by needed_overlap, which by default
+expects 100% overlap. If this percent is not reached, an error is returned.
 
 .. note::
 
-   If no boundaries are set, Gnocchi requires 100% overlap across all series
+   If a start and end boundary are not set, Gnocchi will set the missing
+   boundary to the first or last timestamp common across all series.
 
 The ability to fill in points missing from a subset of time series is supported
 by specifying a `fill` value. Valid fill values include any valid float or

--- a/gnocchi/json.py
+++ b/gnocchi/json.py
@@ -17,7 +17,6 @@ import datetime
 import uuid
 
 import numpy
-import pandas
 import six
 import ujson
 
@@ -36,11 +35,6 @@ def to_primitive(obj):
         return str(obj).rpartition(".000000000")[0] + "+00:00"
     if isinstance(obj, numpy.timedelta64):
         return obj / numpy.timedelta64(1, 's')
-    if isinstance(obj, pandas.Timedelta):
-        # >>> pandas.Timedelta("1 minute").total_seconds()
-        # 60.00000000000001
-        # Never forget that bro.
-        return obj.delta / 10e8
     if isinstance(obj, datetime.timedelta):
         return obj.total_seconds()
     # This mimics what Pecan implements in its default JSON encoder

--- a/gnocchi/rest/cross_metric.py
+++ b/gnocchi/rest/cross_metric.py
@@ -17,16 +17,23 @@
 """Timeseries cross-aggregation."""
 import collections
 
-
 import daiquiri
-import iso8601
-import pandas
+import numpy
 import six
 
+from gnocchi import carbonara
 from gnocchi import storage as gnocchi_storage
 
 
 LOG = daiquiri.getLogger(__name__)
+
+
+AGG_MAP = {'mean': numpy.nanmean,
+           'median': numpy.nanmedian,
+           'std': numpy.nanstd,
+           'min': numpy.nanmin,
+           'max': numpy.nanmax,
+           'sum': numpy.nansum}
 
 
 class UnAggregableTimeseries(Exception):
@@ -108,116 +115,77 @@ def get_cross_metric_measures(storage, metrics, from_timestamp=None,
         tss = list(map(lambda ts: ts.transform(transform), tss))
 
     try:
-        return [(timestamp.replace(tzinfo=iso8601.iso8601.UTC), r, v)
-                for timestamp, r, v
-                in aggregated(tss, reaggregation, from_timestamp, to_timestamp,
-                              needed_overlap, fill)]
-    except UnAggregableTimeseries as e:
+        return [(timestamp, r, v) for timestamp, r, v
+                in aggregated(tss, reaggregation, from_timestamp,
+                              to_timestamp, needed_overlap, fill)]
+    except (UnAggregableTimeseries, carbonara.UnknownAggregationMethod) as e:
         raise MetricUnaggregatable(metrics, e.reason)
 
 
 def aggregated(timeseries, aggregation, from_timestamp=None,
-               to_timestamp=None, needed_percent_of_overlap=100.0,
-               fill=None):
-    index = ['timestamp', 'granularity']
-    columns = ['timestamp', 'granularity', 'value']
-    dataframes = []
+               to_timestamp=None, needed_percent_of_overlap=100.0, fill=None):
 
-    if not timeseries:
-        return []
-
+    series = collections.defaultdict(list)
+    has_content = False
     for timeserie in timeseries:
-        timeserie_raw = list(timeserie.fetch(from_timestamp, to_timestamp))
+        from_ = (None if from_timestamp is None else
+                 carbonara.round_timestamp(from_timestamp, timeserie.sampling))
+        ts = timeserie[from_:to_timestamp]
+        # FIXME(gordc): a test expect empty result if all series empty. it
+        # should not matter, and continue to check overlap.
+        if ts.size > 0:
+            has_content = True
+        series[timeserie.sampling].append(ts)
 
-        if timeserie_raw:
-            dataframe = pandas.DataFrame(timeserie_raw, columns=columns)
-            dataframe = dataframe.set_index(index)
-            dataframes.append(dataframe)
-
-    if not dataframes:
+    if not series or not has_content:
         return []
 
-    number_of_distinct_datasource = len(timeseries) / len(
-        set(ts.sampling for ts in timeseries)
-    )
+    result = {'timestamps': [], 'granularity': [], 'values': []}
+    for key in sorted(series, reverse=True):
+        combine = numpy.concatenate(series[key])
+        # np.unique sorts results for us
+        times, indices = numpy.unique(combine['timestamps'],
+                                      return_inverse=True)
 
-    left_boundary_ts = None
-    right_boundary_ts = None
-    if fill is not None:
-        fill_df = pandas.concat(dataframes, axis=1)
-        if fill != 'null':
-            fill_df = fill_df.fillna(fill)
-        single_df = pandas.concat([series for __, series in
-                                   fill_df.iteritems()]).to_frame()
-        grouped = single_df.groupby(level=index)
-    else:
-        grouped = pandas.concat(dataframes).groupby(level=index)
-        maybe_next_timestamp_is_left_boundary = False
+        # create nd-array (unique series x unique times) and fill
+        filler = fill if fill is not None and fill != 'null' else numpy.NaN
+        val_grid = numpy.full((len(series[key]), len(times)), filler)
+        start = 0
+        for i, split in enumerate(series[key]):
+            size = len(split)
+            val_grid[i][indices[start:start + size]] = split['values']
+            start += size
+        values = val_grid.T
 
-        left_holes = 0
-        right_holes = 0
-        holes = 0
-        for (timestamp, __), group in grouped:
-            if group.count()['value'] != number_of_distinct_datasource:
-                maybe_next_timestamp_is_left_boundary = True
-                if left_boundary_ts is not None:
-                    right_holes += 1
-                else:
-                    left_holes += 1
-            elif maybe_next_timestamp_is_left_boundary:
-                left_boundary_ts = timestamp
-                maybe_next_timestamp_is_left_boundary = False
-            else:
-                right_boundary_ts = timestamp
-                holes += right_holes
-                right_holes = 0
-
-        if to_timestamp is not None:
-            holes += left_holes
-        if from_timestamp is not None:
-            holes += right_holes
-
-        if to_timestamp is not None or from_timestamp is not None:
-            maximum = len(grouped)
-            percent_of_overlap = (float(maximum - holes) * 100.0 /
-                                  float(maximum))
+        if fill is None:
+            overlap = numpy.flatnonzero(~numpy.any(numpy.isnan(values),
+                                                   axis=1))
+            if overlap.size == 0 and needed_percent_of_overlap > 0:
+                raise UnAggregableTimeseries('No overlap')
+            # if no boundary set, use first/last timestamp which overlap
+            if to_timestamp is None and overlap.size:
+                times = times[:overlap[-1] + 1]
+                values = values[:overlap[-1] + 1]
+            if from_timestamp is None and overlap.size:
+                times = times[overlap[0]:]
+                values = values[overlap[0]:]
+            percent_of_overlap = overlap.size * 100.0 / times.size
             if percent_of_overlap < needed_percent_of_overlap:
                 raise UnAggregableTimeseries(
                     'Less than %f%% of datapoints overlap in this '
                     'timespan (%.2f%%)' % (needed_percent_of_overlap,
                                            percent_of_overlap))
-        if (needed_percent_of_overlap > 0 and
-                (right_boundary_ts == left_boundary_ts or
-                 (right_boundary_ts is None
-                  and maybe_next_timestamp_is_left_boundary))):
-            LOG.debug("We didn't find points that overlap in those "
-                      "timeseries. "
-                      "right_boundary_ts=%(right_boundary_ts)s, "
-                      "left_boundary_ts=%(left_boundary_ts)s, "
-                      "groups=%(groups)s", {
-                          'right_boundary_ts': right_boundary_ts,
-                          'left_boundary_ts': left_boundary_ts,
-                          'groups': list(grouped)
-                      })
-            raise UnAggregableTimeseries('No overlap')
 
-    # NOTE(sileht): this call the aggregation method on already
-    # aggregated values, for some kind of aggregation this can
-    # result can looks weird, but this is the best we can do
-    # because we don't have anymore the raw datapoints in those case.
-    # FIXME(sileht): so should we bailout is case of stddev, percentile
-    # and median?
-    agg_timeserie = getattr(grouped, aggregation)()
-    agg_timeserie = agg_timeserie.dropna().reset_index()
+        if aggregation in AGG_MAP:
+            values = AGG_MAP[aggregation](values, axis=1)
+        elif aggregation == 'count':
+            values = numpy.count_nonzero(~numpy.isnan(values), axis=1)
+        else:
+            raise carbonara.UnknownAggregationMethod(aggregation)
 
-    if from_timestamp is None and left_boundary_ts:
-        agg_timeserie = agg_timeserie[
-            agg_timeserie['timestamp'] >= left_boundary_ts]
-    if to_timestamp is None and right_boundary_ts:
-        agg_timeserie = agg_timeserie[
-            agg_timeserie['timestamp'] <= right_boundary_ts]
+        result['timestamps'].extend(times)
+        result['granularity'].extend([key] * len(times))
+        result['values'].extend(values)
 
-    points = agg_timeserie.sort_values(by=['granularity', 'timestamp'],
-                                       ascending=[0, 1])
-    return six.moves.zip(points.timestamp, points.granularity,
-                         points.value)
+    return six.moves.zip(result['timestamps'], result['granularity'],
+                         result['values'])

--- a/gnocchi/tests/test_cross_metric.py
+++ b/gnocchi/tests/test_cross_metric.py
@@ -23,7 +23,6 @@ from gnocchi import carbonara
 from gnocchi.rest import cross_metric
 from gnocchi import storage
 from gnocchi.tests import base
-from gnocchi import utils
 
 
 def datetime64(*args):
@@ -268,23 +267,23 @@ class TestAggregatedTimeseries(base.BaseTestCase):
             tsc1['return'], tsc2['return']], aggregation='mean', fill=0)
 
         self.assertEqual([
-            (datetime.datetime(2014, 1, 1, 12, 0, 0),
+            (datetime64(2014, 1, 1, 12, 0, 0),
              numpy.timedelta64(60000000000, 'ns'), 3.0),
-            (datetime.datetime(2014, 1, 1, 12, 1, 0),
+            (datetime64(2014, 1, 1, 12, 1, 0),
              numpy.timedelta64(60000000000, 'ns'), 1.0),
-            (datetime.datetime(2014, 1, 1, 12, 2, 0),
+            (datetime64(2014, 1, 1, 12, 2, 0),
              numpy.timedelta64(60000000000, 'ns'), 6.5),
-            (datetime.datetime(2014, 1, 1, 12, 3, 0),
+            (datetime64(2014, 1, 1, 12, 3, 0),
              numpy.timedelta64(60000000000, 'ns'), 16.5),
-            (datetime.datetime(2014, 1, 1, 12, 4, 0),
+            (datetime64(2014, 1, 1, 12, 4, 0),
              numpy.timedelta64(60000000000, 'ns'), 2.5),
-            (datetime.datetime(2014, 1, 1, 12, 5, 0),
+            (datetime64(2014, 1, 1, 12, 5, 0),
              numpy.timedelta64(60000000000, 'ns'), 9.0),
-            (datetime.datetime(2014, 1, 1, 12, 6, 0),
+            (datetime64(2014, 1, 1, 12, 6, 0),
              numpy.timedelta64(60000000000, 'ns'), 9.5),
-            (datetime.datetime(2014, 1, 1, 12, 7, 0),
+            (datetime64(2014, 1, 1, 12, 7, 0),
              numpy.timedelta64(60000000000, 'ns'), 2.5),
-            (datetime.datetime(2014, 1, 1, 12, 8, 0),
+            (datetime64(2014, 1, 1, 12, 8, 0),
              numpy.timedelta64(60000000000, 'ns'), 1.5),
         ], list(output))
 
@@ -323,23 +322,23 @@ class TestAggregatedTimeseries(base.BaseTestCase):
             tsc1['return'], tsc2['return']], aggregation='mean', fill='null')
 
         self.assertEqual([
-            (datetime.datetime(2014, 1, 1, 12, 0, 0),
+            (datetime64(2014, 1, 1, 12, 0, 0),
              numpy.timedelta64(60000000000, 'ns'), 6.0),
-            (datetime.datetime(2014, 1, 1, 12, 1, 0),
+            (datetime64(2014, 1, 1, 12, 1, 0),
              numpy.timedelta64(60000000000, 'ns'), 2.0),
-            (datetime.datetime(2014, 1, 1, 12, 2, 0),
+            (datetime64(2014, 1, 1, 12, 2, 0),
              numpy.timedelta64(60000000000, 'ns'), 13.0),
-            (datetime.datetime(2014, 1, 1, 12, 3, 0),
+            (datetime64(2014, 1, 1, 12, 3, 0),
              numpy.timedelta64(60000000000, 'ns'), 16.5),
-            (datetime.datetime(2014, 1, 1, 12, 4, 0),
+            (datetime64(2014, 1, 1, 12, 4, 0),
              numpy.timedelta64(60000000000, 'ns'), 2.5),
-            (datetime.datetime(2014, 1, 1, 12, 5, 0),
+            (datetime64(2014, 1, 1, 12, 5, 0),
              numpy.timedelta64(60000000000, 'ns'), 9.0),
-            (datetime.datetime(2014, 1, 1, 12, 6, 0),
+            (datetime64(2014, 1, 1, 12, 6, 0),
              numpy.timedelta64(60000000000, 'ns'), 9.5),
-            (datetime.datetime(2014, 1, 1, 12, 7, 0),
+            (datetime64(2014, 1, 1, 12, 7, 0),
              numpy.timedelta64(60000000000, 'ns'), 5.0),
-            (datetime.datetime(2014, 1, 1, 12, 8, 0),
+            (datetime64(2014, 1, 1, 12, 8, 0),
              numpy.timedelta64(60000000000, 'ns'), 3.0),
         ], list(output))
 
@@ -374,19 +373,19 @@ class TestAggregatedTimeseries(base.BaseTestCase):
             tsc1['return'], tsc2['return']], aggregation='mean', fill=0)
 
         self.assertEqual([
-            (datetime.datetime(2014, 1, 1, 12, 0, 0),
+            (datetime64(2014, 1, 1, 12, 0, 0),
              numpy.timedelta64(60000000000, 'ns'), 3.0),
-            (datetime.datetime(2014, 1, 1, 12, 1, 0),
+            (datetime64(2014, 1, 1, 12, 1, 0),
              numpy.timedelta64(60000000000, 'ns'), 1.0),
-            (datetime.datetime(2014, 1, 1, 12, 2, 0),
+            (datetime64(2014, 1, 1, 12, 2, 0),
              numpy.timedelta64(60000000000, 'ns'), 6.5),
-            (datetime.datetime(2014, 1, 1, 12, 3, 0),
+            (datetime64(2014, 1, 1, 12, 3, 0),
              numpy.timedelta64(60000000000, 'ns'), 16.5),
-            (datetime.datetime(2014, 1, 1, 12, 4, 0),
+            (datetime64(2014, 1, 1, 12, 4, 0),
              numpy.timedelta64(60000000000, 'ns'), 2.5),
-            (datetime.datetime(2014, 1, 1, 12, 7, 0),
+            (datetime64(2014, 1, 1, 12, 7, 0),
              numpy.timedelta64(60000000000, 'ns'), 2.5),
-            (datetime.datetime(2014, 1, 1, 12, 8, 0),
+            (datetime64(2014, 1, 1, 12, 8, 0),
              numpy.timedelta64(60000000000, 'ns'), 1.5),
         ], list(output))
 
@@ -476,35 +475,35 @@ class TestAggregatedTimeseries(base.BaseTestCase):
             [tsc1['return'], tsc12['return'], tsc2['return'], tsc22['return']],
             'mean')
         self.assertEqual([
-            (datetime.datetime(2014, 1, 1, 11, 45),
+            (datetime64(2014, 1, 1, 11, 45),
              numpy.timedelta64(300, 's'), 5.75),
-            (datetime.datetime(2014, 1, 1, 11, 50),
+            (datetime64(2014, 1, 1, 11, 50),
              numpy.timedelta64(300, 's'), 27.5),
-            (datetime.datetime(2014, 1, 1, 11, 55),
+            (datetime64(2014, 1, 1, 11, 55),
              numpy.timedelta64(300, 's'), 5.3333333333333339),
-            (datetime.datetime(2014, 1, 1, 12, 0),
+            (datetime64(2014, 1, 1, 12, 0),
              numpy.timedelta64(300, 's'), 6.0),
-            (datetime.datetime(2014, 1, 1, 12, 5),
+            (datetime64(2014, 1, 1, 12, 5),
              numpy.timedelta64(300, 's'), 5.1666666666666661),
-            (datetime.datetime(2014, 1, 1, 11, 54),
+            (datetime64(2014, 1, 1, 11, 54),
              numpy.timedelta64(60, 's'), 4.5),
-            (datetime.datetime(2014, 1, 1, 11, 56),
+            (datetime64(2014, 1, 1, 11, 56),
              numpy.timedelta64(60, 's'), 4.5),
-            (datetime.datetime(2014, 1, 1, 11, 57),
+            (datetime64(2014, 1, 1, 11, 57),
              numpy.timedelta64(60, 's'), 6.5),
-            (datetime.datetime(2014, 1, 1, 11, 58),
+            (datetime64(2014, 1, 1, 11, 58),
              numpy.timedelta64(60, 's'), 5.0),
-            (datetime.datetime(2014, 1, 1, 12, 1),
+            (datetime64(2014, 1, 1, 12, 1),
              numpy.timedelta64(60, 's'), 6.0),
-            (datetime.datetime(2014, 1, 1, 12, 2),
+            (datetime64(2014, 1, 1, 12, 2),
              numpy.timedelta64(60, 's'), 7.0),
-            (datetime.datetime(2014, 1, 1, 12, 3),
+            (datetime64(2014, 1, 1, 12, 3),
              numpy.timedelta64(60, 's'), 4.5),
-            (datetime.datetime(2014, 1, 1, 12, 4),
+            (datetime64(2014, 1, 1, 12, 4),
              numpy.timedelta64(60, 's'), 5.5),
-            (datetime.datetime(2014, 1, 1, 12, 5),
+            (datetime64(2014, 1, 1, 12, 5),
              numpy.timedelta64(60, 's'), 6.75),
-            (datetime.datetime(2014, 1, 1, 12, 6),
+            (datetime64(2014, 1, 1, 12, 6),
              numpy.timedelta64(60, 's'), 2.0),
         ], list(output))
 
@@ -721,30 +720,30 @@ class CrossMetricAggregated(base.TestCase):
         values = cross_metric.get_cross_metric_measures(
             self.storage, [self.metric, metric2])
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1, 0, 0, 0),
+            (datetime64(2014, 1, 1, 0, 0, 0),
              numpy.timedelta64(1, 'D'), 22.25),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 0),
+            (datetime64(2014, 1, 1, 12, 0, 0),
              numpy.timedelta64(1, 'h'), 22.25),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 0),
+            (datetime64(2014, 1, 1, 12, 0, 0),
              numpy.timedelta64(5, 'm'), 39.0),
-            (utils.datetime_utc(2014, 1, 1, 12, 5, 0),
+            (datetime64(2014, 1, 1, 12, 5, 0),
              numpy.timedelta64(5, 'm'), 12.5),
-            (utils.datetime_utc(2014, 1, 1, 12, 10, 0),
+            (datetime64(2014, 1, 1, 12, 10, 0),
              numpy.timedelta64(5, 'm'), 24.0)
         ], values)
 
         values = cross_metric.get_cross_metric_measures(
             self.storage, [self.metric, metric2], reaggregation='max')
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1, 0, 0, 0),
+            (datetime64(2014, 1, 1, 0, 0, 0),
              numpy.timedelta64(1, 'D'), 39.75),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 0),
+            (datetime64(2014, 1, 1, 12, 0, 0),
              numpy.timedelta64(1, 'h'), 39.75),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 0),
+            (datetime64(2014, 1, 1, 12, 0, 0),
              numpy.timedelta64(5, 'm'), 69),
-            (utils.datetime_utc(2014, 1, 1, 12, 5, 0),
+            (datetime64(2014, 1, 1, 12, 5, 0),
              numpy.timedelta64(5, 'm'), 23),
-            (utils.datetime_utc(2014, 1, 1, 12, 10, 0),
+            (datetime64(2014, 1, 1, 12, 10, 0),
              numpy.timedelta64(5, 'm'), 44)
         ], values)
 
@@ -752,11 +751,11 @@ class CrossMetricAggregated(base.TestCase):
             self.storage, [self.metric, metric2],
             from_timestamp=datetime64(2014, 1, 1, 12, 10, 0))
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1),
+            (datetime64(2014, 1, 1),
              numpy.timedelta64(1, 'D'), 22.25),
-            (utils.datetime_utc(2014, 1, 1, 12),
+            (datetime64(2014, 1, 1, 12),
              numpy.timedelta64(1, 'h'), 22.25),
-            (utils.datetime_utc(2014, 1, 1, 12, 10, 0),
+            (datetime64(2014, 1, 1, 12, 10, 0),
              numpy.timedelta64(5, 'm'), 24.0),
         ], values)
 
@@ -765,11 +764,11 @@ class CrossMetricAggregated(base.TestCase):
             to_timestamp=datetime64(2014, 1, 1, 12, 5, 0))
 
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1, 0, 0, 0),
+            (datetime64(2014, 1, 1, 0, 0, 0),
              numpy.timedelta64(1, 'D'), 22.25),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 0),
+            (datetime64(2014, 1, 1, 12, 0, 0),
              numpy.timedelta64(1, 'h'), 22.25),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 0),
+            (datetime64(2014, 1, 1, 12, 0, 0),
              numpy.timedelta64(5, 'm'), 39.0),
         ], values)
 
@@ -778,11 +777,11 @@ class CrossMetricAggregated(base.TestCase):
             from_timestamp=datetime64(2014, 1, 1, 12, 10, 10),
             to_timestamp=datetime64(2014, 1, 1, 12, 10, 10))
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1),
+            (datetime64(2014, 1, 1),
              numpy.timedelta64(1, 'D'), 22.25),
-            (utils.datetime_utc(2014, 1, 1, 12),
+            (datetime64(2014, 1, 1, 12),
              numpy.timedelta64(1, 'h'), 22.25),
-            (utils.datetime_utc(2014, 1, 1, 12, 10),
+            (datetime64(2014, 1, 1, 12, 10),
              numpy.timedelta64(5, 'm'), 24.0),
         ], values)
 
@@ -792,11 +791,11 @@ class CrossMetricAggregated(base.TestCase):
             to_timestamp=datetime64(2014, 1, 1, 12, 0, 1))
 
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1),
+            (datetime64(2014, 1, 1),
              numpy.timedelta64(1, 'D'), 22.25),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 0),
+            (datetime64(2014, 1, 1, 12, 0, 0),
              numpy.timedelta64(1, 'h'), 22.25),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 0),
+            (datetime64(2014, 1, 1, 12, 0, 0),
              numpy.timedelta64(5, 'm'), 39.0),
         ], values)
 
@@ -807,7 +806,7 @@ class CrossMetricAggregated(base.TestCase):
             granularity=numpy.timedelta64(5, 'm'))
 
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 0),
+            (datetime64(2014, 1, 1, 12, 0, 0),
              numpy.timedelta64(5, 'm'), 39.0),
         ], values)
 
@@ -831,14 +830,14 @@ class CrossMetricAggregated(base.TestCase):
         values = cross_metric.get_cross_metric_measures(
             self.storage, [self.metric, metric2])
         self.assertEqual([
-            (utils.datetime_utc(2014, 1, 1, 0, 0, 0),
+            (datetime64(2014, 1, 1, 0, 0, 0),
              numpy.timedelta64(1, 'D'), 18.875),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 0),
+            (datetime64(2014, 1, 1, 12, 0, 0),
              numpy.timedelta64(1, 'h'), 18.875),
-            (utils.datetime_utc(2014, 1, 1, 12, 0, 0),
+            (datetime64(2014, 1, 1, 12, 0, 0),
              numpy.timedelta64(5, 'm'), 39.0),
-            (utils.datetime_utc(2014, 1, 1, 12, 5, 0),
+            (datetime64(2014, 1, 1, 12, 5, 0),
              numpy.timedelta64(5, 'm'), 11.0),
-            (utils.datetime_utc(2014, 1, 1, 12, 10, 0),
+            (datetime64(2014, 1, 1, 12, 10, 0),
              numpy.timedelta64(5, 'm'), 22.0)
         ], values)


### PR DESCRIPTION
use numpy instead of pandas to compute cross metric
- find all the unique timestamps
- create a AxB pre-filled grid where
	- A is number of series, and B is length
- if fill, fill as appropriate
- if not fill
	- if needed_overlap > 0, compute overlap
	- reset start/end boundaries if not provided to first/last
	  times which overlap all series.
- aggregate as needed.