### PR TITLE
Rename storage.aggregation_workers_number to parallel_operations

### DIFF
--- a/gnocchi/opts.py
+++ b/gnocchi/opts.py
@@ -94,6 +94,14 @@ _cli_options = (
 def list_opts():
     return [
         ("DEFAULT", _cli_options + (
+            cfg.IntOpt(
+                'parallel_operations',
+                min=1,
+                deprecated_name='aggregation_workers_number',
+                deprecated_group='storage',
+                help='Number of threads to use to parallelize '
+                'some operations. '
+                'Default is set to the number of CPU available.'),
             cfg.BoolOpt(
                 'use-syslog',
                 default=False,

--- a/gnocchi/rest/aggregates/processor.py
+++ b/gnocchi/rest/aggregates/processor.py
@@ -24,6 +24,7 @@ import six
 from gnocchi import carbonara
 from gnocchi.rest.aggregates import operations as agg_operations
 from gnocchi import storage as gnocchi_storage
+from gnocchi import utils
 
 
 LOG = daiquiri.getLogger(__name__)
@@ -101,13 +102,13 @@ def get_measures(storage, metrics_and_aggregations,
     else:
         granularities_in_common = [granularity]
 
-    tss = storage._map_in_thread(_get_measures_timeserie,
-                                 [(storage, metric, aggregation,
-                                   ref_identifier,
-                                   g, from_timestamp, to_timestamp)
-                                  for (metric, aggregation)
-                                  in metrics_and_aggregations
-                                  for g in granularities_in_common])
+    tss = utils.parallel_map(_get_measures_timeserie,
+                             [(storage, metric, aggregation,
+                               ref_identifier,
+                               g, from_timestamp, to_timestamp)
+                              for (metric, aggregation)
+                              in metrics_and_aggregations
+                              for g in granularities_in_common])
 
     if resample and granularity:
         tss = list(map(lambda ref_and_ts: (

--- a/gnocchi/service.py
+++ b/gnocchi/service.py
@@ -46,11 +46,13 @@ def prepare_service(args=None, conf=None,
 
     workers = utils.get_default_workers()
     conf.set_default("workers", workers, group="metricd")
-    conf.set_default("aggregation_workers_number", workers, group="storage")
+    conf.set_default("parallel_operations", workers)
 
     conf(args, project='gnocchi', validate_default_values=True,
          default_config_files=default_config_files,
          version=pbr.version.VersionInfo('gnocchi').version_string())
+
+    utils.parallel_map.NUM_WORKERS = conf.parallel_operations
 
     if not log_to_std and (conf.log_dir or conf.log_file):
         outputs = [daiquiri.output.File(filename=conf.log_file,

--- a/gnocchi/tests/test_utils.py
+++ b/gnocchi/tests/test_utils.py
@@ -115,3 +115,17 @@ class StopWatchTest(tests_base.TestCase):
         with utils.StopWatch() as watch:
             pass
         self.assertGreater(watch.elapsed(), 0)
+
+
+class ParallelMap(tests_base.TestCase):
+    def test_parallel_map_one(self):
+        utils.parallel_map.NUM_WORKERS = 1
+        self.assertEqual([1, 2, 3],
+                         utils.parallel_map(lambda x: x,
+                                            [[1], [2], [3]]))
+
+    def test_parallel_map_four(self):
+        utils.parallel_map.NUM_WORKERS = 4
+        self.assertEqual([1, 2, 3],
+                         utils.parallel_map(lambda x: x,
+                                            [[1], [2], [3]]))

--- a/gnocchi/utils.py
+++ b/gnocchi/utils.py
@@ -22,6 +22,7 @@ import multiprocessing
 import os
 import uuid
 
+from concurrent import futures
 import daiquiri
 import iso8601
 import monotonic
@@ -303,3 +304,19 @@ def get_driver_class(namespace, conf):
     """
     return driver.DriverManager(namespace,
                                 conf.driver).driver
+
+
+def parallel_map(fn, list_of_args):
+    """Run a function in parallel."""
+
+    if parallel_map.MAX_WORKERS == 1:
+        return list(itertools.starmap(fn, list_of_args))
+
+    with futures.ThreadPoolExecutor(
+            max_workers=parallel_map.MAX_WORKERS) as executor:
+        # We use 'list' to iterate all threads here to raise the first
+        # exception now, not much choice
+        return list(executor.map(lambda args: fn(*args), list_of_args))
+
+
+parallel_map.MAX_WORKERS = get_default_workers()

--- a/releasenotes/notes/parallel_operations_replaces_aggregation_workers_numbers-cb3a8cf62211bd5b.yaml
+++ b/releasenotes/notes/parallel_operations_replaces_aggregation_workers_numbers-cb3a8cf62211bd5b.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    The `storage.aggregation_workers_number` parameter has been replaced by a
+    more general `parallel_operations` option. It controls the number of
+    parallel jobs that can be run by a worker using threads in various code
+    paths.


### PR DESCRIPTION
The option storage.aggregation_workers_number is not only used by storage, but
also by API cross aggregation. Make it generic and move the map_in_thread
method in a generic parallel_map function in gnocchi.utils.