### PR TITLE
aggregates: search-and-fetch api

### DIFF
--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -602,7 +602,16 @@ least one of the time series is returned.
 
 {{ scenarios['get-aggregates-by-metric-ids-fill']['doc'] }}
 
+It's also possible to do that aggregation on |metrics| linked to |resources|.
+In order to select these |resources|, the following endpoint accepts a query
+such as the one described in `Searching for resources`_.
 
+{{ scenarios['get-aggregates-by-attributes-lookup']['doc'] }}
+
+It is possible to group the |resource| search results by any attribute of the
+requested |resource| type, and then compute the aggregation:
+
+{{ scenarios['get-aggregates-by-attributes-lookup-groupby']['doc'] }}
 
 List of supported <operations>
 ------------------------------

--- a/doc/source/rest.yaml
+++ b/doc/source/rest.yaml
@@ -775,7 +775,7 @@
 
 - name: get-aggregates-by-metric-ids
   request: |
-    POST /v1/aggregates/fetch?start=2014-10-06T14:34&stop=2017-10-06T14:34 HTTP/1.1
+    POST /v1/aggregates?start=2014-10-06T14:34&stop=2017-10-06T14:34 HTTP/1.1
     Content-Type: application/json
 
     {
@@ -792,7 +792,7 @@
 
 - name: get-aggregates-between-metrics
   request: |
-    POST /v1/aggregates/fetch?start=2014-10-06T14:34&stop=2017-10-06T14:34 HTTP/1.1
+    POST /v1/aggregates?start=2014-10-06T14:34&stop=2017-10-06T14:34 HTTP/1.1
     Content-Type: application/json
 
     {
@@ -809,11 +809,33 @@
 
 - name: get-aggregates-by-metric-ids-fill
   request: |
-    POST /v1/aggregates/fetch?fill=0&granularity=1 HTTP/1.1
+    POST /v1/aggregates?fill=0&granularity=1 HTTP/1.1
     Content-Type: application/json
 
     {
       "operations": "(* (aggregate mean (metric {{ scenarios['create-resource-instance-with-metrics']['response'].json['metrics']['cpu.util'] }} mean)) 4)"
+    }
+
+- name: get-aggregates-by-attributes-lookup
+  request: |
+    POST /v1/aggregates?start=2014-10-06T14:34 HTTP/1.1
+    Content-Type: application/json
+
+    {
+      "resource_type": "instance",
+      "search": {"=": {"server_group": "my_autoscaling_group"}},
+      "operations": ["*", ["aggregate", "mean", ["metric", "cpu.util", "mean"]], 4]
+    }
+
+- name: get-aggregates-by-attributes-lookup-groupby
+  request: |
+    POST /v1/aggregates?start=2014-10-06T14:34&groupby=host&groupby=flavor_id HTTP/1.1
+    Content-Type: application/json
+
+    {
+      "resource_type": "instance",
+      "search": "server_group='my_autoscaling_group'",
+      "operations": "(* (aggregate mean (metric cpu.util mean)) 4)"
     }
 
 - name: get-capabilities

--- a/gnocchi/rest/aggregates/api.py
+++ b/gnocchi/rest/aggregates/api.py
@@ -14,12 +14,15 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import itertools
+
 import pecan
 from pecan import rest
 import pyparsing
 import six
 import voluptuous
 
+from gnocchi import indexer
 from gnocchi.rest.aggregates import exceptions
 from gnocchi.rest.aggregates import operations as agg_operations
 from gnocchi.rest.aggregates import processor
@@ -155,15 +158,28 @@ def get_measures_or_abort(metrics_and_aggregations, operations, start,
                         "detail": [(str(e.metric.id), e.method)]})
 
 
-class FetchController(rest.RestController):
+def ResourceTypeSchema(resource_type):
+    try:
+        pecan.request.indexer.get_resource_type(resource_type)
+    except indexer.NoSuchResourceType as e:
+        api.abort(400, e)
+    return resource_type
 
-    FetchSchema = {
+
+class AggregatesController(rest.RestController):
+
+    FetchSchema = voluptuous.Any({
         "operations": OperationsSchema
-    }
+    }, {
+        "operations": OperationsSchema,
+        "resource_type": ResourceTypeSchema,
+        "search": voluptuous.Any(api.ResourceSearchSchema,
+                                 api.QueryStringSearchAttrFilter.parse),
+    })
 
     @pecan.expose("json")
     def post(self, start=None, stop=None, granularity=None,
-             needed_overlap=100.0, fill=None):
+             needed_overlap=100.0, fill=None, groupby=None):
         start, stop, granularity, needed_overlap, fill = api.validate_qs(
             start, stop, granularity, needed_overlap, fill)
 
