### PR TITLE
storage: do not create coordinator oneself

### DIFF
--- a/gnocchi/cli/manage.py
+++ b/gnocchi/cli/manage.py
@@ -61,7 +61,10 @@ def upgrade():
         LOG.info("Upgrading indexer %s", index)
         index.upgrade()
     if not conf.skip_storage:
-        s = storage.get_driver(conf)
+        # FIXME(jd) Pass None as coordinator because it's not needed in this
+        # case. This will be removed when the storage will stop requiring a
+        # coordinator object.
+        s = storage.get_driver(conf, None)
         LOG.info("Upgrading storage %s", s)
         s.upgrade()
     if not conf.skip_incoming:

--- a/gnocchi/rest/app.py
+++ b/gnocchi/rest/app.py
@@ -26,12 +26,12 @@ from pecan import jsonify
 from stevedore import driver
 import webob.exc
 
+from gnocchi.cli import metricd
 from gnocchi import exceptions
 from gnocchi import incoming as gnocchi_incoming
 from gnocchi import indexer as gnocchi_indexer
 from gnocchi import json
 from gnocchi import storage as gnocchi_storage
-from gnocchi import utils
 
 
 LOG = daiquiri.getLogger(__name__)
@@ -93,7 +93,7 @@ def load_app(conf, indexer=None, storage=None, incoming=None, coord=None,
             # NOTE(jd) This coordinator is never stop. I don't think it's a
             # real problem since the Web app can never really be stopped
             # anyway, except by quitting it entirely.
-            coord = utils.get_coordinator_and_start(
+            coord = metricd.get_coordinator_and_start(
                 conf.storage.coordination_url)
         storage = gnocchi_storage.get_driver(conf, coord)
     if not incoming:

--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -111,7 +111,7 @@ class SackLockTimeoutError(StorageError):
         pass
 
 
-def get_driver(conf, coord=None):
+def get_driver(conf, coord):
     """Return the configured driver."""
     return utils.get_driver_class('gnocchi.storage', conf.storage)(
         conf.storage, coord)
@@ -119,14 +119,8 @@ def get_driver(conf, coord=None):
 
 class StorageDriver(object):
 
-    def __init__(self, conf, coord=None):
-        self.coord = (coord if coord else
-                      utils.get_coordinator_and_start(conf.coordination_url))
-        self.shared_coord = bool(coord)
-
-    def stop(self):
-        if not self.shared_coord:
-            self.coord.stop()
+    def __init__(self, conf, coord):
+        self.coord = coord
 
     @staticmethod
     def upgrade():

--- a/gnocchi/tests/base.py
+++ b/gnocchi/tests/base.py
@@ -33,13 +33,13 @@ except ImportError:
 from testtools import testcase
 
 from gnocchi import archive_policy
+from gnocchi.cli import metricd
 from gnocchi import exceptions
 from gnocchi import incoming
 from gnocchi import indexer
 from gnocchi import service
 from gnocchi import storage
 from gnocchi.tests import utils
-from gnocchi import utils as g_utils
 
 
 class SkipNotImplementedMeta(type):
@@ -300,7 +300,7 @@ class TestCase(BaseTestCase):
 
         self.index = indexer.get_driver(self.conf)
 
-        self.coord = g_utils.get_coordinator_and_start(
+        self.coord = metricd.get_coordinator_and_start(
             self.conf.storage.coordination_url)
 
         # NOTE(jd) So, some driver, at least SQLAlchemy, can't create all

--- a/gnocchi/tests/base.py
+++ b/gnocchi/tests/base.py
@@ -31,7 +31,6 @@ try:
 except ImportError:
     swexc = None
 from testtools import testcase
-from tooz import coordination
 
 from gnocchi import archive_policy
 from gnocchi import exceptions
@@ -40,6 +39,7 @@ from gnocchi import indexer
 from gnocchi import service
 from gnocchi import storage
 from gnocchi.tests import utils
+from gnocchi import utils as g_utils
 
 
 class SkipNotImplementedMeta(type):
@@ -300,21 +300,16 @@ class TestCase(BaseTestCase):
 
         self.index = indexer.get_driver(self.conf)
 
+        self.coord = g_utils.get_coordinator_and_start(
+            self.conf.storage.coordination_url)
+
         # NOTE(jd) So, some driver, at least SQLAlchemy, can't create all
         # their tables in a single transaction even with the
         # checkfirst=True, so what we do here is we force the upgrade code
         # path to be sequential to avoid race conditions as the tests run
         # in parallel.
-        self.coord = coordination.get_coordinator(
-            self.conf.storage.coordination_url,
-            str(uuid.uuid4()).encode('ascii'))
-
-        self.coord.start(start_heart=True)
-
         with self.coord.get_lock(b"gnocchi-tests-db-lock"):
             self.index.upgrade()
-
-        self.coord.stop()
 
         self.archive_policies = self.ARCHIVE_POLICIES.copy()
         for name, ap in six.iteritems(self.archive_policies):
@@ -356,7 +351,7 @@ class TestCase(BaseTestCase):
         self.conf.set_override("s3_bucket_prefix", str(uuid.uuid4())[:26],
                                "storage")
 
-        self.storage = storage.get_driver(self.conf)
+        self.storage = storage.get_driver(self.conf, self.coord)
         self.incoming = incoming.get_driver(self.conf)
 
         if self.conf.storage.driver == 'redis':
@@ -371,8 +366,12 @@ class TestCase(BaseTestCase):
 
     def tearDown(self):
         self.index.disconnect()
-        self.storage.stop()
         super(TestCase, self).tearDown()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.coord.stop()
+        super(TestCase, cls).tearDownClass()
 
     def _create_metric(self, archive_policy_name="low"):
         """Create a metric and return it"""

--- a/gnocchi/tests/functional/fixtures.py
+++ b/gnocchi/tests/functional/fixtures.py
@@ -28,6 +28,7 @@ from oslo_config import cfg
 from oslo_middleware import cors
 import sqlalchemy_utils
 
+from gnocchi.cli import metricd
 from gnocchi import incoming
 from gnocchi import indexer
 from gnocchi.indexer import sqlalchemy
@@ -36,7 +37,6 @@ from gnocchi import service
 from gnocchi import storage
 from gnocchi.tests import base
 from gnocchi.tests import utils
-from gnocchi import utils as g_utils
 
 # NOTE(chdent): Hack to restore semblance of global configuration to
 # pass to the WSGI app used per test suite. LOAD_APP_KWARGS are the olso
@@ -127,7 +127,7 @@ class ConfigFixture(fixture.GabbiFixture):
 
         self.index = index
 
-        self.coord = g_utils.get_coordinator_and_start(
+        self.coord = metricd.get_coordinator_and_start(
             conf.storage.coordination_url)
         s = storage.get_driver(conf, self.coord)
         s.upgrade()

--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -45,7 +45,7 @@ class TestStorageDriver(tests_base.TestCase):
         self.metric, __ = self._create_metric()
 
     def test_driver_str(self):
-        driver = storage.get_driver(self.conf)
+        driver = storage.get_driver(self.conf, None)
 
         if isinstance(driver, file.FileStorage):
             s = driver.basepath
@@ -62,7 +62,7 @@ class TestStorageDriver(tests_base.TestCase):
                          driver.__class__.__name__, s))
 
     def test_get_driver(self):
-        driver = storage.get_driver(self.conf)
+        driver = storage.get_driver(self.conf, None)
         self.assertIsInstance(driver, storage.StorageDriver)
 
     def test_corrupted_data(self):

--- a/gnocchi/utils.py
+++ b/gnocchi/utils.py
@@ -30,7 +30,6 @@ import numpy
 import pytimeparse
 import six
 from stevedore import driver
-from tooz import coordination
 
 
 LOG = daiquiri.getLogger(__name__)
@@ -69,12 +68,6 @@ def UUID(value):
         return uuid.UUID(value)
     except Exception as e:
         raise ValueError(e)
-
-
-def get_coordinator_and_start(url):
-    coord = coordination.get_coordinator(url, str(uuid.uuid4()).encode())
-    coord.start(start_heart=True)
-    return coord
 
 
 unix_universal_start64 = numpy.datetime64("1970")


### PR DESCRIPTION
This forces the storage driver to receive a coordinator as parameter.