### PR TITLE
aggregates: make aggregated() extensible

### DIFF
--- a/gnocchi/rest/aggregates/operations.py
+++ b/gnocchi/rest/aggregates/operations.py
@@ -1,0 +1,77 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright © 2016-2017 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import numpy
+
+from gnocchi import carbonara
+
+
+AGG_MAP = {
+    'mean': numpy.nanmean,
+    'median': numpy.nanmedian,
+    'std': numpy.nanstd,
+    'min': numpy.nanmin,
+    'max': numpy.nanmax,
+    'sum': numpy.nansum,
+    'var': numpy.nanvar,
+    'count': lambda values, axis: numpy.count_nonzero(
+        ~numpy.isnan(values), axis=axis),
+}
+
+
+def handle_aggregate(agg, granularity, timestamps, values, is_aggregated):
+    values = numpy.array([AGG_MAP[agg](values, axis=1)]).T
+    if values.shape[1] != 1:
+        raise RuntimeError("Unexpected resulting aggregated array shape: %s" %
+                           values)
+    return (granularity, timestamps, values, True)
+
+
+def handle_aggregation_operator(nodes, granularity, timestamps, initial_values,
+                                is_aggregated, references):
+    op = aggregation_operators[nodes[0]]
+    agg = nodes[1]
+    subnodes = nodes[-1]
+    args = nodes[2:-1]
+    if agg not in AGG_MAP:
+        raise carbonara.UnknownAggregationMethod(agg)
+    granularity, timestamps, values, is_aggregated = evaluate(
+        subnodes, granularity, timestamps, initial_values,
+        is_aggregated, references)
+    return op(agg, granularity, timestamps, values, is_aggregated, *args)
+
+
+aggregation_operators = {
+    u"aggregate": handle_aggregate,
+}
+
+
+def evaluate(nodes, granularity, timestamps, initial_values, is_aggregated,
+             references):
+    if nodes[0] in aggregation_operators:
+        return handle_aggregation_operator(nodes, granularity, timestamps,
+                                           initial_values, is_aggregated,
+                                           references)
+    elif nodes[0] == "metric":
+        if isinstance(nodes[1], list):
+            predicat = lambda r: r in nodes[1:]
+        else:
+            predicat = lambda r: r == nodes[1:]
+        indexes = [i for i, r in enumerate(references) if predicat(r)]
+        return (granularity, timestamps, initial_values.T[indexes].T,
+                is_aggregated)
+    else:
+        raise RuntimeError("Operation node tree is malformed: %s" % nodes)

--- a/gnocchi/rest/aggregates/processor.py
+++ b/gnocchi/rest/aggregates/processor.py
@@ -22,18 +22,11 @@ import numpy
 import six
 
 from gnocchi import carbonara
+from gnocchi.rest.aggregates import operations as agg_operations
 from gnocchi import storage as gnocchi_storage
 
 
 LOG = daiquiri.getLogger(__name__)
-
-
-AGG_MAP = {'mean': numpy.nanmean,
-           'median': numpy.nanmedian,
-           'std': numpy.nanstd,
-           'min': numpy.nanmin,
-           'max': numpy.nanmax,
-           'sum': numpy.nansum}
 
 
 class UnAggregableTimeseries(Exception):
@@ -46,33 +39,39 @@ class UnAggregableTimeseries(Exception):
 class MetricUnaggregatable(Exception):
     """Error raised when metrics can't be aggregated."""
 
-    def __init__(self, metrics, reason):
-        self.metrics = metrics
+    def __init__(self, metrics_and_aggregations, reason):
+        self.metrics_and_aggregations = metrics_and_aggregations
         self.reason = reason
+        metrics = ("%s/%s" % (m.id, a) for (m, a) in metrics_and_aggregations)
         super(MetricUnaggregatable, self).__init__(
-            "Metrics %s can't be aggregated: %s"
-            % (", ".join((str(m.id) for m in metrics)), reason))
+            "Metrics %s can't be aggregated: %s" % (
+                ", ".join(metrics), reason))
 
 
-def get_measures(storage, metrics, from_timestamp=None,
-                 to_timestamp=None, aggregation='mean',
-                 reaggregation=None,
+def _get_measures_timeserie(storage, metric, aggregation, ref_identifier,
+                            *args, **kwargs):
+    return ([str(getattr(metric, ref_identifier)), aggregation],
+            storage._get_measures_timeserie(metric, aggregation, *args,
+                                            **kwargs))
+
+
+def get_measures(storage, metrics_and_aggregations,
+                 operations,
+                 from_timestamp=None, to_timestamp=None,
                  granularity=None, needed_overlap=100.0,
-                 fill=None, resample=None):
+                 fill=None, resample=None, ref_identifier="id"):
     """Get aggregated measures of multiple entities.
 
     :param storage: The storage driver.
-    :param metrics: The metrics measured to aggregate.
+    :param metrics_and_aggregations: List of metric+agg_method tuple
+                                     measured to aggregate.
     :param from timestamp: The timestamp to get the measure from.
     :param to timestamp: The timestamp to get the measure to.
     :param granularity: The granularity to retrieve.
-    :param aggregation: The type of aggregation to retrieve.
-    :param reaggregation: The type of aggregation to compute
-                          on the retrieved measures.
     :param fill: The value to use to fill in missing data in series.
     :param resample: The granularity to resample to.
     """
-    for metric in metrics:
+    for (metric, aggregation) in metrics_and_aggregations:
         if aggregation not in metric.archive_policy.aggregation_methods:
             raise gnocchi_storage.AggregationDoesNotExist(metric, aggregation)
         if granularity is not None:
