### PR TITLE
aggregates: new fill=dropna

### DIFF
--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -590,15 +590,12 @@ error is returned.
    boundary to the first or last timestamp common across all series.
 
 The ability to fill in missing points from a subset of time series is supported
-by specifying a `fill` value. Valid fill values include any float or `null`. In
-the case of `null`, Gnocchi will compute the aggregation using only the
-existing points. The `fill` parameter will not backfill timestamps which contain no
-points in any of the time series. Only timestamps which have datapoints in at
-least one of the time series is returned.
-
-.. note::
-
-   A |granularity| must be specified when using the `fill` parameter.
+by specifying a `fill` value. Valid fill values include any float, `dropna` or
+`null`. In the case of `null`, Gnocchi will compute the aggregation using only
+the existing points. `dropna` is like `null` but remove NaN from the result.
+The `fill` parameter will not backfill timestamps which contain no points in
+any of the time series. Only timestamps which have datapoints in at least one
+of the time series is returned.
 
 {{ scenarios['get-aggregates-by-metric-ids-fill']['doc'] }}
 
@@ -739,16 +736,13 @@ expects 100% overlap. If this percentage is not reached, an error is returned.
    If `start` or `stop` boundary is not set, Gnocchi will set the missing
    boundary to the first or last timestamp common across all series.
 
-The ability to fill in  missing points from a subset of time series is supported
-by specifying a `fill` value. Valid fill values include any float or `null`. In
-the case of `null`, Gnocchi will compute the aggregation using only the
-existing points. The `fill` parameter will not backfill timestamps which contain no
-points in any of the time series. Only timestamps which have datapoints in at
-least one of the time series is returned.
-
-.. note::
-
-   A |granularity| must be specified when using the `fill` parameter.
+The ability to fill in missing points from a subset of time series is supported
+by specifying a `fill` value. Valid fill values include any float, `dropna` or
+`null`. In the case of `null`, Gnocchi will compute the aggregation using only
+the existing points. `dropna` is like `null` but remove NaN from the result.
+The `fill` parameter will not backfill timestamps which contain no points in
+any of the time series. Only timestamps which have datapoints in at least one
+of the time series is returned.
 
 {{ scenarios['get-across-metrics-measures-by-metric-ids-fill']['doc'] }}
 

--- a/gnocchi/rest/aggregates/api.py
+++ b/gnocchi/rest/aggregates/api.py
@@ -179,7 +179,9 @@ class AggregatesController(rest.RestController):
 
     @pecan.expose("json")
     def post(self, start=None, stop=None, granularity=None,
-             needed_overlap=100.0, fill=None, groupby=None):
+             needed_overlap=None, fill=None, groupby=None):
+        if fill is None and needed_overlap is None:
+            fill = "dropna"
         start, stop, granularity, needed_overlap, fill = api.validate_qs(
             start, stop, granularity, needed_overlap, fill)
 

--- a/gnocchi/tests/functional/gabbits/aggregates-with-metric-ids.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregates-with-metric-ids.yaml
@@ -51,6 +51,12 @@ tests:
           archive_policy_name: cookies
       status: 201
 
+    - name: create metric4
+      POST: /v1/metric
+      data:
+          archive_policy_name: cookies
+      status: 201
+
     - name: push measurements to metric1
       POST: /v1/metric/$HISTORY['create metric1'].$RESPONSE['$.id']/measures
       data:
@@ -79,6 +85,15 @@ tests:
             value: 10
           - timestamp: "2015-03-06T14:35:15"
             value: 15
+      status: 202
+
+    - name: push measurements to metric4
+      POST: /v1/metric/$HISTORY['create metric4'].$RESPONSE['$.id']/measures
+      data:
+          - timestamp: "2017-04-06T14:33:57"
+            value: 20
+          - timestamp: "2017-04-06T14:34:12"
+            value: 10
       status: 202
 
     - name: get measurements from metric1
@@ -387,6 +402,86 @@ tests:
           - ['2015-03-06T14:37:00+00:00', 1.0, 123.0]
           - ['2015-03-06T14:38:00+00:00', 1.0, 123.0]
 
