### PR TITLE
aggregates: implements more operations

### DIFF
--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -551,15 +551,134 @@ argument, and in this case the second argument passed is the value, or it.
 The operators or (`or` or `∨`), and (`and` or `∧`) and `not` are also
 supported, and take a list of arguments as parameters.
 
+.. _aggregates:
+
+Aggregates: on the fly, measurements modification and aggregation
+===================================================================
+
+Gnocchi allows to do on-the-fly aggregation and modification of already
+aggregated data of |metrics|.
+
+It can be done by providing the list of |metrics| to aggregate:
+
+{{ scenarios['get-aggregates-by-metric-ids']['doc'] }}
+
+This example computes the mean aggregates with `all` metrics listed in
+`metrics` and then multiples it by `4`.
+
+.. note::
+
+   `operations` can also be passed as a string, for example:
+   `"operations": "(aggregate mean (metric (metric-id aggregation) (metric-id aggregation))"`
+
+Operations between metrics can also be done, such as:
+
+{{ scenarios['get-aggregates-between-metrics']['doc'] }}
+
+Aggregation across |metrics| have different behavior depending
+on whether boundary values are set (`start` and `stop`) and if `needed_overlap`
+is set.
+
+Gnocchi expects that time series have a certain percentage of timestamps in
+common. This percent is controlled by the `needed_overlap` needed_overlap,
+which by default expects 100% overlap. If this percentage is not reached, an
+error is returned.
+
+.. note::
+
+   If `start` or `stop` boundary is not set, Gnocchi will set the missing
+   boundary to the first or last timestamp common across all series.
+
+The ability to fill in missing points from a subset of time series is supported
+by specifying a `fill` value. Valid fill values include any float or `null`. In
+the case of `null`, Gnocchi will compute the aggregation using only the
+existing points. The `fill` parameter will not backfill timestamps which contain no
+points in any of the time series. Only timestamps which have datapoints in at
+least one of the time series is returned.
+
+.. note::
+
+   A |granularity| must be specified when using the `fill` parameter.
+
+{{ scenarios['get-aggregates-by-metric-ids-fill']['doc'] }}
+
+
+
+List of supported <operations>
+------------------------------
+
+getting one or more metrics::
+
+   (metric <metric-id> <aggregation>)
+   (metric ((<metric-id> <aggregation>), (<metric-id> <aggregation>), ...))
+
+   metric-id: the id of a metric to retrieve
+   aggregation: the aggregation method to retrieve
+
+rolling window aggregation::
+
+   (rolling <aggregation method> <rolling window> (<operations>))
+
+   aggregation method: the aggregation method to use to compute the rolling window.
+                       (mean, median, std, min, max, sum, var, count)
+   rolling window: number of previous values to aggregate
+
+
+aggregation across metrics::
+
+   aggregate <aggregation method> ((<operations>), (<operations>), ...))
+
+   aggregation method: the aggregation method to use to compute the aggregate between metrics
+                       (mean, median, std, min, max, sum, var, count)
+
+resampling metrics::
+
+   (resample <aggregation method> <granularity> (<operations>))
+
+   aggregation method: the aggregation method to use to compute the aggregate between metrics
+                       (mean, median, std, min, max, sum, var, count)
+
+   granularity: the granularity (e.g.: 1d, 60s, ...)
+
+math operations::
+
+   (<operator> <operations_or_float> <operations_or_float>)
+
+   operator: %, mod, +, add, -, sub, *, ×, mul, /, ÷, div, **, ^, pow
+
+boolean operations::
+
+   (<operator> <operations_or_float> <operations_or_float>)
+
+   operator: =, ==, eq, <, lt, >, gt, <=, ≤, le, =, ≥, ge, !=, ≠, ne
+
+function operations::
+
+   (abs (<operations>))
+   (absolute (<operations>))
+   (neg (<operations>))
+   (negative (<operations>))
+   (cos (<operations>))
+   (sin (<operations>))
+   (tan (<operations>))
+   (floor (<operations>))
+   (ceil (<operations>))
+
+
 .. _aggregation-across-metrics:
 
-Aggregation across metrics
-==========================
+Aggregation across metrics (deprecated)
+=======================================
 
-Gnocchi allows to do on-the-fly aggregation of already aggregated data of
+.. Note::
+
+   This API have been replaced by the more flexible :ref:`aggregates API <aggregates>`
+
+
+Gnocchi supports on-the-fly aggregation of previously aggregated data of
 |metrics|.
 
