### PR TITLE
storage: remove process_background_tasks

### DIFF
--- a/gnocchi/cli/metricd.py
+++ b/gnocchi/cli/metricd.py
@@ -223,7 +223,7 @@ class MetricProcessor(MetricProcessBase):
             try:
                 metrics = self.incoming.list_metric_with_measures_to_process(s)
                 m_count += len(metrics)
-                self.store.process_background_tasks(
+                self.store.process_new_measures(
                     self.index, self.incoming, metrics)
                 s_count += 1
             except Exception:

--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -472,26 +472,6 @@ class StorageDriver(object):
                 LOG.error("Unable to expunge metric %s from storage", m,
                           exc_info=True)
 
-    def process_background_tasks(self, index, incoming, metrics, sync=False):
-        """Process background tasks for this storage.
-
-        This calls :func:`process_new_measures` to process new measures
-
-        :param index: An indexer to be used for querying metrics
-        :param incoming: The incoming storage
-        :param metrics: The list of metrics waiting for processing
-        :param sync: If True, then process everything synchronously and raise
-                     on error
-        :type sync: bool
-        """
-        try:
-            self.process_new_measures(index, incoming, metrics, sync)
-        except Exception:
-            if sync:
-                raise
-            LOG.error("Unexpected error during measures processing",
-                      exc_info=True)
-
     def process_new_measures(self, indexer, incoming, metrics_to_process,
                              sync=False):
         """Process added measures in background.

--- a/gnocchi/tests/base.py
+++ b/gnocchi/tests/base.py
@@ -385,5 +385,5 @@ class TestCase(BaseTestCase):
     def trigger_processing(self, metrics=None):
         if metrics is None:
             metrics = [str(self.metric.id)]
-        self.storage.process_background_tasks(
+        self.storage.process_new_measures(
             self.index, self.incoming, metrics, sync=True)

--- a/gnocchi/tests/test_aggregates.py
+++ b/gnocchi/tests/test_aggregates.py
@@ -51,7 +51,7 @@ class TestAggregates(tests_base.TestCase):
         self.index.create_metric(metric.id, str(uuid.uuid4()), 'medium')
         self.incoming.add_measures(metric, measures)
         metrics = tests_utils.list_all_incoming_metrics(self.incoming)
-        self.storage.process_background_tasks(
+        self.storage.process_new_measures(
             self.index, self.incoming, metrics, sync=True)
 
         return metric

--- a/gnocchi/tests/test_rest.py
+++ b/gnocchi/tests/test_rest.py
@@ -129,7 +129,7 @@ class TestingApp(webtest.TestApp):
             req.remote_user = self.user
         response = super(TestingApp, self).do_request(req, *args, **kwargs)
         metrics = tests_utils.list_all_incoming_metrics(self.incoming)
-        self.storage.process_background_tasks(
+        self.storage.process_new_measures(
             self.indexer, self.incoming, metrics, sync=True)
         return response
 

--- a/gnocchi/tests/test_statsd.py
+++ b/gnocchi/tests/test_statsd.py
@@ -71,7 +71,7 @@ class TestStatsd(tests_base.TestCase):
 
         metric = r.get_metric(metric_key)
 
-        self.storage.process_background_tasks(
+        self.storage.process_new_measures(
             self.stats.indexer, self.stats.incoming,
             [str(metric.id)], sync=True)
 
@@ -92,7 +92,7 @@ class TestStatsd(tests_base.TestCase):
             ("127.0.0.1", 12345))
         self.stats.flush()
 
-        self.storage.process_background_tasks(
+        self.storage.process_new_measures(
             self.stats.indexer, self.stats.incoming,
             [str(metric.id)], sync=True)
 
@@ -126,7 +126,7 @@ class TestStatsd(tests_base.TestCase):
         metric = r.get_metric(metric_key)
         self.assertIsNotNone(metric)
 
-        self.storage.process_background_tasks(
+        self.storage.process_new_measures(
             self.stats.indexer, self.stats.incoming,
             [str(metric.id)], sync=True)
 
@@ -146,7 +146,7 @@ class TestStatsd(tests_base.TestCase):
             ("127.0.0.1", 12345))
         self.stats.flush()
 
-        self.storage.process_background_tasks(
+        self.storage.process_new_measures(
             self.stats.indexer, self.stats.incoming,
             [str(metric.id)], sync=True)
 


### PR DESCRIPTION
The function does nothing anymore, just wraps process_new_measures. Remove it.