+    - name: no overlap dropna
+      POST: /v1/aggregates
+      data:
+        operations: "(metric ($HISTORY['create metric1'].$RESPONSE['$.id'] mean) ($HISTORY['create metric4'].$RESPONSE['$.id'] mean))"
+      response_json_paths:
+        $.`len`: 2
+        $."$HISTORY['create metric1'].$RESPONSE['$.id']_mean":
+          - ["2015-03-06T14:33:00+00:00", 60.0, 43.1]
+          - ["2015-03-06T14:34:00+00:00", 60.0, -2.0]
+          - ["2015-03-06T14:35:00+00:00", 60.0, 10.0]
+          - ['2015-03-06T14:37:00+00:00', 60.0, 15.0]
+          - ['2015-03-06T14:38:00+00:00', 60.0, 15.0]
+          - ["2015-03-06T14:33:57+00:00", 1.0, 43.1]
+          - ["2015-03-06T14:34:12+00:00", 1.0, 12.0]
+          - ["2015-03-06T14:34:15+00:00", 1.0, -16.0]
+          - ["2015-03-06T14:35:12+00:00", 1.0, 9.0]
+          - ["2015-03-06T14:35:15+00:00", 1.0, 11.0]
+          - ['2015-03-06T14:37:00+00:00', 1.0, 15.0]
+          - ['2015-03-06T14:38:00+00:00', 1.0, 15.0]
+        $."$HISTORY['create metric4'].$RESPONSE['$.id']_mean":
+          - ["2017-04-06T14:33:00+00:00", 60.0, 20.0]
+          - ["2017-04-06T14:34:00+00:00", 60.0, 10.0]
+          - ["2017-04-06T14:33:57+00:00", 1.0, 20.0]
+          - ["2017-04-06T14:34:12+00:00", 1.0, 10.0]
+
+    - name: no overlap null
+      POST: /v1/aggregates?fill=null
+      xfail: gabbi use assertEqual to compare .NAN which is always false
+      data:
+        operations: "(metric ($HISTORY['create metric1'].$RESPONSE['$.id'] mean) ($HISTORY['create metric4'].$RESPONSE['$.id'] mean))"
+      response_json_paths:
+        $.`len`: 2
+        $."$HISTORY['create metric1'].$RESPONSE['$.id']_mean":
+          - ["2015-03-06T14:33:00+00:00", 60.0, 43.1]
+          - ["2015-03-06T14:34:00+00:00", 60.0, -2.0]
+          - ["2015-03-06T14:35:00+00:00", 60.0, 10.0]
+          - ['2015-03-06T14:37:00+00:00', 60.0, 15.0]
+          - ['2015-03-06T14:38:00+00:00', 60.0, 15.0]
+          - ["2017-04-06T14:33:00+00:00", 60.0, .NAN]
+          - ["2017-04-06T14:34:00+00:00", 60.0, .NAN]
+          - ["2015-03-06T14:33:57+00:00", 1.0, 43.1]
+          - ["2015-03-06T14:34:12+00:00", 1.0, 12.0]
+          - ["2015-03-06T14:34:15+00:00", 1.0, -16.0]
+          - ["2015-03-06T14:35:12+00:00", 1.0, 9.0]
+          - ["2015-03-06T14:35:15+00:00", 1.0, 11.0]
+          - ['2015-03-06T14:37:00+00:00', 1.0, 15.0]
+          - ['2015-03-06T14:38:00+00:00', 1.0, 15.0]
+          - ["2017-04-06T14:33:57+00:00", 1.0, .NAN]
+          - ["2017-04-06T14:34:12+00:00", 1.0, .NAN]
+        $."$HISTORY['create metric4'].$RESPONSE['$.id']_mean":
+          - ["2015-03-06T14:33:00+00:00", 60.0, .NAN]
+          - ["2015-03-06T14:34:00+00:00", 60.0, .NAN]
+          - ["2015-03-06T14:35:00+00:00", 60.0, .NAN]
+          - ['2015-03-06T14:37:00+00:00', 60.0, .NAN]
+          - ['2015-03-06T14:38:00+00:00', 60.0, .NAN]
+          - ["2017-04-06T14:33:00+00:00", 60.0, 20.0]
+          - ["2017-04-06T14:34:00+00:00", 60.0, 10.0]
+          - ["2015-03-06T14:33:57+00:00", 1.0, .NAN]
+          - ["2015-03-06T14:34:12+00:00", 1.0, .NAN]
+          - ["2015-03-06T14:34:15+00:00", 1.0, .NAN]
+          - ["2015-03-06T14:35:12+00:00", 1.0, .NAN]
+          - ["2015-03-06T14:35:15+00:00", 1.0, .NAN]
+          - ['2015-03-06T14:37:00+00:00', 1.0, .NAN]
+          - ['2015-03-06T14:38:00+00:00', 1.0, .NAN]
+          - ["2017-04-06T14:33:57+00:00", 1.0, 20.0]
+          - ["2017-04-06T14:34:12+00:00", 1.0, 10.0]
+
+    - name: no overlap null light check due to previous xfail
+      POST: /v1/aggregates?fill=null
+      data:
+        operations: "(metric ($HISTORY['create metric1'].$RESPONSE['$.id'] mean) ($HISTORY['create metric4'].$RESPONSE['$.id'] mean))"
+      response_json_paths:
+        $.`len`: 2
+        $."$HISTORY['create metric1'].$RESPONSE['$.id']_mean".`len`: 16
+        $."$HISTORY['create metric4'].$RESPONSE['$.id']_mean".`len`: 16
+        $."$HISTORY['create metric1'].$RESPONSE['$.id']_mean"[0]: ["2015-03-06T14:33:00+00:00", 60.0, 43.1]
+        $."$HISTORY['create metric1'].$RESPONSE['$.id']_mean"[7]: ["2015-03-06T14:33:57+00:00", 1.0, 43.1]
+        $."$HISTORY['create metric4'].$RESPONSE['$.id']_mean"[5]: ["2017-04-06T14:33:00+00:00", 60.0, 20.0]
+        $."$HISTORY['create metric4'].$RESPONSE['$.id']_mean"[14]: ["2017-04-06T14:33:57+00:00", 1.0, 20.0]
+
 # Negative tests
 
     - name: get no operations
