### PR TITLE
metricd: only re-add sack to be processed on failure

### DIFF
--- a/gnocchi/cli/metricd.py
+++ b/gnocchi/cli/metricd.py
@@ -229,11 +229,11 @@ class MetricProcessor(MetricProcessBase):
             except Exception:
                 LOG.error("Unexpected error processing assigned job",
                           exc_info=True)
-            finally:
-                lock.release()
                 # If processing failed, re-add it to the sack list
                 if notified:
                     self.sacks_with_measures_to_process.add(s)
+            finally:
+                lock.release()
         LOG.debug("%d metrics processed from %d sacks", m_count, s_count)
         if sacks == self._get_sacks_to_process():
             # We just did a full scan of all sacks, reset the timer


### PR DESCRIPTION
The condition for re-adding the sack on failure has been put under finally by
mistake, rather than under the except block.

Fixes #397