@@ -83,55 +82,58 @@ def get_measures(storage, metrics, from_timestamp=None,
                 raise gnocchi_storage.GranularityDoesNotExist(
                     metric, granularity)
 
-    if reaggregation is None:
-        reaggregation = aggregation
-
     if granularity is None:
         granularities = (
             definition.granularity
-            for metric in metrics
+            for (metric, aggregation) in metrics_and_aggregations
             for definition in metric.archive_policy.definition
         )
         granularities_in_common = [
             g
             for g, occurrence in six.iteritems(
                 collections.Counter(granularities))
-            if occurrence == len(metrics)
+            if occurrence == len(metrics_and_aggregations)
         ]
 
         if not granularities_in_common:
             raise MetricUnaggregatable(
-                metrics, 'No granularity match')
+                metrics_and_aggregations, 'No granularity match')
     else:
         granularities_in_common = [granularity]
 
-    tss = storage._map_in_thread(storage._get_measures_timeserie,
-                                 [(metric, aggregation, g,
-                                   from_timestamp, to_timestamp)
-                                  for metric in metrics
+    tss = storage._map_in_thread(_get_measures_timeserie,
+                                 [(storage, metric, aggregation,
+                                   ref_identifier,
+                                   g, from_timestamp, to_timestamp)
+                                  for (metric, aggregation)
+                                  in metrics_and_aggregations
                                   for g in granularities_in_common])
 
     if resample and granularity:
-        tss = list(map(lambda ts: ts.resample(resample), tss))
+        tss = list(map(lambda ref_and_ts: (
+            ref_and_ts[0], ref_and_ts[1].resample(resample)), tss))
 
     try:
-        return [(timestamp, r, v) for timestamp, r, v
-                in aggregated(tss, reaggregation, from_timestamp,
-                              to_timestamp, needed_overlap, fill)]
+        return aggregated(tss, operations, from_timestamp, to_timestamp,
+                          needed_overlap, fill)
     except (UnAggregableTimeseries, carbonara.UnknownAggregationMethod) as e:
-        raise MetricUnaggregatable(metrics, e.reason)
+        raise MetricUnaggregatable(metrics_and_aggregations, e.reason)
 
 
-def aggregated(timeseries, aggregation, from_timestamp=None,
+def aggregated(refs_and_timeseries, operations, from_timestamp=None,
                to_timestamp=None, needed_percent_of_overlap=100.0, fill=None):
 
     series = collections.defaultdict(list)
-    for timeserie in timeseries:
+    references = collections.defaultdict(list)
+    for (reference, timeserie) in refs_and_timeseries:
         from_ = (None if from_timestamp is None else
                  carbonara.round_timestamp(from_timestamp, timeserie.sampling))
+        references[timeserie.sampling].append(reference)
         series[timeserie.sampling].append(timeserie[from_:to_timestamp])
 
-    result = {'timestamps': [], 'granularity': [], 'values': []}
+    result = collections.defaultdict(lambda: {'timestamps': [],
+                                              'granularity': [],
+                                              'values': []})
     for key in sorted(series, reverse=True):
         combine = numpy.concatenate(series[key])
         # np.unique sorts results for us
@@ -167,16 +169,23 @@ def aggregated(timeseries, aggregation, from_timestamp=None,
                     'timespan (%.2f%%)' % (needed_percent_of_overlap,
                                            percent_of_overlap))
 
-        if aggregation in AGG_MAP:
-            values = AGG_MAP[aggregation](values, axis=1)
-        elif aggregation == 'count':
-            values = numpy.count_nonzero(~numpy.isnan(values), axis=1)
+        granularity, times, values, is_aggregated = (
+            agg_operations.evaluate(operations, key, times, values,
+                                    False, references[key]))
+
+        if is_aggregated:
+            result["aggregated"]["timestamps"].extend(times)
+            result["aggregated"]['granularity'].extend([granularity] *
+                                                       len(times))
+            result["aggregated"]['values'].extend(values.T[0])
         else:
-            raise carbonara.UnknownAggregationMethod(aggregation)
+            for i, ref in enumerate(references[key]):
+                ident = "%s_%s" % tuple(ref)
+                result[ident]["timestamps"].extend(times)
+                result[ident]['granularity'].extend([granularity] * len(times))
+                result[ident]['values'].extend(values.T[i])
 
-        result['timestamps'].extend(times)
-        result['granularity'].extend([key] * len(times))
-        result['values'].extend(values)
-
-    return six.moves.zip(result['timestamps'], result['granularity'],
-                         result['values'])
+    return dict(((ident, list(six.moves.zip(result[ident]['timestamps'],
+                                            result[ident]['granularity'],
+                                            result[ident]['values'])))
+                 for ident in result))

--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -1705,6 +1705,13 @@ class AggregationController(rest.RestController):
                 % (aggregation,
                    archive_policy.ArchivePolicy.VALID_AGGREGATION_METHODS))
 
+        if reaggregation is None:
+            reaggregation = aggregation
+
+        metrics_and_aggregations = [[str(m.id), aggregation] for m in metrics]
+        operations = ["aggregate", reaggregation,
+                      ["metric"] + metrics_and_aggregations]
+
         for metric in metrics:
             enforce("get metric", metric)
 
@@ -1754,9 +1761,10 @@ class AggregationController(rest.RestController):
                     granularity, resample)
             return processor.get_measures(
                 pecan.request.storage,
-                metrics, start, stop, aggregation,
-                reaggregation, granularity, needed_overlap, fill,
-                resample)
+                [(m, aggregation) for m in metrics],
+                operations, start, stop,
+                granularity, needed_overlap, fill,
+                resample)["aggregated"]
         except processor.MetricUnaggregatable as e:
             abort(400, ("One of the metrics being aggregated doesn't have "
                         "matching granularity: %s") % str(e))


### PR DESCRIPTION
This changes make aggregated() method more generic.

Related #419