-It can also be done by providing the list of |metrics| to aggregate:
+It can be done by providing the list of |metrics| to aggregate:
 
 {{ scenarios['get-across-metrics-measures-by-metric-ids']['doc'] }}
 
@@ -604,19 +723,19 @@ is set.
 
 Gnocchi expects that we have a certain percent of timestamps common between
 time series. This percent is controlled by needed_overlap, which by default
-expects 100% overlap. If this percent is not reached, an error is returned.
+expects 100% overlap. If this percentage is not reached, an error is returned.
 
 .. note::
 
-   If a start and end boundary are not set, Gnocchi will set the missing
+   If `start` or `stop` boundary is not set, Gnocchi will set the missing
    boundary to the first or last timestamp common across all series.
 
-The ability to fill in points missing from a subset of time series is supported
-by specifying a `fill` value. Valid fill values include any valid float or
-`null` which will compute aggregation with only the points that exist. The
-`fill` parameter will not backfill timestamps which contain no points in any
-of the time series. Only timestamps which have datapoints in at least one of
-the time series is returned.
+The ability to fill in  missing points from a subset of time series is supported
+by specifying a `fill` value. Valid fill values include any float or `null`. In
+the case of `null`, Gnocchi will compute the aggregation using only the
+existing points. The `fill` parameter will not backfill timestamps which contain no
+points in any of the time series. Only timestamps which have datapoints in at
+least one of the time series is returned.
 
 .. note::
 

--- a/doc/source/rest.yaml
+++ b/doc/source/rest.yaml
@@ -773,6 +773,49 @@
 
     {"memory": {"archive_policy_name": "low"}}
 
+- name: get-aggregates-by-metric-ids
+  request: |
+    POST /v1/aggregates/fetch?start=2014-10-06T14:34&stop=2017-10-06T14:34 HTTP/1.1
+    Content-Type: application/json
+
+    {
+      "operations": [
+        "*",
+        ["aggregate", "mean", [
+            "metric",
+            ["{{ scenarios['create-resource-instance-with-metrics']['response'].json['metrics']['cpu.util'] }}", "mean"],
+            ["{{ scenarios['create-resource-instance-with-dynamic-metrics']['response'].json['metrics']['cpu.util'] }}", "mean"]
+        ]],
+        4
+      ]
+    }
+
+- name: get-aggregates-between-metrics
+  request: |
+    POST /v1/aggregates/fetch?start=2014-10-06T14:34&stop=2017-10-06T14:34 HTTP/1.1
+    Content-Type: application/json
+
+    {
+      "operations": [
+        "absolute",
+        [
+          "**",
+          ["metric", "{{ scenarios['create-resource-instance-with-metrics']['response'].json['metrics']['cpu.util'] }}", "mean"],
+          ["metric", "{{ scenarios['create-resource-instance-with-dynamic-metrics']['response'].json['metrics']['cpu.util'] }}", "mean"]
+        ]
+      ]
+    }
+
+
+- name: get-aggregates-by-metric-ids-fill
+  request: |
+    POST /v1/aggregates/fetch?fill=0&granularity=1 HTTP/1.1
+    Content-Type: application/json
+
+    {
+      "operations": "(* (aggregate mean (metric {{ scenarios['create-resource-instance-with-metrics']['response'].json['metrics']['cpu.util'] }} mean)) 4)"
+    }
+
 - name: get-capabilities
   request: GET /v1/capabilities HTTP/1.1
 

--- a/gnocchi/rest/aggregates/exceptions.py
+++ b/gnocchi/rest/aggregates/exceptions.py
@@ -1,0 +1,30 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright © 2016-2017 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+class UnAggregableTimeseries(Exception):
+    """Error raised when timeseries cannot be aggregated."""
+    def __init__(self, references, reason):
+        self.references = references
+        self.reason = reason
+        super(UnAggregableTimeseries, self).__init__(reason)
+
+    def jsonify(self):
+        return {
+            "cause": "Metrics can't being aggregated",
+            "reason": self.reason,
+            "detail": self.references
+        }

--- a/gnocchi/rest/aggregates/operations.py
+++ b/gnocchi/rest/aggregates/operations.py
@@ -14,9 +14,13 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import numbers
+
 import numpy
+from numpy.lib.stride_tricks import as_strided
 
 from gnocchi import carbonara
