### PR TITLE
storage: remove aggregation_workers_number option

### DIFF
--- a/gnocchi/rest/cross_metric.py
+++ b/gnocchi/rest/cross_metric.py
@@ -105,11 +105,12 @@ def get_cross_metric_measures(storage, metrics, from_timestamp=None,
     else:
         granularities_in_common = [granularity]
 
-    tss = storage._map_in_thread(storage._get_measures_timeserie,
-                                 [(metric, aggregation, g,
-                                   from_timestamp, to_timestamp)
-                                  for metric in metrics
-                                  for g in granularities_in_common])
+    tss = [
+        storage._get_measures_timeserie(metric, aggregation, g,
+                                        from_timestamp, to_timestamp)
+        for metric in metrics
+        for g in granularities_in_common
+    ]
 
     if transform is not None:
         tss = list(map(lambda ts: ts.transform(transform), tss))

--- a/releasenotes/notes/remove-option-aggregation_workers_number-c6b9a09d5e3cf46e.yaml
+++ b/releasenotes/notes/remove-option-aggregation_workers_number-c6b9a09d5e3cf46e.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    The `aggregation_workers_number` option has been removed.


### PR DESCRIPTION
This has been set to 1 by default for a long time now as threads overhead are
usually bigger than the gain they offer. In medium-large scale deployment,
there's no interest to change that to something else than 1.

It also is being used by cross_metric aggregation where it is actually not
related to it. That's weird.

Let's remove it and simplify the code base a bit.