### PR TITLE
incoming: fix logging on SackDetectionError

### DIFF
--- a/gnocchi/cli/manage.py
+++ b/gnocchi/cli/manage.py
@@ -87,7 +87,8 @@ def change_sack_size():
     try:
         report = s.measures_report(details=False)
     except incoming.SackDetectionError:
-        # issue is already logged by NUM_SACKS, abort.
+        LOG.error('Unable to detect the number of storage sacks.\n'
+                  'Ensure gnocchi-upgrade has been executed.')
         return
     remainder = report['summary']['measures']
     if remainder:

--- a/gnocchi/incoming/__init__.py
+++ b/gnocchi/incoming/__init__.py
@@ -53,8 +53,6 @@ class IncomingDriver(object):
             try:
                 self._num_sacks = int(self._get_storage_sacks())
             except Exception as e:
-                LOG.error('Unable to detect the number of storage sacks. '
-                          'Ensure gnocchi-upgrade has been executed: %s', e)
                 raise SackDetectionError(e)
         return self._num_sacks
 


### PR DESCRIPTION
Accessing NUM_SACKS and having SackDetectionError is the mechanism that
upgrade() uses to detect if it needs to do its job. But since logging is down
too low-level, the error message is print on the first call of gnocchi-upgrade,
which does not make any sense. Log only where it makes sense.