@@ -171,41 +187,90 @@ class FetchController(rest.RestController):
 
         references = list(extract_references(body["operations"]))
         if not references:
-            api.abort(400, {"cause": "operations is invalid",
-                            "reason": "at least one 'metric' is required",
+            api.abort(400, {"cause": "Operations is invalid",
+                            "reason": "At least one 'metric' is required",
                             "detail": body["operations"]})
 
-        try:
-            metric_ids = [six.text_type(utils.UUID(m))
-                          for (m, a) in references]
-        except ValueError as e:
-            api.abort(400, {"cause": "Invalid metric references",
-                            "reason": six.text_type(e),
-                            "detail": references})
+        if "resource_type" in body:
+            attr_filter = body["search"]
+            policy_filter = (
+                pecan.request.auth_helper.get_resource_policy_filter(
+                    pecan.request, "search resource", body["resource_type"]))
+            if policy_filter:
+                if attr_filter:
+                    attr_filter = {"and": [
+                        policy_filter,
+                        attr_filter
+                    ]}
+                else:
+                    attr_filter = policy_filter
 
-        metrics = pecan.request.indexer.list_metrics(ids=metric_ids)
-        missing_metric_ids = (set(metric_ids)
-                              - set(six.text_type(m.id) for m in metrics))
-        if missing_metric_ids:
-            api.abort(404, {"cause": "Unknown metrics",
-                            "reason": "Provided metrics don't exists",
-                            "detail": missing_metric_ids})
+            groupby = sorted(set(api.arg_to_list(groupby)))
+            resources = pecan.request.indexer.list_resources(
+                body["resource_type"],
+                attribute_filter=attr_filter,
+                sorts=groupby)
+            if not groupby:
+                return self._get_measures_by_name(
+                    resources, references, body["operations"], start, stop,
+                    granularity, needed_overlap, fill)
 
-        number_of_metrics = len(metrics)
-        if number_of_metrics == 0:
-            return []
+            def groupper(r):
+                return tuple((attr, r[attr]) for attr in groupby)
 
-        for metric in metrics:
-            api.enforce("get metric", metric)
+            results = []
+            for key, resources in itertools.groupby(resources, groupper):
+                results.append({
+                    "group": dict(key),
+                    "measures": self._get_measures_by_name(
+                        resources, references, body["operations"], start, stop,
+                        granularity, needed_overlap, fill)
+                })
+            return results
 
-        metrics_by_ids = dict((six.text_type(m.id), m) for m in metrics)
-        metrics_and_aggregations = [(metrics_by_ids[m], a)
-                                    for (m, a) in references]
-        return get_measures_or_abort(
-            metrics_and_aggregations, body["operations"],
-            start, stop, granularity, needed_overlap, fill,
-            ref_identifier="id")
+        else:
+            try:
+                metric_ids = [six.text_type(utils.UUID(m))
+                              for (m, a) in references]
+            except ValueError as e:
+                api.abort(400, {"cause": "Invalid metric references",
+                                "reason": six.text_type(e),
+                                "detail": references})
 
+            metrics = pecan.request.indexer.list_metrics(ids=metric_ids)
+            missing_metric_ids = (set(metric_ids)
+                                  - set(six.text_type(m.id) for m in metrics))
+            if missing_metric_ids:
+                api.abort(404, {"cause": "Unknown metrics",
+                                "reason": "Provided metrics don't exists",
+                                "detail": missing_metric_ids})
 
-class AggregatesController(object):
-    fetch = FetchController()
+            number_of_metrics = len(metrics)
+            if number_of_metrics == 0:
+                return []
+
+            for metric in metrics:
+                api.enforce("get metric", metric)
+
+            metrics_by_ids = dict((six.text_type(m.id), m) for m in metrics)
+            metrics_and_aggregations = [(metrics_by_ids[m], a)
+                                        for (m, a) in references]
+            return get_measures_or_abort(
+                metrics_and_aggregations, body["operations"],
+                start, stop, granularity, needed_overlap, fill,
+                ref_identifier="id")
+
+    def _get_measures_by_name(self, resources, metric_names, operations,
+                              start, stop, granularity, needed_overlap, fill):
+
+        metrics_and_aggregations = list(filter(
+            lambda x: x[0] is not None, ([r.get_metric(metric_name), agg]
+                                         for (metric_name, agg) in metric_names
+                                         for r in resources)))
+        if not metrics_and_aggregations:
+            api.abort(400, {"cause": "Metrics not found",
+                            "detail": set((m for (m, a) in metric_names))})
+
+        return get_measures_or_abort(metrics_and_aggregations, operations,
+                                     start, stop, granularity, needed_overlap,
+                                     fill, ref_identifier="name")

--- a/gnocchi/tests/functional/gabbits/aggregates-with-metric-ids.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregates-with-metric-ids.yaml
@@ -109,7 +109,7 @@ tests:
           - ["2015-03-06T14:35:15+00:00", 1.0, 15.0]
 
     - name: get aggregates
-      POST: /v1/aggregates/fetch
+      POST: /v1/aggregates
       data:
         operations: ["metric", ["$HISTORY['create metric1'].$RESPONSE['$.id']", "mean"], ["$HISTORY['create metric2'].$RESPONSE['$.id']", "mean"]]
       response_json_paths:
@@ -134,7 +134,7 @@ tests:
           - ["2015-03-06T14:35:15+00:00", 1.0, 15.0]
 
     - name: get aggregates start and stop
-      POST: /v1/aggregates/fetch
+      POST: /v1/aggregates
       query_parameters:
         start: "2015-03-06T14:34:00"
         stop: "2015-03-06T14:35:13"
@@ -156,7 +156,7 @@ tests:
           - ["2015-03-06T14:35:12+00:00", 1.0, 10.0]
 
     - name: get aggregates granularity
-      POST: /v1/aggregates/fetch?granularity=60
+      POST: /v1/aggregates?granularity=60
       data:
         operations: ["metric", ["$HISTORY['create metric1'].$RESPONSE['$.id']", "max"], ["$HISTORY['create metric2'].$RESPONSE['$.id']", "min"]]
       response_json_paths:
@@ -171,7 +171,7 @@ tests:
           - ["2015-03-06T14:35:00+00:00", 60.0, 10.0]
 
     - name: get aggregates simple with array
-      POST: /v1/aggregates/fetch
+      POST: /v1/aggregates
       data:
         operations: ["+", ["metric", ["$HISTORY['create metric1'].$RESPONSE['$.id']", "mean"], ["$HISTORY['create metric2'].$RESPONSE['$.id']", "mean"]], 2.0]
       response_json_paths:
@@ -196,7 +196,7 @@ tests:
           - ["2015-03-06T14:35:15+00:00", 1.0, 17.0]
 
     - name: get aggregates resample
-      POST: /v1/aggregates/fetch?granularity=1
+      POST: /v1/aggregates?granularity=1
       data:
         operations:
           - resample
@@ -215,7 +215,7 @@ tests:
           - ["2015-03-06T14:35:00+00:00", 60.0, 12.5]
 
     - name: get aggregates rolling
-      POST: /v1/aggregates/fetch?granularity=1
+      POST: /v1/aggregates?granularity=1
       data:
         operations:
           - rolling
@@ -237,7 +237,7 @@ tests:
 
 
     - name: get one metric
-      POST: /v1/aggregates/fetch
+      POST: /v1/aggregates
       data:
         operations: "(metric $HISTORY['create metric1'].$RESPONSE['$.id'] mean)"
       response_json_paths:
@@ -253,7 +253,7 @@ tests:
           - ["2015-03-06T14:35:15+00:00", 1.0, 11.0]
 
     - name: get aggregates one metric
-      POST: /v1/aggregates/fetch
+      POST: /v1/aggregates
       data:
         operations: "(aggregate mean (metric $HISTORY['create metric1'].$RESPONSE['$.id'] mean))"
       response_json_paths:
@@ -269,7 +269,7 @@ tests:
           - ["2015-03-06T14:35:15+00:00", 1.0, 11.0]
 
     - name: get aggregates math with string
-      POST: /v1/aggregates/fetch
+      POST: /v1/aggregates
       data:
         operations: "(+ (metric ($HISTORY['create metric1'].$RESPONSE['$.id'] mean) ($HISTORY['create metric2'].$RESPONSE['$.id'] mean)) 2.0)"
       response_json_paths:
@@ -294,7 +294,7 @@ tests:
           - ["2015-03-06T14:35:15+00:00", 1.0, 17.0]
 
     - name: get aggregates substact
-      POST: /v1/aggregates/fetch
+      POST: /v1/aggregates
       data:
         operations: "(- (metric $HISTORY['create metric1'].$RESPONSE['$.id'] mean) (metric $HISTORY['create metric2'].$RESPONSE['$.id'] mean)))"
       response_json_paths:
@@ -310,7 +310,7 @@ tests:
           - ["2015-03-06T14:35:15+00:00", 1.0, -4.0]
 
     - name: get aggregates mean aggregate
-      POST: /v1/aggregates/fetch
+      POST: /v1/aggregates
       data:
         operations: "(aggregate mean (metric ($HISTORY['create metric1'].$RESPONSE['$.id'] mean) ($HISTORY['create metric2'].$RESPONSE['$.id'] mean)))"
       response_json_paths:
@@ -326,7 +326,7 @@ tests:
           - ["2015-03-06T14:35:15+00:00", 1.0, 13.0]
 
     - name: get aggregates negative absolute
-      POST: /v1/aggregates/fetch
+      POST: /v1/aggregates
       data:
         operations: "(negative (absolute (aggregate mean (metric ($HISTORY['create metric1'].$RESPONSE['$.id'] mean) ($HISTORY['create metric2'].$RESPONSE['$.id'] mean)))))"
       response_json_paths:
@@ -344,7 +344,7 @@ tests:
 # Negative tests
 
     - name: get no operations
-      POST: /v1/aggregates/fetch
+      POST: /v1/aggregates
       request_headers:
         accept: application/json
         content-type: application/json
@@ -356,7 +356,7 @@ tests:
         - "Invalid input: Operation must not be empty"
 
     - name: get operations without list
-      POST: /v1/aggregates/fetch
+      POST: /v1/aggregates
       request_headers:
         accept: application/json
         content-type: application/json
@@ -369,7 +369,7 @@ tests:
         - "Invalid input: Expected a tuple/list, got a "
 
     - name: invalid operations string
-      POST: /v1/aggregates/fetch
+      POST: /v1/aggregates
       request_headers:
         accept: application/json
         content-type: application/json
@@ -384,7 +384,7 @@ tests:
         $.description.detail: "Expected \")\" (at char 15), (line:1, col:16)"
 
     - name: get invalid metric operations
-      POST: /v1/aggregates/fetch
+      POST: /v1/aggregates
       request_headers:
         accept: application/json
         content-type: application/json
@@ -396,7 +396,7 @@ tests:
         - "Invalid input: Operation need at least one argument for dictionary value"
 
     - name: get unknown metrics
-      POST: /v1/aggregates/fetch
+      POST: /v1/aggregates
       request_headers:
         accept: application/json
         content-type: application/json
@@ -417,7 +417,7 @@ tests:
             - "e4864464-1b27-4622-9fbb-dc900e06c192"
 
     - name: get not matching granularity
-      POST: /v1/aggregates/fetch
+      POST: /v1/aggregates
       request_headers:
         accept: application/json
         content-type: application/json
@@ -437,7 +437,7 @@ tests:
         $.description.detail.`len`: 3
 
     - name: get unknown granularity
-      POST: /v1/aggregates/fetch?granularity=123
+      POST: /v1/aggregates?granularity=123
       request_headers:
         accept: application/json
         content-type: application/json
@@ -456,7 +456,7 @@ tests:
         - ["$HISTORY['create metric1'].$RESPONSE['$.id']", mean]
 
     - name: get unknown aggregation
-      POST: /v1/aggregates/fetch
+      POST: /v1/aggregates
       request_headers:
         accept: application/json
         content-type: application/json
@@ -474,7 +474,7 @@ tests:
         - ["$HISTORY['create metric1'].$RESPONSE['$.id']", "what?"]
 
     - name: invalid start
-      POST: /v1/aggregates/fetch?start=notadate
+      POST: /v1/aggregates?start=notadate
       request_headers:
         accept: application/json
         content-type: application/json
@@ -487,7 +487,7 @@ tests:
         $.description.reason: "Must be a datetime or a timestamp"
 
     - name: invalid stop
-      POST: /v1/aggregates/fetch?stop=notadate
+      POST: /v1/aggregates?stop=notadate
       request_headers:
         accept: application/json
         content-type: application/json
@@ -500,7 +500,7 @@ tests:
         $.description.reason: "Must be a datetime or a timestamp"
 
     - name: invalid needed_overlap
-      POST: /v1/aggregates/fetch?needed_overlap=notnumber
+      POST: /v1/aggregates?needed_overlap=notnumber
       request_headers:
         accept: application/json
         content-type: application/json
@@ -513,7 +513,7 @@ tests:
         $.description.reason: "Must be a number"
 
     - name: incomplete needed_overlap
-      POST: /v1/aggregates/fetch?needed_overlap=50
+      POST: /v1/aggregates?needed_overlap=50
       request_headers:
         accept: application/json
         content-type: application/json
@@ -526,7 +526,7 @@ tests:
         $.description.reason: "start and/or stop must be provided if specifying needed_overlap"
 
     - name: invalid granularity
-      POST: /v1/aggregates/fetch?granularity=foobar
+      POST: /v1/aggregates?granularity=foobar
       request_headers:
         accept: application/json
         content-type: application/json
@@ -539,7 +539,7 @@ tests:
         $.description.reason: "Unable to parse timespan"
 
     - name: incomplete fill
-      POST: /v1/aggregates/fetch?fill=123
+      POST: /v1/aggregates?fill=123
       request_headers:
         accept: application/json
         content-type: application/json
@@ -552,7 +552,7 @@ tests:
         $.description.reason: "Unable to fill without a granularity"
 
     - name: invalid fill
-      POST: /v1/aggregates/fetch?fill=foobar&granularity=5
+      POST: /v1/aggregates?fill=foobar&granularity=5
       request_headers:
         accept: application/json
         content-type: application/json
@@ -565,7 +565,7 @@ tests:
         $.description.reason: "Must be a float or 'null', got 'foobar'"
 
     - name: get rolling bad aggregate
-      POST: /v1/aggregates/fetch
+      POST: /v1/aggregates
       request_headers:
         accept: application/json
         content-type: application/json
@@ -577,7 +577,7 @@ tests:
         - "Invalid input: 'rolling' operation invalid for dictionary value"
 
     - name: get rolling-mean missing window
-      POST: /v1/aggregates/fetch
+      POST: /v1/aggregates
       request_headers:
         accept: application/json
         content-type: application/json
@@ -589,7 +589,7 @@ tests:
         - "Invalid input: 'rolling' operation invalid for dictionary value"
 
     - name: get measurements from metric and invalid operations
-      POST: /v1/aggregates/fetch
+      POST: /v1/aggregates
       request_headers:
         accept: application/json
         content-type: application/json
@@ -601,7 +601,7 @@ tests:
         - "Invalid input: 'notexist' operation invalid for dictionary value"
 
     - name: invalid resample
-      POST: /v1/aggregates/fetch
+      POST: /v1/aggregates
       request_headers:
         accept: application/json
         content-type: application/json

--- a/gnocchi/tests/functional/gabbits/aggregates-with-resources.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregates-with-resources.yaml
@@ -1,0 +1,190 @@
+fixtures:
+    - ConfigFixture
+
+defaults:
+  request_headers:
+    # User foobar
+    authorization: "basic Zm9vYmFyOg=="
+    content-type: application/json
+
+tests:
+    - name: create archive policy
+      desc: for later use
+      POST: /v1/archive_policy
+      request_headers:
+        # User admin
+        authorization: "basic YWRtaW46"
+      data:
+        name: low
+        definition:
+          - granularity: 1 second
+          - granularity: 300 seconds
+      status: 201
+
+    - name: create another archive policy
+      desc: for later use
+      POST: /v1/archive_policy
+      request_headers:
+        # User admin
+        authorization: "basic YWRtaW46"
+      data:
+        name: unrelated
+        definition:
+          - granularity: 5 second
+      status: 201
+
+    - name: create resource 1
+      POST: /v1/resource/generic
+      data:
+        id: 4ed9c196-4c9f-4ba8-a5be-c9a71a82aac4
+        user_id: 6c865dd0-7945-4e08-8b27-d0d7f1c2b667
+        project_id: c7f32f1f-c5ef-427a-8ecd-915b219c66e8
+        metrics:
+          cpu.util:
+            archive_policy_name: low
+      status: 201
+
+    - name: post cpuutil measures 1
+      POST: /v1/resource/generic/4ed9c196-4c9f-4ba8-a5be-c9a71a82aac4/metric/cpu.util/measures
+      data:
+        - timestamp: "2015-03-06T14:33:57"
+          value: 43.1
+        - timestamp: "2015-03-06T14:34:12"
+          value: 12
+      status: 202
+
+    - name: create resource 2
+      POST: /v1/resource/generic
+      data:
+        id: 1447CD7E-48A6-4C50-A991-6677CC0D00E6
+        user_id: 6c865dd0-7945-4e08-8b27-d0d7f1c2b667
+        project_id: c7f32f1f-c5ef-427a-8ecd-915b219c66e8
+        metrics:
+          cpu.util:
+            archive_policy_name: low
+      status: 201
+
+    - name: post cpuutil measures 2
+      POST: /v1/resource/generic/1447CD7E-48A6-4C50-A991-6677CC0D00E6/metric/cpu.util/measures
+      data:
+        - timestamp: "2015-03-06T14:33:57"
+          value: 23
+        - timestamp: "2015-03-06T14:34:12"
+          value: 8
+      status: 202
+
+    - name: create resource 3
+      POST: /v1/resource/generic
+      data:
+        id: 33333BC5-5948-4F29-B7DF-7DE607660452
+        user_id: 6c865dd0-7945-4e08-8b27-d0d7f1c2b667
+        project_id: ee4cfc41-1cdc-4d2f-9a08-f94111d80171
+        metrics:
+          cpu.util:
+            archive_policy_name: low
+      status: 201
+
+    - name: post cpuutil measures 3
+      POST: /v1/resource/generic/33333BC5-5948-4F29-B7DF-7DE607660452/metric/cpu.util/measures
+      data:
+        - timestamp: "2015-03-06T14:33:57"
+          value: 230
+        - timestamp: "2015-03-06T14:34:12"
+          value: 45.41
+      status: 202
+
+    - name: create resource 4
+      POST: /v1/resource/generic
+      data:
+        id: b1409ec6-3909-4b37-bbff-f9a5448fe328
+        user_id: 70b5b732-9d81-4dfb-a8a1-a424ef3eae6b
+        project_id: ee4cfc41-1cdc-4d2f-9a08-f94111d80171
+        metrics:
+          cpu.util:
+            archive_policy_name: unrelated
+      status: 201
+
+    - name: post cpuutil measures 4
+      POST: /v1/resource/generic/b1409ec6-3909-4b37-bbff-f9a5448fe328/metric/cpu.util/measures
+      data:
+        - timestamp: "2015-03-06T14:33:57"
+          value: 230
+        - timestamp: "2015-03-06T14:34:12"
+          value: 45.41
+      status: 202
+
+    - name: aggregate metric
+      POST: /v1/aggregates
+      data:
+        resource_type: generic
+        search: "user_id = '6c865dd0-7945-4e08-8b27-d0d7f1c2b667'"
+        operations: "(aggregate mean (metric cpu.util mean))"
+      poll:
+        count: 10
+        delay: 1
+      response_json_paths:
+        $.aggregated:
+          - ['2015-03-06T14:30:00+00:00', 300.0, 60.251666666666665]
+          - ['2015-03-06T14:33:57+00:00', 1.0, 98.7]
+          - ['2015-03-06T14:34:12+00:00', 1.0, 21.80333333333333]
+
+    - name: aggregate metric with groupby on project_id and user_id with aggregates API
+      POST: /v1/aggregates?groupby=project_id&groupby=user_id
+      data:
+        resource_type: generic
+        search: "user_id = '6c865dd0-7945-4e08-8b27-d0d7f1c2b667'"
+        operations: "(aggregate mean (metric cpu.util mean))"
+      response_json_paths:
+        $:
+          - measures:
+              aggregated:
+              - ['2015-03-06T14:30:00+00:00', 300.0, 21.525]
+              - ['2015-03-06T14:33:57+00:00', 1.0, 33.05]
+              - ['2015-03-06T14:34:12+00:00', 1.0, 10.0]
+            group:
+              user_id: 6c865dd0-7945-4e08-8b27-d0d7f1c2b667
+              project_id: c7f32f1f-c5ef-427a-8ecd-915b219c66e8
+          - measures:
+              aggregated:
+              - ['2015-03-06T14:30:00+00:00', 300.0, 137.70499999999998]
+              - ['2015-03-06T14:33:57+00:00', 1.0, 230.0]
+              - ['2015-03-06T14:34:12+00:00', 1.0, 45.41]
+            group:
+              user_id: 6c865dd0-7945-4e08-8b27-d0d7f1c2b667
+              project_id: ee4cfc41-1cdc-4d2f-9a08-f94111d80171
+
+# Negative tests
+
+    - name: not matching granularity
+      POST: /v1/aggregates
+      request_headers:
+        accept: application/json
+        content-type: application/json
+        authorization: "basic Zm9vYmFyOg=="
+      data:
+        resource_type: generic
+        search: {}
+        operations: "(aggregate mean (metric cpu.util mean))"
+      status: 400
+      response_json_paths:
+        $.code: 400
+        $.description.cause: "Metrics can't being aggregated"
+        $.description.detail.`len`: 4
+
+    - name: not matching metrics
+      POST: /v1/aggregates
+      request_headers:
+        accept: application/json
+        content-type: application/json
+        authorization: "basic Zm9vYmFyOg=="
+      data:
+        resource_type: generic
+        search: "user_id = '6c865dd0-7945-4e08-8b27-d0d7f1c2b667'"
+        operations: "(aggregate mean (metric (notexists mean) (foobar mean)))"
+      status: 400
+      response_json_paths:
+        $.code: 400
+        $.description.cause: "Metrics not found"
+        $.description.detail.`sorted`:
+          - foobar
+          - notexists

--- a/gnocchi/tests/functional/gabbits/aggregation.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregation.yaml
@@ -132,7 +132,7 @@ tests:
           - ['2015-03-06T14:34:00+00:00', 60.0, 7.0]
 
     - name: get measure aggregates and operations
-      POST: /v1/aggregates/fetch?granularity=1
+      POST: /v1/aggregates?granularity=1
       data:
         operations: "(aggregate mean (resample mean 60 (metric ($HISTORY['get metric list'].$RESPONSE['$[0].id'] mean) ($HISTORY['get metric list'].$RESPONSE['$[1].id'] mean))))"
       response_json_paths:
@@ -235,10 +235,43 @@ tests:
           - ['2015-03-06T14:33:57+00:00', 1.0, 23.1]
           - ['2015-03-06T14:34:12+00:00', 1.0, 7.0]
 
+    - name: get measure aggregates by granularity from aggregates API
+      POST: /v1/aggregates?granularity=1
+      data:
+        resource_type: generic
+        search: {}
+        operations: '(aggregate mean (metric agg_meter mean))'
+      response_json_paths:
+        $.aggregated:
+          - ['2015-03-06T14:33:57+00:00', 1.0, 23.1]
+          - ['2015-03-06T14:34:12+00:00', 1.0, 7.0]
+
     - name: get measure aggregates by granularity from resources and resample
       POST: /v1/aggregation/resource/generic/metric/agg_meter?granularity=1&resample=60
       response_json_paths:
         $:
+          - ['2015-03-06T14:33:00+00:00', 60.0, 23.1]
+          - ['2015-03-06T14:34:00+00:00', 60.0, 7.0]
+
+    - name: get measure aggregates by granularity from aggregates API and resample
+      POST: /v1/aggregates?granularity=1
+      data:
+        resource_type: generic
+        search: {}
+        operations: '(aggregate mean (resample mean 60 (metric agg_meter mean)))'
+      response_json_paths:
+        $.aggregated:
+          - ['2015-03-06T14:33:00+00:00', 60.0, 23.1]
+          - ['2015-03-06T14:34:00+00:00', 60.0, 7.0]
+
+    - name: get measure aggregates by granularity from resources and operations
+      POST: /v1/aggregates?granularity=1
+      data:
+        resource_type: generic
+        search: {}
+        operations: '(aggregate mean (resample mean 60 (metric agg_meter mean)))'
+      response_json_paths:
+        $.aggregated:
           - ['2015-03-06T14:33:00+00:00', 60.0, 23.1]
           - ['2015-03-06T14:34:00+00:00', 60.0, 7.0]
 
@@ -262,6 +295,20 @@ tests:
           - ['2015-03-06T14:30:00+00:00', 300.0, 15.05]
           - ['2015-03-06T14:33:57+00:00', 1.0, 23.1]
 
+    - name: get measure aggregates by granularity with timestamps from aggregates API
+      POST: /v1/aggregates?start=2015-03-06T15:33:57%2B01:00&stop=2015-03-06T15:34:00%2B01:00
+      data:
+        resource_type: generic
+        search: {}
+        operations: '(aggregate mean (metric agg_meter mean))'
+      poll:
+          count: 10
+          delay: 1
+      response_json_paths:
+        $.aggregated:
+          - ['2015-03-06T14:30:00+00:00', 300.0, 15.05]
+          - ['2015-03-06T14:33:57+00:00', 1.0, 23.1]
+
     - name: get measure aggregates by granularity from resources and reaggregate
       POST: /v1/aggregation/resource/generic/metric/agg_meter?granularity=1&reaggregation=min
       poll:
@@ -280,6 +327,17 @@ tests:
           - ['2015-03-06T14:34:12+00:00', 1.0, 7.0]
           - ['2015-03-06T14:35:12+00:00', 1.0, 2.5]
 
+    - name: get measure aggregates from aggregates API with fill zero
+      POST: /v1/aggregates?granularity=1&fill=0
+      data:
+        resource_type: generic
+        search: {}
+        operations: '(aggregate mean (metric agg_meter mean))'
+      response_json_paths:
+        $.aggregated:
+          - ['2015-03-06T14:33:57+00:00', 1.0, 23.1]
+          - ['2015-03-06T14:34:12+00:00', 1.0, 7.0]
+          - ['2015-03-06T14:35:12+00:00', 1.0, 2.5]
 
 # Some negative tests
 

--- a/gnocchi/tests/functional/gabbits/metric.yaml
+++ b/gnocchi/tests/functional/gabbits/metric.yaml
@@ -214,7 +214,7 @@ tests:
           - ["2015-03-06T14:35:00+00:00", 60.0, 10.0]
 
     - name: get measurements from metric and resample and negative
-      POST: /v1/aggregates/fetch?granularity=1
+      POST: /v1/aggregates?granularity=1
       data:
         operations: "(negative (resample mean 60 (metric $HISTORY['list valid metrics'].$RESPONSE['$[0].id'] mean)))"
       response_json_paths:
@@ -236,7 +236,7 @@ tests:
       GET: /v1/metric/$HISTORY['list valid metrics'].$RESPONSE['$[0].id']/measures?refresh=true
 
     - name: get absolute measurements from metric
-      POST: /v1/aggregates/fetch
+      POST: /v1/aggregates
       data:
         operations: "(absolute (metric $HISTORY['list valid metrics'].$RESPONSE['$[0].id'] mean))"
       response_json_paths:
@@ -250,7 +250,7 @@ tests:
           - ["2015-03-06T14:37:15+00:00", 1.0, 23.0]
 
     - name: rolling-mean
-      POST: /v1/aggregates/fetch
+      POST: /v1/aggregates
       data:
         operations: "(rolling mean 2 (metric $HISTORY['list valid metrics'].$RESPONSE['$[0].id'] mean))"
       status: 200
@@ -264,7 +264,7 @@ tests:
           - ["2015-03-06T14:37:15+00:00", 1.0, -19.5]
 
     - name: get measurements from metric and two operations
-      POST: /v1/aggregates/fetch
+      POST: /v1/aggregates
       data:
         operations: "(negative (absolute (metric $HISTORY['list valid metrics'].$RESPONSE['$[0].id'] mean)))"
       response_json_paths:
@@ -278,7 +278,7 @@ tests:
           - ["2015-03-06T14:37:15+00:00", 1.0, -23.0]
 
     - name: get measurements from metric and invalid operations
-      POST: /v1/aggregates/fetch
+      POST: /v1/aggregates
       data:
         operations: "(notexist (absolute (metric $HISTORY['list valid metrics'].$RESPONSE['$[0].id'] mean)))"
       status: 400

--- a/releasenotes/notes/aggregates-API-d31db66e674cbf60.yaml
+++ b/releasenotes/notes/aggregates-API-d31db66e674cbf60.yaml
@@ -2,7 +2,9 @@
 features:
   - |
     New API endpoint allows to retrieve, transform, aggregates measurements on the
-    fly in an flexible way. The endpoint location is `/v1/aggregates/fetch`.
-    This endpoint allows to describe `operations` to be done on a metrics
-    list. Example: `(* 5  (rolling mean 3 (aggregate sum (metric (metric1 mean)
-    (metric2 mean)))))`. More details are available in the documentation.
+    fly in an flexible way. The endpoint location is `/v1/aggregates`.
+    This endpoint allows to describe `operations` to be done on a metrics list.
+    Example: `(* 5  (rolling mean 3 (aggregate sum (metric (metric1 mean)
+    (metric2 mean)))))`. The metrics list can be retrieved by searching in
+    resources by setting 'resource_type' and 'search'. More details are
+    available in the documentation.


### PR DESCRIPTION
This change adds the /v1/aggregates/search-and-fetch API.

It allows to search for metrics with the same format as
resource search and cross metric aggregation.

And then it applies operations on them like /v1/aggregates/fetch API.

It also re-add transformation tests related to cross metric aggregation
endpoint but with new aggregates API.

Related #419