### PR TITLE
redis: do not emit notifications until sack is processed

### DIFF
--- a/gnocchi/incoming/__init__.py
+++ b/gnocchi/incoming/__init__.py
@@ -182,6 +182,11 @@ class IncomingDriver(object):
         """Return an iterable of sack that got new measures to process."""
         raise exceptions.NotImplementedError
 
+    @staticmethod
+    def finish_sack_processing(sack):
+        """Mark sack processing has finished."""
+        pass
+
 
 def get_driver(conf):
     """Return configured incoming driver only

--- a/gnocchi/tests/test_incoming.py
+++ b/gnocchi/tests/test_incoming.py
@@ -58,6 +58,7 @@ class TestIncomingDriver(tests_base.TestCase):
                 break
             # NOTE(jd) Retry to send measures. It cannot be done only once as
             # there might be a race condition between the threads
+            self.incoming.finish_sack_processing(sack_to_find)
             self.incoming.add_measures(self.metric, [
                 incoming.Measure(numpy.datetime64("2014-01-01 12:00:01"), 69),
             ])


### PR DESCRIPTION
The current behavior is to notify no matter what as soon as a new measure is
push into a metric, and therefore, into a sack.

This patches modifies this behaviour by having the measure storage putting a
flag into a special key named after the sack it is pushing into. Metricd
processes watches for this key to be set and get a notification _only the first
time it is set_. Once metricd finishes processing that sack, it delete the key
so it can get notified again if any new measures has arrived.

This patch also simplifies the notification processing in metricd by just
setting back on the notification system when processing is finished. Previous
version was trying to re-enable notification prior to processing but it just
complicates the workflow for little gain; there's no lock around notification,
and would just add overhead.