### PR TITLE
statsd: StatsdServer inherits from asyncio.Protocol

### DIFF
--- a/gnocchi/statsd.py
+++ b/gnocchi/statsd.py
@@ -128,7 +128,7 @@ class Stats(object):
         return ap.name
 
 
-class StatsdServer(object):
+class StatsdServer(asyncio.Protocol):
     def __init__(self, stats):
         self.stats = stats
 


### PR DESCRIPTION
This makes StatsdServer explicitely implement the asyncio.Protocol interface.
It does not change much but it makes sure all methods are implemented, even if
they do nothing.