### PR TITLE
always return no overlap if there's no overlap

### DIFF
--- a/gnocchi/rest/cross_metric.py
+++ b/gnocchi/rest/cross_metric.py
@@ -126,19 +126,10 @@ def aggregated(timeseries, aggregation, from_timestamp=None,
                to_timestamp=None, needed_percent_of_overlap=100.0, fill=None):
 
     series = collections.defaultdict(list)
-    has_content = False
     for timeserie in timeseries:
         from_ = (None if from_timestamp is None else
                  carbonara.round_timestamp(from_timestamp, timeserie.sampling))
-        ts = timeserie[from_:to_timestamp]
-        # FIXME(gordc): a test expect empty result if all series empty. it
-        # should not matter, and continue to check overlap.
-        if ts.size > 0:
-            has_content = True
-        series[timeserie.sampling].append(ts)
-
-    if not series or not has_content:
-        return []
+        series[timeserie.sampling].append(timeserie[from_:to_timestamp])
 
     result = {'timestamps': [], 'granularity': [], 'values': []}
     for key in sorted(series, reverse=True):

--- a/gnocchi/tests/test_cross_metric.py
+++ b/gnocchi/tests/test_cross_metric.py
@@ -629,14 +629,12 @@ class CrossMetricAggregated(base.TestCase):
         # A lot of tests wants a metric, create one
         self.metric, __ = self._create_metric()
 
-    def test_get_cross_metric_measures_unknown_metric(self):
-        self.assertEqual([],
-                         cross_metric.get_cross_metric_measures(
-                             self.storage,
-                             [storage.Metric(uuid.uuid4(),
-                                             self.archive_policies['low']),
-                              storage.Metric(uuid.uuid4(),
-                                             self.archive_policies['low'])]))
+    def test_get_cross_metric_measures_empty_metrics_no_overlap(self):
+        self.assertRaises(
+            cross_metric.MetricUnaggregatable,
+            cross_metric.get_cross_metric_measures, self.storage,
+            [storage.Metric(uuid.uuid4(), self.archive_policies['low']),
+             storage.Metric(uuid.uuid4(), self.archive_policies['low'])])
 
     def test_get_cross_metric_measures_unknown_aggregation(self):
         metric2 = storage.Metric(uuid.uuid4(),


### PR DESCRIPTION
if empty series are cross computed, it should say there's no overlap
rather than an empty result. (unless needed_overlap=0)