### PR TITLE
remove boundary requirements

### DIFF
--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -1661,11 +1661,6 @@ def validate_qs(start, stop, granularity, needed_overlap, fill):
         abort(400, {"cause": "Argument value error",
                     "detail": "needed_overlap",
                     "reason": "Must be a number"})
-    if needed_overlap != 100.0 and start is None and stop is None:
-        abort(400, {"cause": "Argument value error",
-                    "detail": "needed_overlap",
-                    "reason": "start and/or stop must be provided "
-                    "if specifying needed_overlap"})
 
     if start is not None:
         try:

--- a/gnocchi/tests/functional/gabbits/aggregates-with-metric-ids.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregates-with-metric-ids.yaml
@@ -512,19 +512,6 @@ tests:
         $.description.detail: "needed_overlap"
         $.description.reason: "Must be a number"
 
-    - name: incomplete needed_overlap
-      POST: /v1/aggregates?needed_overlap=50
-      request_headers:
-        accept: application/json
-        content-type: application/json
-        authorization: "basic Zm9vYmFyOg=="
-      status: 400
-      response_json_paths:
-        $.code: 400
-        $.description.cause: "Argument value error"
-        $.description.detail: "needed_overlap"
-        $.description.reason: "start and/or stop must be provided if specifying needed_overlap"
-
     - name: invalid granularity
       POST: /v1/aggregates?granularity=foobar
       request_headers:

--- a/gnocchi/tests/functional/gabbits/aggregation.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregation.yaml
@@ -171,13 +171,6 @@ tests:
       response_strings:
         - Granularity '42.0' for metric
 
-    - name: get measure aggregates no boundary custom overlap
-      desc: https://github.com/gnocchixyz/gnocchi/issues/17
-      GET: /v1/aggregation/metric?metric=$HISTORY['get metric list'].$RESPONSE['$[0].id']&metric=$HISTORY['get metric list'].$RESPONSE['$[1].id']&needed_overlap=50
-      status: 400
-      response_strings:
-        - start and/or stop must be provided if specifying needed_overlap
-
 # Aggregation by resource and metric_name
 
     - name: post a resource


### PR DESCRIPTION
we explicitly take first and last timstamps common across all
series as the boundaries if missing.