@@ -582,7 +677,7 @@ tests:
         $.code: 400
         $.description.cause: "Argument value error"
         $.description.detail: "fill"
-        $.description.reason: "Must be a float or 'null', got 'foobar'"
+        $.description.reason: "Must be a float, 'dropna' or 'null'"
 
     - name: get rolling bad aggregate
       POST: /v1/aggregates

--- a/gnocchi/tests/functional/gabbits/aggregation.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregation.yaml
@@ -139,6 +139,7 @@ tests:
         $.aggregated:
           - ['2015-03-06T14:33:00+00:00', 60.0, 23.1]
           - ['2015-03-06T14:34:00+00:00', 60.0, 7.0]
+          - ['2015-03-06T14:35:00+00:00', 60.0, 5.0]
 
     - name: get measure aggregates with fill zero
       GET: /v1/aggregation/metric?metric=$HISTORY['get metric list'].$RESPONSE['$[0].id']&metric=$HISTORY['get metric list'].$RESPONSE['$[1].id']&granularity=1&fill=0
@@ -244,6 +245,7 @@ tests:
         $.aggregated:
           - ['2015-03-06T14:33:57+00:00', 1.0, 23.1]
           - ['2015-03-06T14:34:12+00:00', 1.0, 7.0]
+          - ['2015-03-06T14:35:12+00:00', 1.0, 5.0]
 
     - name: get measure aggregates by granularity from resources and resample
       POST: /v1/aggregation/resource/generic/metric/agg_meter?granularity=1&resample=60
@@ -262,6 +264,7 @@ tests:
         $.aggregated:
           - ['2015-03-06T14:33:00+00:00', 60.0, 23.1]
           - ['2015-03-06T14:34:00+00:00', 60.0, 7.0]
+          - ['2015-03-06T14:35:00+00:00', 60.0, 5.0]
 
     - name: get measure aggregates by granularity from resources and operations
       POST: /v1/aggregates?granularity=1
@@ -273,6 +276,7 @@ tests:
         $.aggregated:
           - ['2015-03-06T14:33:00+00:00', 60.0, 23.1]
           - ['2015-03-06T14:34:00+00:00', 60.0, 7.0]
+          - ['2015-03-06T14:35:00+00:00', 60.0, 5.0]
 
     - name: get measure aggregates by granularity from resources and bad resample
       POST: /v1/aggregation/resource/generic/metric/agg_meter?resample=abc

--- a/releasenotes/notes/fill=dropna-9e055895e7bff778.yaml
+++ b/releasenotes/notes/fill=dropna-9e055895e7bff778.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Aggregates API and cross metrics aggregation API can take `dropna` for the
+    `fill` parameter. This acts like `null`, but NaN values are removed from
+    the result.


### PR DESCRIPTION
dropna is like null but nan values are not returned.

This is the default for /v1/aggregates API.

This also change our json dumps() to handle nan and return null instead.