+from gnocchi.rest.aggregates import exceptions
 
 
 AGG_MAP = {
@@ -32,12 +36,161 @@ AGG_MAP = {
 }
 
 
-def handle_aggregate(agg, granularity, timestamps, values, is_aggregated):
+# TODO(sileht): expose all operators in capability API
+binary_operators = {
+    u"=": numpy.equal,
+    u"==": numpy.equal,
+    u"eq": numpy.equal,
+
+    u"<": numpy.less,
+    u"lt": numpy.less,
+
+    u">": numpy.greater,
+    u"gt": numpy.greater,
+
+    u"<=": numpy.less_equal,
+    u"≤": numpy.less_equal,
+    u"le": numpy.less_equal,
+
+    u">=": numpy.greater_equal,
+    u"≥": numpy.greater_equal,
+    u"ge": numpy.greater_equal,
+
+    u"!=": numpy.not_equal,
+    u"≠": numpy.not_equal,
+    u"ne": numpy.not_equal,
+
+    u"%": numpy.mod,
+    u"mod": numpy.mod,
+
+    u"+": numpy.add,
+    u"add": numpy.add,
+
+    u"-": numpy.subtract,
+    u"sub": numpy.subtract,
+
+    u"*": numpy.multiply,
+    u"×": numpy.multiply,
+    u"mul": numpy.multiply,
+
+    u"/": numpy.true_divide,
+    u"÷": numpy.true_divide,
+    u"div": numpy.true_divide,
+
+    u"**": numpy.power,
+    u"^": numpy.power,
+    u"pow": numpy.power,
+
+}
+
+# TODO(sileht): adds, numpy.around, but it take a decimal argument to handle
+unary_operators = {
+    u"abs": numpy.absolute,
+    u"absolute": numpy.absolute,
+
+    u"neg": numpy.negative,
+    u"negative": numpy.negative,
+
+    u"cos": numpy.cos,
+    u"sin": numpy.sin,
+    u"tan": numpy.tan,
+    u"floor": numpy.floor,
+    u"ceil": numpy.ceil,
+}
+
+
+def handle_unary_operator(nodes, granularity, timestamps, initial_values,
+                          is_aggregated, references):
+    op = nodes[0]
+    granularity, timestamps, values, is_aggregated = evaluate(
+        nodes[1], granularity, timestamps, initial_values,
+        is_aggregated, references)
+
+    values = unary_operators[op](values)
+    return granularity, timestamps, values, is_aggregated
+
+
+def handle_binary_operator(nodes, granularity, timestamps,
+                           initial_values, is_aggregated, references):
+    op = nodes[0]
+    g1, t1, v1, is_a1 = evaluate(nodes[1], granularity, timestamps,
+                                 initial_values, is_aggregated, references)
+    g2, t2, v2, is_a2 = evaluate(nodes[2], granularity, timestamps,
+                                 initial_values, is_aggregated, references)
+
+    is_aggregated = is_a1 or is_a2
+    # We keep the computed timeseries
+    if isinstance(v1, numpy.ndarray) and isinstance(v2, numpy.ndarray):
+        if not numpy.array_equal(t1, t2) or g1 != g2:
+            raise exceptions.UnAggregableTimeseries(
+                references,
+                "Can't compute timeseries with different "
+                "granularity %s <> %s" % (nodes[1], nodes[2]))
+        timestamps = t1
+        granularity = g1
+        is_aggregated = True
+
+    elif isinstance(v2, numpy.ndarray):
+        timestamps = t2
+        granularity = g2
+    else:
+        timestamps = t1
+        granularity = g1
+
+    values = binary_operators[op](v1, v2)
+    return granularity, timestamps, values, is_aggregated
+
+
+def handle_aggregate(agg, granularity, timestamps, values, is_aggregated,
+                     references):
     values = numpy.array([AGG_MAP[agg](values, axis=1)]).T
     if values.shape[1] != 1:
         raise RuntimeError("Unexpected resulting aggregated array shape: %s" %
                            values)
     return (granularity, timestamps, values, True)
+
+
+def handle_rolling(agg, granularity, timestamps, values, is_aggregated,
+                   references, window):
+    if window > len(values):
+        raise exceptions.UnAggregableTimeseries(
+            references,
+            "Rolling window '%d' is greater than serie length '%d'" %
+            (window, len(values))
+        )
+
+    # TODO(sileht): make a more optimised version that
+    # compute the data across the whole matrix
+    new_values = None
+    timestamps = timestamps[window - 1:]
+    for ts in values.T:
+        # arogozhnikov.github.io/2015/09/30/NumpyTipsAndTricks2.html
+        stride = ts.strides[0]
+        ts = AGG_MAP[agg](as_strided(
+            ts, shape=[len(ts) - window + 1, window],
+            strides=[stride, stride]), axis=1)
+        if new_values is None:
+            new_values = numpy.array([ts])
+        else:
+            new_values = numpy.append(new_values, [ts], axis=0)
+    return granularity, timestamps, new_values.T, is_aggregated
+
+
+def handle_resample(agg, granularity, timestamps, values, is_aggregated,
+                    references, sampling):
+    # TODO(sileht): make a more optimised version that
+    # compute the data across the whole matrix
+    new_values = None
+    result_timestamps = timestamps
+    for ts in values.T:
+        ts = carbonara.AggregatedTimeSerie.from_data(None, agg, timestamps, ts)
+        ts = ts.resample(sampling)
+        result_timestamps = ts["timestamps"]
+        if new_values is None:
+            new_values = numpy.array([ts["values"]])
+        else:
+            new_values = numpy.append(new_values, [ts["values"]], axis=0)
+    return sampling, result_timestamps, new_values.T, is_aggregated
 
 
 def handle_aggregation_operator(nodes, granularity, timestamps, initial_values,
@@ -46,25 +199,65 @@ def handle_aggregation_operator(nodes, granularity, timestamps, initial_values,
     agg = nodes[1]
     subnodes = nodes[-1]
     args = nodes[2:-1]
-    if agg not in AGG_MAP:
-        raise carbonara.UnknownAggregationMethod(agg)
     granularity, timestamps, values, is_aggregated = evaluate(
         subnodes, granularity, timestamps, initial_values,
         is_aggregated, references)
-    return op(agg, granularity, timestamps, values, is_aggregated, *args)
+    return op(agg, granularity, timestamps, values, is_aggregated,
+              references, *args)
 
 
 aggregation_operators = {
     u"aggregate": handle_aggregate,
+    u"rolling": handle_rolling,
+    u"resample": handle_resample,
 }
 
 
+def sanity_check(method):
+    # NOTE(sileht): This is important checks, because caller may use zip and
+    # build an incomplete timeseries without we notice the result is
+    # unexpected.
+
+    def inner(*args, **kwargs):
+        granularity, timestamps, values, is_aggregated = method(
+            *args, **kwargs)
+
+        t_len = len(timestamps)
+        if t_len > 2 and not ((timestamps[1] - timestamps[0]) /
+                              granularity).is_integer():
+            # NOTE(sileht): numpy.mod is not possible with timedelta64,
+            # we don't really care about the remainder value, instead we just
+            # check we don't have remainder, by using floor_divide and checking
+            # the result is an integer.
+            raise RuntimeError("timestamps and granularity doesn't match: "
+                               "%s vs %s" % (timestamps[1] - timestamps[0],
+                                             granularity))
+
+        elif isinstance(values, numpy.ndarray) and t_len != len(values):
+            raise RuntimeError("timestamps and values length are different: "
+                               "%s vs %s" % (t_len, len(values)))
+
+        return granularity, timestamps, values, is_aggregated
+    return inner
+
+
+@sanity_check
 def evaluate(nodes, granularity, timestamps, initial_values, is_aggregated,
              references):
-    if nodes[0] in aggregation_operators:
+    if isinstance(nodes, numbers.Number):
+        return granularity, timestamps, nodes, is_aggregated
+    elif nodes[0] in aggregation_operators:
         return handle_aggregation_operator(nodes, granularity, timestamps,
                                            initial_values, is_aggregated,
                                            references)
+    elif nodes[0] in binary_operators:
+        return handle_binary_operator(nodes, granularity, timestamps,
+                                      initial_values, is_aggregated,
+                                      references)
+    elif nodes[0] in unary_operators:
+        return handle_unary_operator(nodes, granularity, timestamps,
+                                     initial_values, is_aggregated,
+                                     references)
     elif nodes[0] == "metric":
         if isinstance(nodes[1], list):
             predicat = lambda r: r in nodes[1:]

--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -37,6 +37,7 @@ from gnocchi import incoming
 from gnocchi import indexer
 from gnocchi import json
 from gnocchi import resource_type
+from gnocchi.rest.aggregates import exceptions
 from gnocchi.rest.aggregates import processor
 from gnocchi import storage
 from gnocchi import utils
@@ -1790,7 +1791,7 @@ class AggregationController(rest.RestController):
                 operations, start, stop,
                 granularity, needed_overlap, fill,
                 resample)["aggregated"]
-        except processor.UnAggregableTimeseries as e:
+        except exceptions.UnAggregableTimeseries as e:
             abort(400, e)
         except (storage.MetricDoesNotExist,
                 storage.GranularityDoesNotExist,

--- a/gnocchi/tests/functional/gabbits/aggregates-fetch.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregates-fetch.yaml
@@ -170,6 +170,112 @@ tests:
           - ["2015-03-06T14:34:00+00:00", 60.0, 4.0]
           - ["2015-03-06T14:35:00+00:00", 60.0, 10.0]
 
+    - name: get aggregates simple with array
+      POST: /v1/aggregates/fetch
+      data:
+        operations: ["+", ["metric", ["$HISTORY['create metric1'].$RESPONSE['$.id']", "mean"], ["$HISTORY['create metric2'].$RESPONSE['$.id']", "mean"]], 2.0]
+      response_json_paths:
+        $.`len`: 2
+        $."$HISTORY['create metric1'].$RESPONSE['$.id']_mean":
+          - ["2015-03-06T14:33:00+00:00", 60.0, 45.1]
+          - ["2015-03-06T14:34:00+00:00", 60.0, 0.0]
+          - ["2015-03-06T14:35:00+00:00", 60.0, 12.0]
+          - ["2015-03-06T14:33:57+00:00", 1.0, 45.1]
+          - ["2015-03-06T14:34:12+00:00", 1.0, 14.0]
+          - ["2015-03-06T14:34:15+00:00", 1.0, -14.0]
+          - ["2015-03-06T14:35:12+00:00", 1.0, 11.0]
+          - ["2015-03-06T14:35:15+00:00", 1.0, 13.0]
+        $."$HISTORY['create metric2'].$RESPONSE['$.id']_mean":
+          - ["2015-03-06T14:33:00+00:00", 60.0, 4.0]
+          - ["2015-03-06T14:34:00+00:00", 60.0, 6.5]
+          - ["2015-03-06T14:35:00+00:00", 60.0, 14.5]
+          - ["2015-03-06T14:33:57+00:00", 1.0, 4.0]
+          - ["2015-03-06T14:34:12+00:00", 1.0, 6.0]
+          - ["2015-03-06T14:34:15+00:00", 1.0, 7.0]
+          - ["2015-03-06T14:35:12+00:00", 1.0, 12.0]
+          - ["2015-03-06T14:35:15+00:00", 1.0, 17.0]
+
+    - name: get aggregates resample
+      POST: /v1/aggregates/fetch?granularity=1
+      data:
+        operations:
+          - resample
+          - mean
+          - 60
+          - ["metric", ["$HISTORY['create metric1'].$RESPONSE['$.id']", "mean"], ["$HISTORY['create metric2'].$RESPONSE['$.id']", "mean"]]
+      response_json_paths:
+        $.`len`: 2
+        $."$HISTORY['create metric1'].$RESPONSE['$.id']_mean":
+          - ["2015-03-06T14:33:00+00:00", 60.0, 43.1]
+          - ["2015-03-06T14:34:00+00:00", 60.0, -2.0]
+          - ["2015-03-06T14:35:00+00:00", 60.0, 10.0]
+        $."$HISTORY['create metric2'].$RESPONSE['$.id']_mean":
+          - ["2015-03-06T14:33:00+00:00", 60.0, 2.0]
+          - ["2015-03-06T14:34:00+00:00", 60.0, 4.5]
+          - ["2015-03-06T14:35:00+00:00", 60.0, 12.5]
+
+    - name: get aggregates rolling
+      POST: /v1/aggregates/fetch?granularity=1
+      data:
+        operations:
+          - rolling
+          - mean
+          - 2
+          - ["metric", ["$HISTORY['create metric1'].$RESPONSE['$.id']", "mean"], ["$HISTORY['create metric2'].$RESPONSE['$.id']", "mean"]]
+      response_json_paths:
+        $.`len`: 2
+        $."$HISTORY['create metric1'].$RESPONSE['$.id']_mean":
+          - ["2015-03-06T14:34:12+00:00", 1.0, 27.55]
+          - ["2015-03-06T14:34:15+00:00", 1.0, -2.0]
+          - ["2015-03-06T14:35:12+00:00", 1.0, -3.5]
+          - ["2015-03-06T14:35:15+00:00", 1.0, 10.0]
+        $."$HISTORY['create metric2'].$RESPONSE['$.id']_mean":
+          - ["2015-03-06T14:34:12+00:00", 1.0, 3.0]
+          - ["2015-03-06T14:34:15+00:00", 1.0, 4.5]
+          - ["2015-03-06T14:35:12+00:00", 1.0, 7.5]
+          - ["2015-03-06T14:35:15+00:00", 1.0, 12.5]
+
+    - name: get aggregates math with string
+      POST: /v1/aggregates/fetch
+      data:
+        operations: "(+ (metric ($HISTORY['create metric1'].$RESPONSE['$.id'] mean) ($HISTORY['create metric2'].$RESPONSE['$.id'] mean)) 2.0)"
+      response_json_paths:
+        $.`len`: 2
+        $."$HISTORY['create metric1'].$RESPONSE['$.id']_mean":
+          - ["2015-03-06T14:33:00+00:00", 60.0, 45.1]
+          - ["2015-03-06T14:34:00+00:00", 60.0, 0.0]
+          - ["2015-03-06T14:35:00+00:00", 60.0, 12.0]
+          - ["2015-03-06T14:33:57+00:00", 1.0, 45.1]
+          - ["2015-03-06T14:34:12+00:00", 1.0, 14.0]
+          - ["2015-03-06T14:34:15+00:00", 1.0, -14.0]
+          - ["2015-03-06T14:35:12+00:00", 1.0, 11.0]
+          - ["2015-03-06T14:35:15+00:00", 1.0, 13.0]
+        $."$HISTORY['create metric2'].$RESPONSE['$.id']_mean":
+          - ["2015-03-06T14:33:00+00:00", 60.0, 4.0]
+          - ["2015-03-06T14:34:00+00:00", 60.0, 6.5]
+          - ["2015-03-06T14:35:00+00:00", 60.0, 14.5]
+          - ["2015-03-06T14:33:57+00:00", 1.0, 4.0]
+          - ["2015-03-06T14:34:12+00:00", 1.0, 6.0]
+          - ["2015-03-06T14:34:15+00:00", 1.0, 7.0]
+          - ["2015-03-06T14:35:12+00:00", 1.0, 12.0]
+          - ["2015-03-06T14:35:15+00:00", 1.0, 17.0]
+
+    - name: get aggregates substact
+      POST: /v1/aggregates/fetch
+      data:
+        operations: "(- (metric $HISTORY['create metric1'].$RESPONSE['$.id'] mean) (metric $HISTORY['create metric2'].$RESPONSE['$.id'] mean)))"
+      response_json_paths:
+        $.`len`: 1
+        $."aggregated":
+          - ["2015-03-06T14:33:00+00:00", 60.0, 41.1]
+          - ["2015-03-06T14:34:00+00:00", 60.0, -6.5]
+          - ["2015-03-06T14:35:00+00:00", 60.0, -2.5]
+          - ["2015-03-06T14:33:57+00:00", 1.0, 41.1]
+          - ["2015-03-06T14:34:12+00:00", 1.0, 8.0]
+          - ["2015-03-06T14:34:15+00:00", 1.0, -21.0]
+          - ["2015-03-06T14:35:12+00:00", 1.0, -1.0]
+          - ["2015-03-06T14:35:15+00:00", 1.0, -4.0]
+
     - name: get aggregates mean aggregate
       POST: /v1/aggregates/fetch
       data:
@@ -186,6 +292,22 @@ tests:
           - ["2015-03-06T14:35:12+00:00", 1.0, 9.5]
           - ["2015-03-06T14:35:15+00:00", 1.0, 13.0]
 
+    - name: get aggregates negative absolute
+      POST: /v1/aggregates/fetch
+      data:
+        operations: "(negative (absolute (aggregate mean (metric ($HISTORY['create metric1'].$RESPONSE['$.id'] mean) ($HISTORY['create metric2'].$RESPONSE['$.id'] mean)))))"
+      response_json_paths:
+        $.`len`: 1
+        $."aggregated":
+          - ["2015-03-06T14:33:00+00:00", 60.0, -22.55]
+          - ["2015-03-06T14:34:00+00:00", 60.0, -1.25]
+          - ["2015-03-06T14:35:00+00:00", 60.0, -11.25]
+          - ["2015-03-06T14:33:57+00:00", 1.0, -22.55]
+          - ["2015-03-06T14:34:12+00:00", 1.0, -8.0]
+          - ["2015-03-06T14:34:15+00:00", 1.0, -5.5]
+          - ["2015-03-06T14:35:12+00:00", 1.0, -9.5]
+          - ["2015-03-06T14:35:15+00:00", 1.0, -13.0]
+
 # Negative tests
 
     - name: get no operations
@@ -198,7 +320,20 @@ tests:
         operations: []
       status: 400
       response_strings:
-        - "'metric' is invalid"
+        - "Invalid input: Operation must not be empty"
+
+    - name: get operations without list
+      POST: /v1/aggregates/fetch
+      request_headers:
+        accept: application/json
+        content-type: application/json
+        authorization: "basic Zm9vYmFyOg=="
+      data:
+        operations:
+          foo: bar
+      status: 400
+      response_strings:
+        - "Invalid input: Expected a tuple/list, got a "
 
     - name: invalid operations string
       POST: /v1/aggregates/fetch
@@ -225,7 +360,7 @@ tests:
         operations: ["metric"]
       status: 400
       response_strings:
-        - "'metric' is invalid"
+        - "Invalid input: Operation need at least one argument for dictionary value"
 
     - name: get unknown metrics
       POST: /v1/aggregates/fetch
@@ -395,3 +530,51 @@ tests:
         $.description.cause: "Argument value error"
         $.description.detail: "fill"
         $.description.reason: "Must be a float or 'null', got 'foobar'"
+
+    - name: get rolling bad aggregate
+      POST: /v1/aggregates/fetch
+      request_headers:
+        accept: application/json
+        content-type: application/json
+        authorization: "basic Zm9vYmFyOg=="
+      data:
+        operations: "(rolling blah 2 (metric $HISTORY['create metric1'].$RESPONSE['$.id'] mean))"
+      status: 400
+      response_strings:
+        - "Invalid input: 'rolling' operation invalid for dictionary value"
+
+    - name: get rolling-mean missing window
+      POST: /v1/aggregates/fetch
+      request_headers:
+        accept: application/json
+        content-type: application/json
+        authorization: "basic Zm9vYmFyOg=="
+      data:
+        operations: "(rolling mean (metric $HISTORY['create metric1'].$RESPONSE['$.id'] mean))"
+      status: 400
+      response_strings:
+        - "Invalid input: 'rolling' operation invalid for dictionary value"
+
+    - name: get measurements from metric and invalid operations
+      POST: /v1/aggregates/fetch
+      request_headers:
+        accept: application/json
+        content-type: application/json
+        authorization: "basic Zm9vYmFyOg=="
+      data:
+        operations: "(notexist (absolute (metric $HISTORY['create metric1'].$RESPONSE['$.id'] mean)))"
+      status: 400
+      response_strings:
+        - "Invalid input: 'notexist' operation invalid for dictionary value"
+
+    - name: invalid resample
+      POST: /v1/aggregates/fetch
+      request_headers:
+        accept: application/json
+        content-type: application/json
+        authorization: "basic Zm9vYmFyOg=="
+      data:
+        operations: "(resample mean invalid (metric ($HISTORY['create metric1'].$RESPONSE['$.id'] mean) ($HISTORY['create metric2'].$RESPONSE['$.id'] mean)))"
+      status: 400
+      response_strings:
+        - "Invalid input: 'resample' operation invalid for dictionary value"

--- a/gnocchi/tests/functional/gabbits/aggregation.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregation.yaml
@@ -131,6 +131,15 @@ tests:
           - ['2015-03-06T14:33:00+00:00', 60.0, 23.1]
           - ['2015-03-06T14:34:00+00:00', 60.0, 7.0]
 
+    - name: get measure aggregates and operations
+      POST: /v1/aggregates/fetch?granularity=1
+      data:
+        operations: "(aggregate mean (resample mean 60 (metric ($HISTORY['get metric list'].$RESPONSE['$[0].id'] mean) ($HISTORY['get metric list'].$RESPONSE['$[1].id'] mean))))"
+      response_json_paths:
+        $.aggregated:
+          - ['2015-03-06T14:33:00+00:00', 60.0, 23.1]
+          - ['2015-03-06T14:34:00+00:00', 60.0, 7.0]
+
     - name: get measure aggregates with fill zero
       GET: /v1/aggregation/metric?metric=$HISTORY['get metric list'].$RESPONSE['$[0].id']&metric=$HISTORY['get metric list'].$RESPONSE['$[1].id']&granularity=1&fill=0
       response_json_paths:

--- a/gnocchi/tests/functional/gabbits/metric.yaml
+++ b/gnocchi/tests/functional/gabbits/metric.yaml
@@ -213,6 +213,16 @@ tests:
           - ["2015-03-06T14:34:00+00:00", 60.0, 14.0]
           - ["2015-03-06T14:35:00+00:00", 60.0, 10.0]
 
+    - name: get measurements from metric and resample and negative
+      POST: /v1/aggregates/fetch?granularity=1
+      data:
+        operations: "(negative (resample mean 60 (metric $HISTORY['list valid metrics'].$RESPONSE['$[0].id'] mean)))"
+      response_json_paths:
+        $."$HISTORY['list valid metrics'].$RESPONSE['$[0].id']_mean":
+          - ["2015-03-06T14:33:00+00:00", 60.0, -43.1]
+          - ["2015-03-06T14:34:00+00:00", 60.0, -14.0]
+          - ["2015-03-06T14:35:00+00:00", 60.0, -10.0]
+
     - name: push negative measurements to metric again
       POST: /v1/metric/$HISTORY['list valid metrics'].$RESPONSE['$[0].id']/measures
       data:
@@ -221,6 +231,57 @@ tests:
           - timestamp: "2015-03-06T14:37:15"
             value: -23
       status: 202
+
+    - name: refresh metric
+      GET: /v1/metric/$HISTORY['list valid metrics'].$RESPONSE['$[0].id']/measures?refresh=true
+
+    - name: get absolute measurements from metric
+      POST: /v1/aggregates/fetch
+      data:
+        operations: "(absolute (metric $HISTORY['list valid metrics'].$RESPONSE['$[0].id'] mean))"
+      response_json_paths:
+        $."$HISTORY['list valid metrics'].$RESPONSE['$[0].id']_mean":
+          - ["2015-03-06T14:33:57+00:00", 1.0, 43.1]
+          - ["2015-03-06T14:34:12+00:00", 1.0, 12.0]
+          - ["2015-03-06T14:34:15+00:00", 1.0, 16.0]
+          - ["2015-03-06T14:35:12+00:00", 1.0, 9.0]
+          - ["2015-03-06T14:35:15+00:00", 1.0, 11.0]
+          - ["2015-03-06T14:36:15+00:00", 1.0, 16.0]
+          - ["2015-03-06T14:37:15+00:00", 1.0, 23.0]
+
+    - name: rolling-mean
+      POST: /v1/aggregates/fetch
+      data:
+        operations: "(rolling mean 2 (metric $HISTORY['list valid metrics'].$RESPONSE['$[0].id'] mean))"
+      status: 200
+      response_json_paths:
+        $."$HISTORY['list valid metrics'].$RESPONSE['$[0].id']_mean":
+          - ["2015-03-06T14:34:12+00:00", 1.0, 27.55]
+          - ["2015-03-06T14:34:15+00:00", 1.0, 14.0]
+          - ["2015-03-06T14:35:12+00:00", 1.0, 12.5]
+          - ["2015-03-06T14:35:15+00:00", 1.0, 10.0]
+          - ["2015-03-06T14:36:15+00:00", 1.0, -2.5]
+          - ["2015-03-06T14:37:15+00:00", 1.0, -19.5]
+
+    - name: get measurements from metric and two operations
+      POST: /v1/aggregates/fetch
+      data:
+        operations: "(negative (absolute (metric $HISTORY['list valid metrics'].$RESPONSE['$[0].id'] mean)))"
+      response_json_paths:
+        $."$HISTORY['list valid metrics'].$RESPONSE['$[0].id']_mean":
+          - ["2015-03-06T14:33:57+00:00", 1.0, -43.1]
+          - ["2015-03-06T14:34:12+00:00", 1.0, -12.0]
+          - ["2015-03-06T14:34:15+00:00", 1.0, -16.0]
+          - ["2015-03-06T14:35:12+00:00", 1.0, -9.0]
+          - ["2015-03-06T14:35:15+00:00", 1.0, -11.0]
+          - ["2015-03-06T14:36:15+00:00", 1.0, -16.0]
+          - ["2015-03-06T14:37:15+00:00", 1.0, -23.0]
+
+    - name: get measurements from metric and invalid operations
+      POST: /v1/aggregates/fetch
+      data:
+        operations: "(notexist (absolute (metric $HISTORY['list valid metrics'].$RESPONSE['$[0].id'] mean)))"
+      status: 400
 
     - name: get measurements from metric and resample no granularity
       GET: /v1/metric/$HISTORY['list valid metrics'].$RESPONSE['$[0].id']/measures?resample=60

--- a/releasenotes/notes/aggregates-API-d31db66e674cbf60.yaml
+++ b/releasenotes/notes/aggregates-API-d31db66e674cbf60.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    New API endpoint allows to retrieve, transform, aggregates measurements on the
+    fly in an flexible way. The endpoint location is `/v1/aggregates/fetch`.
+    This endpoint allows to describe `operations` to be done on a metrics
+    list. Example: `(* 5  (rolling mean 3 (aggregate sum (metric (metric1 mean)
+    (metric2 mean)))))`. More details are available in the documentation.


### PR DESCRIPTION
This changes implements the following operations for the aggregates API:
- rolling <agg> <window>
- resample <agg> <granularity>
- math (*/+-%...)
- abosolute/negative

It also re-add transformation tests related to metrics endpoint
but with new aggregates API.

Related #419