### PR TITLE
metricd: cache sacks to process

### DIFF
--- a/gnocchi/cli/metricd.py
+++ b/gnocchi/cli/metricd.py
@@ -16,6 +16,7 @@
 import threading
 import time
 
+import cachetools.func
 import cotyledon
 from cotyledon import oslo_config_glue
 import daiquiri
@@ -126,6 +127,11 @@ class MetricProcessor(MetricProcessBase):
         # This stores the last time the processor did a scan on all the sack it
         # is responsible for
         self._last_full_sack_scan = utils.StopWatch().start()
+        # Only update the list of sacks to process every
+        # metric_processing_delay
+        self._get_sacks_to_process = cachetools.func.ttl_cache(
+            ttl=conf.metricd.metric_processing_delay
+        )(self._get_sacks_to_process)
 
     @tenacity.retry(
         wait=_wait_exponential,

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ daiquiri
 pyparsing>=2.2.0
 lz4>=0.9.0
 tooz>=1.38
+cachetools


### PR DESCRIPTION
With the new notification system calling _get_sack_to_process as often as each
notification is received, the tooz `run_watchers` function is called too often,
hitting the backend a lot, often for no change.

This patch restores back the previous behavior of updating the list of sack to
process every `metric_processing_delay` maximum. In order to do that, it simply
leverages cachetools and cache the output for a defined TTL equals to
`metric_processing_delay`. That avoids trying to be too smart about when/how to
call run_watchers while giving the wanted result.

Closes #406