### PR TITLE
Allow to rename archive policies

### DIFF
--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -242,6 +242,15 @@ not retroactively calculated as backfill to accommodate the new |timespan|:
    |Granularities| cannot be changed to a different rate. Also, |granularities|
    cannot be added or dropped from a policy.
 
+Existing |archive policies| can be renamed:
+
+{{ scenarios['rename-archive-policy']['doc'] }}
+
+.. note::
+
+    The `name` and `definition` parameters can both be specified to update and
+    rename an |archive policy| within the same PATCH request.
+
 It is possible to delete an |archive policy| if it is not used by any |metric|:
 
 {{ scenarios['delete-archive-policy']['doc'] }}

--- a/doc/source/rest.yaml
+++ b/doc/source/rest.yaml
@@ -63,6 +63,35 @@
       ]
     }
 
+- name: create-archive-policy-to-rename
+  request: |
+    POST /v1/archive_policy HTTP/1.1
+    Content-Type: application/json
+
+    {
+      "name": "very-short",
+      "back_window": 0,
+      "definition": [
+        {
+          "granularity": "0.001s",
+          "timespan": "1 hour"
+        },
+        {
+          "points": 48,
+          "timespan": "1 day"
+        }
+      ]
+    }
+
+- name: rename-archive-policy
+  request: |
+    PATCH /v1/archive_policy/{{ scenarios['create-archive-policy-to-rename']['response'].json['name'] }} HTTP/1.1
+    Content-Type: application/json
+
+    {
+      "name": "not-so-short"
+    }
+
 - name: create-archive-policy-to-delete
   request: |
     POST /v1/archive_policy HTTP/1.1

--- a/gnocchi/archive_policy.py
+++ b/gnocchi/archive_policy.py
@@ -17,6 +17,7 @@
 import collections
 import datetime
 import operator
+import uuid
 
 import numpy
 from oslo_config import cfg
@@ -52,7 +53,8 @@ class ArchivePolicy(object):
                 VALID_AGGREGATION_METHODS)))
 
     def __init__(self, name, back_window, definition,
-                 aggregation_methods=None):
+                 aggregation_methods=None, id=None):
+        self.id = id or uuid.uuid4()
         self.name = name
         self.back_window = back_window
         self.definition = []
@@ -119,14 +121,16 @@ class ArchivePolicy(object):
         return cls(d['name'],
                    d['back_window'],
                    d['definition'],
-                   d.get('aggregation_methods'))
+                   d.get('aggregation_methods'),
+                   d.get('id'))
 
     def __eq__(self, other):
         return (isinstance(other, ArchivePolicy)
                 and self.name == other.name
                 and self.back_window == other.back_window
                 and self.definition == other.definition
-                and self.aggregation_methods == other.aggregation_methods)
+                and self.aggregation_methods == other.aggregation_methods
+                and self.id == other.id)
 
     def jsonify(self):
         return {
@@ -134,6 +138,7 @@ class ArchivePolicy(object):
             "back_window": self.back_window,
             "definition": self.definition,
             "aggregation_methods": self.aggregation_methods,
+            "id": self.id
         }
 
     @property

--- a/gnocchi/indexer/__init__.py
+++ b/gnocchi/indexer/__init__.py
@@ -416,7 +416,7 @@ class IndexerDriver(object):
         rules = self.list_archive_policy_rules()
         for rule in rules:
             if fnmatch.fnmatch(metric_name or "", rule.metric_pattern):
-                return self.get_archive_policy(rule.archive_policy_name)
+                return self.get_archive_policy(id=rule.archive_policy_id)
         raise NoArchivePolicyRuleMatch(metric_name)
 
     @staticmethod

