### PR TITLE
Set a correct default value for aggregation_workers_number

### DIFF
--- a/gnocchi/service.py
+++ b/gnocchi/service.py
@@ -44,7 +44,9 @@ def prepare_service(args=None, conf=None,
 
     conf.register_cli_opts(opts._cli_options)
 
-    conf.set_default("workers", utils.get_default_workers(), group="metricd")
+    workers = utils.get_default_workers()
+    conf.set_default("workers", workers, group="metricd")
+    conf.set_default("aggregation_workers_number", workers, group="storage")
 
     conf(args, project='gnocchi', validate_default_values=True,
          default_config_files=default_config_files,

--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -38,7 +38,7 @@ OPTS = [
 
 _CARBONARA_OPTS = [
     cfg.IntOpt('aggregation_workers_number',
-               default=1, min=1,
+               min=1,
                help='Number of threads to process and store aggregates. '
                'Set value roughly equal to number of aggregates to be '
                'computed per metric'),


### PR DESCRIPTION
The current value of 1 is not the optimal setting by default, spreading on the
number of available CPU is likely to have better results to avoid being I/O
bound.