### PR TITLE
aggregates: remove useless checks

### DIFF
--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -1692,10 +1692,6 @@ def validate_qs(start, stop, granularity, needed_overlap, fill):
                         "reason": six.text_type(e)})
 
     if fill is not None:
-        if granularity is None:
-            abort(400, {"cause": "Argument value error",
-                        "detail": "granularity",
-                        "reason": "Unable to fill without a granularity"})
         if fill != "null":
             try:
                 fill = float(fill)

--- a/gnocchi/tests/functional/gabbits/aggregates-with-metric-ids.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregates-with-metric-ids.yaml
@@ -341,6 +341,52 @@ tests:
           - ["2015-03-06T14:35:12+00:00", 1.0, -9.5]
           - ["2015-03-06T14:35:15+00:00", 1.0, -13.0]
 
+
+    - name: push new measurements to metric1
+      POST: /v1/metric/$HISTORY['create metric1'].$RESPONSE['$.id']/measures
+      data:
+          - timestamp: "2015-03-06T14:37:00"
+            value: 15
+          - timestamp: "2015-03-06T14:38:00"
+            value: 15
+      status: 202
+
+    - name: refresh metric1
+      GET: /v1/metric/$HISTORY['create metric1'].$RESPONSE['$.id']/measures?refresh=true
+
+    - name: fill and no granularity
+      POST: /v1/aggregates?fill=123
+      data:
+        operations: "(metric ($HISTORY['create metric1'].$RESPONSE['$.id'] mean) ($HISTORY['create metric2'].$RESPONSE['$.id'] mean))"
+      response_json_paths:
+        $.`len`: 2
+        $."$HISTORY['create metric1'].$RESPONSE['$.id']_mean":
+          - ["2015-03-06T14:33:00+00:00", 60.0, 43.1]
+          - ["2015-03-06T14:34:00+00:00", 60.0, -2.0]
+          - ["2015-03-06T14:35:00+00:00", 60.0, 10.0]
+          - ['2015-03-06T14:37:00+00:00', 60.0, 15.0]
+          - ['2015-03-06T14:38:00+00:00', 60.0, 15.0]
+          - ["2015-03-06T14:33:57+00:00", 1.0, 43.1]
+          - ["2015-03-06T14:34:12+00:00", 1.0, 12.0]
+          - ["2015-03-06T14:34:15+00:00", 1.0, -16.0]
+          - ["2015-03-06T14:35:12+00:00", 1.0, 9.0]
+          - ["2015-03-06T14:35:15+00:00", 1.0, 11.0]
+          - ['2015-03-06T14:37:00+00:00', 1.0, 15.0]
+          - ['2015-03-06T14:38:00+00:00', 1.0, 15.0]
+        $."$HISTORY['create metric2'].$RESPONSE['$.id']_mean":
+          - ["2015-03-06T14:33:00+00:00", 60.0, 2.0]
+          - ["2015-03-06T14:34:00+00:00", 60.0, 4.5]
+          - ["2015-03-06T14:35:00+00:00", 60.0, 12.5]
+          - ['2015-03-06T14:37:00+00:00', 60.0, 123.0]
+          - ['2015-03-06T14:38:00+00:00', 60.0, 123.0]
+          - ["2015-03-06T14:33:57+00:00", 1.0, 2.0]
+          - ["2015-03-06T14:34:12+00:00", 1.0, 4.0]
+          - ["2015-03-06T14:34:15+00:00", 1.0, 5.0]
+          - ["2015-03-06T14:35:12+00:00", 1.0, 10.0]
+          - ["2015-03-06T14:35:15+00:00", 1.0, 15.0]
+          - ['2015-03-06T14:37:00+00:00', 1.0, 123.0]
+          - ['2015-03-06T14:38:00+00:00', 1.0, 123.0]
+
 # Negative tests
 
     - name: get no operations
@@ -537,19 +583,6 @@ tests:
         $.description.cause: "Argument value error"
         $.description.detail: "granularity"
         $.description.reason: "Unable to parse timespan"
-
-    - name: incomplete fill
-      POST: /v1/aggregates?fill=123
-      request_headers:
-        accept: application/json
-        content-type: application/json
-        authorization: "basic Zm9vYmFyOg=="
-      status: 400
-      response_json_paths:
-        $.code: 400
-        $.description.cause: "Argument value error"
-        $.description.detail: "granularity"
-        $.description.reason: "Unable to fill without a granularity"
 
     - name: invalid fill
       POST: /v1/aggregates?fill=foobar&granularity=5

--- a/gnocchi/tests/functional/gabbits/aggregation.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregation.yaml
@@ -156,9 +156,15 @@ tests:
           - ['2015-03-06T14:34:12+00:00', 1.0, 7.0]
           - ['2015-03-06T14:35:12+00:00', 1.0, 5.0]
 
-    - name: get measure aggregates with fill missing granularity
+    - name: get measure aggregates with fill all granularities
       GET: /v1/aggregation/metric?metric=$HISTORY['get metric list'].$RESPONSE['$[0].id']&metric=$HISTORY['get metric list'].$RESPONSE['$[1].id']&fill=0
-      status: 400
+      response_json_paths:
+        $:
+          - ['2015-03-06T14:30:00+00:00', 300.0, 15.05]
+          - ['2015-03-06T14:35:00+00:00', 300.0, 2.5]
+          - ['2015-03-06T14:33:57+00:00', 1.0, 23.1]
+          - ['2015-03-06T14:34:12+00:00', 1.0, 7.0]
+          - ['2015-03-06T14:35:12+00:00', 1.0, 2.5]
 
     - name: get measure aggregates with bad fill
       GET: /v1/aggregation/metric?metric=$HISTORY['get metric list'].$RESPONSE['$[0].id']&metric=$HISTORY['get metric list'].$RESPONSE['$[1].id']&granularity=1&fill=asdf


### PR DESCRIPTION
It's not necessary useful to forbid fill without granularity.

Of course, some "operations" doesn't make sense. Like resample without
granularity. But it's up to the user to understand that.