--- a/gnocchi/indexer/alembic/versions/71cfe62bcf98_use_an_id_as_primary_key_for_archive_.py
+++ b/gnocchi/indexer/alembic/versions/71cfe62bcf98_use_an_id_as_primary_key_for_archive_.py
@@ -1,0 +1,147 @@
+# Copyright 2017 The Gnocchi Developers
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+"""Use an id as primary key for archive policy
+
+Revision ID: 71cfe62bcf98
+Revises: 1e1a63d3d186
+Create Date: 2017-09-24 19:46:22.660503
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+import sqlalchemy_utils
+import uuid
+
+
+# revision identifiers, used by Alembic.
+revision = '71cfe62bcf98'
+down_revision = '1e1a63d3d186'
+branch_labels = None
+depends_on = None
+
+archive_policy_helper = sa.Table(
+    'archive_policy',
+    sa.MetaData(),
+    sa.Column('id', sqlalchemy_utils.types.uuid.UUIDType(binary=True),
+              primary_key=True),
+    sa.Column('name', sa.String(length=255), nullable=False, unique=True),
+)
+
+metric_helper = sa.Table(
+    'metric',
+    sa.MetaData(),
+    sa.Column('archive_policy_id',
+              sqlalchemy_utils.types.uuid.UUIDType(binary=True)),
+    sa.Column('archive_policy_name', sa.String(length=255), nullable=False),
+)
+
+apr_helper = sa.Table(
+    'archive_policy_rule',
+    sa.MetaData(),
+    sa.Column('archive_policy_id',
+              sqlalchemy_utils.types.uuid.UUIDType(binary=True)),
+    sa.Column('archive_policy_name', sa.String(length=255), nullable=False),
+)
+
+
+def upgrade():
+    connection = op.get_bind()
+    op.add_column('archive_policy',
+                  sa.Column('id',
+                            sqlalchemy_utils.types.uuid.UUIDType(
+                                binary=True),
+                            nullable=True))
+    op.add_column('metric',
+                  sa.Column('archive_policy_id',
+                            sqlalchemy_utils.types.uuid.UUIDType(
+                                binary=True),
+                            nullable=True))
+    op.add_column('archive_policy_rule',
+                  sa.Column('archive_policy_id',
+                            sqlalchemy_utils.types.uuid.UUIDType(
+                                binary=True),
+                            nullable=True))
+
+    # Migrate data
+    for archive_policy in connection.execute(
+            archive_policy_helper.select()):
+        ap_id = uuid.uuid4()
+        connection.execute(
+            archive_policy_helper.update().where(
+                archive_policy_helper.c.name == archive_policy.name
+            ).values(
+                id=ap_id
+            )
+        )
+        for metric in connection.execute(metric_helper.select().where(
+                metric_helper.c.archive_policy_name == archive_policy.name)):
+            connection.execute(
+                metric_helper.update().where(
+                    metric_helper.c.archive_policy_name ==
+                    metric.archive_policy_name
+                ).values(
+                    archive_policy_id=ap_id
+                )
+            )
+        for apr in connection.execute(apr_helper.select().where(
+                apr_helper.c.archive_policy_name == archive_policy.name)):
+            connection.execute(
+                apr_helper.update().where(
+                    apr_helper.c.archive_policy_name == apr.archive_policy_name
+                ).values(
+                    archive_policy_id=ap_id
+                )
+            )
+    op.alter_column('archive_policy', 'id', nullable=False,
+                    type_=sqlalchemy_utils.types.uuid.UUIDType(binary=True))
+    op.alter_column('metric', 'archive_policy_id', nullable=False,
+                    type_=sqlalchemy_utils.types.uuid.UUIDType(binary=True))
+    op.alter_column('archive_policy_rule', 'archive_policy_id', nullable=False,
+                    type_=sqlalchemy_utils.types.uuid.UUIDType(binary=True))
+
+    op.drop_constraint('fk_metric_ap_name_ap_name', 'metric',
+                       type_='foreignkey')
+    op.drop_constraint('fk_apr_ap_name_ap_name', 'archive_policy_rule',
+                       type_='foreignkey')
+    if connection and connection.engine.name == "mysql":
+        op.drop_constraint('PRIMARY', 'archive_policy', type_='primary')
+        # FIXME(0livd) When recreating a primary key named PRIMARY
+        # the following error is raised "Incorrect index name 'PRIMARY'"
+        op.create_primary_key('archive_policy_pkey', 'archive_policy', ['id'])
+    if connection and connection.engine.name == "postgresql":
+        op.drop_constraint('archive_policy_pkey', 'archive_policy',
+                           type_='primary')
+        op.create_primary_key('archive_policy_pkey', 'archive_policy', ['id'])
+    op.create_foreign_key(
+        'fk_metric_ap_id_ap_id',
+        'metric',
+        'archive_policy',
+        ['archive_policy_id'],
+        ['id'],
+        ondelete="RESTRICT")
+    op.create_foreign_key(
+        'fk_apr_ap_id_ap_id',
+        'archive_policy_rule',
+        'archive_policy',
+        ['archive_policy_id'],
+        ['id'],
+        ondelete="RESTRICT")
+    op.create_unique_constraint('uniq_ap_name', 'archive_policy', ['name'])
+    op.create_index('ix_ap_name', 'archive_policy', ['name'])
+
+    op.drop_column('metric', 'archive_policy_name')
+    op.drop_column('archive_policy_rule', 'archive_policy_name')

--- a/gnocchi/tests/base.py
+++ b/gnocchi/tests/base.py
@@ -225,6 +225,7 @@ class TestCase(BaseTestCase):
                     timespan=numpy.timedelta64(1, 'D'),
                 ),
             ],
+            id=uuid.UUID('1350af0d-2bca-4526-8b0f-f71c50cdecd2'),
         ),
         'low': archive_policy.ArchivePolicy(
             "low", 0, [
@@ -238,6 +239,7 @@ class TestCase(BaseTestCase):
                 archive_policy.ArchivePolicyItem(
                     granularity=numpy.timedelta64(1, 'D'), points=30),
             ],
+            id=uuid.UUID('595f9bd1-38f8-4c75-b57b-0899ac6c26ab'),
         ),
         'medium': archive_policy.ArchivePolicy(
             "medium", 0, [
@@ -251,6 +253,7 @@ class TestCase(BaseTestCase):
                 archive_policy.ArchivePolicyItem(
                     granularity=numpy.timedelta64(1, 'D'), points=365),
             ],
+            id=uuid.UUID('686d9406-41ad-435b-8dee-49a97e6721e9'),
         ),
         'high': archive_policy.ArchivePolicy(
             "high", 0, [
@@ -264,6 +267,7 @@ class TestCase(BaseTestCase):
                 archive_policy.ArchivePolicyItem(
                     granularity=numpy.timedelta64(1, 'h'), points=365 * 24),
             ],
+            id=uuid.UUID('fa81a4d2-6503-43fd-8b32-bd0765fbdd22'),
         ),
     }
 

--- a/gnocchi/tests/functional/gabbits/archive.yaml
+++ b/gnocchi/tests/functional/gabbits/archive.yaml
@@ -292,6 +292,80 @@ tests:
       response_strings:
           - Archive policy large already exists
 
+# Create another one, rename it and delete it
+
+    - name: create to_rename policy
+      POST: /v1/archive_policy
+      request_headers:
+          # User admin
+          authorization: "basic YWRtaW46"
+      data:
+          name: to_rename
+          definition:
+              - granularity: 1 second
+                points: 20
+              - granularity: 2 second
+      response_headers:
+          location: $SCHEME://$NETLOC/v1/archive_policy/to_rename
+      status: 201
+
+    - name: rename archive policy with existing name
+      PATCH: /v1/archive_policy/to_rename
+      request_headers:
+          # User admin
+          authorization: "basic YWRtaW46"
+      data:
+          name: medium
+      status: 400
+      response_strings:
+          - "Archive policy medium already exists."
+
+    - name: rename archive policy
+      PATCH: $LAST_URL
+      request_headers:
+          # User admin
+          authorization: "basic YWRtaW46"
+      data:
+          name: renamed
+      status: 200
+      response_json_paths:
+          $.name: renamed
+          $.definition[0].granularity: "0:00:01"
+          $.definition[0].points: 20
+          $.definition[0].timespan: "0:00:20"
+          $.definition[1].granularity: "0:00:02"
+          $.definition[1].points: null
+          $.definition[1].timespan: null
+
+    - name: confirm rename
+      GET: $LAST_URL
+      status: 404
+
+    - name: rename and update archive policy
+      PATCH: /v1/archive_policy/renamed
+      request_headers:
+          # User admin
+          authorization: "basic YWRtaW46"
+      data:
+          name: renamed_twice
+          definition:
+              - granularity: 1 second
+                points: 50
+              - granularity: 2 second
+      status: 200
+      response_json_paths:
+          $.name: renamed_twice
+          $.definition[0].granularity: "0:00:01"
+          $.definition[0].points: 50
+          $.definition[0].timespan: "0:00:50"
+
+    - name: delete renamed policy
+      DELETE: /v1/archive_policy/renamed_twice
+      request_headers:
+        # User admin
+        authorization: "basic YWRtaW46"
+      status: 204
+
 # Create a unicode named policy
 
     - name: post unicode policy name

--- a/gnocchi/tests/functional/gabbits/base.yaml
+++ b/gnocchi/tests/functional/gabbits/base.yaml
@@ -61,14 +61,14 @@ tests:
   GET: $LOCATION
   status: 200
   response_json_paths:
-      $.archive_policy.name: test1
+      $.archive_policy_name: test1
       $.creator: foobar
 
 - name: list the one metric
   GET: /v1/metric
   status: 200
   response_json_paths:
-      $[0].archive_policy.name: test1
+      $[0].archive_policy_name: test1
 
 - name: post a single measure
   desc: post one measure

--- a/gnocchi/tests/functional/gabbits/metric-list.yaml
+++ b/gnocchi/tests/functional/gabbits/metric-list.yaml
@@ -96,7 +96,7 @@ tests:
       response_json_paths:
           $.`len`: 1
           $[0].name: disk.io.rate
-          $[0].archive_policy.name: first_archive
+          $[0].archive_policy_name: first_archive
 
     - name: list metrics by name
       GET: /v1/metric?name=disk.io.rate
@@ -107,15 +107,15 @@ tests:
           $.`len`: 2
           $[0].name: disk.io.rate
           $[1].name: disk.io.rate
-          $[0].archive_policy.name: first_archive
-          $[1].archive_policy.name: first_archive
+          $[0].archive_policy_name: first_archive
+          $[1].archive_policy_name: first_archive
 
     - name: list metrics by unit
       GET: /v1/metric?unit=ns
       response_json_paths:
           $.`len`: 1
           $[0].name: cpu
-          $[0].archive_policy.name: second_archive
+          $[0].archive_policy_name: second_archive
 
     - name: list metrics by archive_policy
       GET: /v1/metric?archive_policy_name=first_archive&sort=name:desc
@@ -127,9 +127,9 @@ tests:
           $[0].name: disk.io.rate
           $[1].name: disk.io.rate
           $[2].name: cpu_util
-          $[0].archive_policy.name: first_archive
-          $[1].archive_policy.name: first_archive
-          $[2].archive_policy.name: first_archive
+          $[0].archive_policy_name: first_archive
+          $[1].archive_policy_name: first_archive
+          $[2].archive_policy_name: first_archive
 
     - name: list metrics by archive_policy with limit and pagination links page 1
       GET: /v1/metric?archive_policy_name=first_archive&sort=name:desc&limit=2
@@ -142,8 +142,8 @@ tests:
           $.`len`: 2
           $[0].name: disk.io.rate
           $[1].name: disk.io.rate
-          $[0].archive_policy.name: first_archive
-          $[1].archive_policy.name: first_archive
+          $[0].archive_policy_name: first_archive
+          $[1].archive_policy_name: first_archive
 
     - name: list metrics by archive_policy with limit and pagination links page 2
       GET: /v1/metric?archive_policy_name=first_archive&limit=2&marker=$RESPONSE['$[1].id']&sort=name:desc
@@ -153,7 +153,7 @@ tests:
       response_json_paths:
           $.`len`: 1
           $[0].name: cpu_util
-          $[0].archive_policy.name: first_archive
+          $[0].archive_policy_name: first_archive
 
     - name: list metrics ensure no Link header
       GET: /v1/metric?archive_policy_name=first_archive&sort=name:desc

--- a/gnocchi/tests/functional/gabbits/metric.yaml
+++ b/gnocchi/tests/functional/gabbits/metric.yaml
@@ -138,7 +138,7 @@ tests:
       GET: /v1/metric/$RESPONSE['$.id']
       status: 200
       response_json_paths:
-        $.archive_policy.name: cookies
+        $.archive_policy_name: cookies
 
     - name: push measurements to metric before epoch
       POST: /v1/metric/$RESPONSE['$.id']/measures
@@ -152,7 +152,7 @@ tests:
     - name: list valid metrics
       GET: /v1/metric
       response_json_paths:
-          $[0].archive_policy.name: cookies
+          $[0].archive_policy_name: cookies
 
     - name: push measurements to metric with bad timestamp
       POST: /v1/metric/$HISTORY['list valid metrics'].$RESPONSE['$[0].id']/measures
@@ -344,7 +344,7 @@ tests:
       GET: /v1/metric
       status: 200
       response_json_paths:
-          $[0].archive_policy.name: cookies
+          $[0].archive_policy_name: cookies
 
     - name: get measure unknown aggregates
       GET: /v1/aggregation/metric?metric=$HISTORY['get metric list for aggregates'].$RESPONSE['$[0].id']&aggregation=last

--- a/gnocchi/tests/functional/gabbits/resource.yaml
+++ b/gnocchi/tests/functional/gabbits/resource.yaml
@@ -462,7 +462,7 @@ tests:
     - name: request cpuutil metric from generic
       GET: /v1/resource/generic/85C44741-CC60-4033-804E-2D3098C7D2E9/metric/cpu.util
       response_json_paths:
-          $.archive_policy.name: medium
+          $.archive_policy_name: medium
 
     - name: try post cpuutil metric to generic
       POST: $LAST_URL

--- a/gnocchi/tests/functional/gabbits/search-metric.yaml
+++ b/gnocchi/tests/functional/gabbits/search-metric.yaml
@@ -71,7 +71,7 @@ tests:
       GET: /v1/metric
       status: 200
       response_json_paths:
-          $[0].archive_policy.name: high
+          $[0].archive_policy_name: high
 
     - name: search with one correct granularity
       POST: /v1/search/metric?metric_id=$HISTORY['get metric id'].$RESPONSE['$[0].id']&granularity=1s

--- a/gnocchi/tests/functional_live/gabbits/live.yaml
+++ b/gnocchi/tests/functional_live/gabbits/live.yaml
@@ -413,7 +413,7 @@ tests:
       GET: $LOCATION
       status: 200
       response_json_paths:
-        $.archive_policy.name: gabbilive
+        $.archive_policy_name: gabbilive
 
     - name: delete the metric
       DELETE: /v1/metric/$RESPONSE['$.id']

--- a/gnocchi/tests/test_rest.py
+++ b/gnocchi/tests/test_rest.py
@@ -287,6 +287,7 @@ class ArchivePolicyTest(RestTest):
         ]
         self.assertEqual(set(ap['aggregation_methods']),
                          ap_dict['aggregation_methods'])
+        ap['id'] = uuid.UUID(ap['id'])
         del ap['aggregation_methods']
         del ap_dict['aggregation_methods']
         self.assertEqual(ap_dict, ap)
@@ -297,6 +298,7 @@ class ArchivePolicyTest(RestTest):
         # Transform list to set
         for ap in aps:
             ap['aggregation_methods'] = set(ap['aggregation_methods'])
+            ap['id'] = uuid.UUID(ap['id'])
         for name, ap in six.iteritems(self.archive_policies):
             apj = ap.jsonify()
             apj['definition'] = [

--- a/releasenotes/notes/add_update_archive_policy-fb5b46ff86e5bf2e.yaml
+++ b/releasenotes/notes/add_update_archive_policy-fb5b46ff86e5bf2e.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - Possibility to rename an archive policy.


### PR DESCRIPTION
This supersedes #389.

Archive policies can be renamed by issuing a PATCH request containing the new name.
The definition of an ap can also be patched along with the name within the same request.
Archive policies are now identified by id but their name must still be unique.