### PR TITLE
Move coordination_url option out of the storage section

### DIFF
--- a/devstack/plugin.sh
+++ b/devstack/plugin.sh
@@ -215,7 +215,7 @@ function configure_gnocchi {
     fi
 
     if [ -n "$GNOCCHI_COORDINATOR_URL" ]; then
-        iniset $GNOCCHI_CONF storage coordination_url "$GNOCCHI_COORDINATOR_URL"
+        iniset $GNOCCHI_CONF coordination_url "$GNOCCHI_COORDINATOR_URL"
     fi
 
     if is_service_enabled gnocchi-statsd ; then

--- a/gnocchi/cli/metricd.py
+++ b/gnocchi/cli/metricd.py
@@ -66,7 +66,7 @@ class MetricProcessBase(cotyledon.Service):
 
     def _configure(self):
         self.coord = retry_on_exception(get_coordinator_and_start,
-                                        self.conf.storage.coordination_url)
+                                        self.conf.coordination_url)
         self.store = retry_on_exception(
             storage.get_driver, self.conf, self.coord)
         self.incoming = retry_on_exception(incoming.get_driver, self.conf)

--- a/gnocchi/opts.py
+++ b/gnocchi/opts.py
@@ -94,6 +94,11 @@ _cli_options = (
 def list_opts():
     return [
         ("DEFAULT", _cli_options + (
+            cfg.StrOpt(
+                'coordination_url',
+                secret=True,
+                deprecated_group="storage",
+                help='Coordination driver URL'),
             cfg.IntOpt(
                 'parallel_operations',
                 min=1,
@@ -174,7 +179,7 @@ def list_opts():
                             'to force refresh of metric.'),
         ) + API_OPTS,
         ),
-        ("storage", _STORAGE_OPTS + gnocchi.storage._CARBONARA_OPTS),
+        ("storage", _STORAGE_OPTS),
         ("incoming", _INCOMING_OPTS),
         ("statsd", (
             cfg.HostAddressOpt('host',

--- a/gnocchi/rest/app.py
+++ b/gnocchi/rest/app.py
@@ -93,8 +93,7 @@ def load_app(conf, indexer=None, storage=None, incoming=None, coord=None,
             # NOTE(jd) This coordinator is never stop. I don't think it's a
             # real problem since the Web app can never really be stopped
             # anyway, except by quitting it entirely.
-            coord = metricd.get_coordinator_and_start(
-                conf.storage.coordination_url)
+            coord = metricd.get_coordinator_and_start(conf.coordination_url)
         storage = gnocchi_storage.get_driver(conf, coord)
     if not incoming:
         incoming = gnocchi_incoming.get_driver(conf)

--- a/gnocchi/service.py
+++ b/gnocchi/service.py
@@ -84,15 +84,13 @@ def prepare_service(args=None, conf=None,
 
     # If no coordination URL is provided, default to using the indexer as
     # coordinator
-    if conf.storage.coordination_url is None:
+    if conf.coordination_url is None:
         if conf.storage.driver == "redis":
             conf.set_default("coordination_url",
-                             conf.storage.redis_url,
-                             "storage")
+                             conf.storage.redis_url)
         elif conf.incoming.driver == "redis":
             conf.set_default("coordination_url",
-                             conf.incoming.redis_url,
-                             "storage")
+                             conf.incoming.redis_url)
         else:
             parsed = urlparse.urlparse(conf.indexer.url)
             proto, _, _ = parsed.scheme.partition("+")
@@ -100,8 +98,7 @@ def prepare_service(args=None, conf=None,
             # Set proto without the + part
             parsed[0] = proto
             conf.set_default("coordination_url",
-                             urlparse.urlunparse(parsed),
-                             "storage")
+                             urlparse.urlunparse(parsed))
 
     conf.log_opt_values(LOG, logging.DEBUG)
 

--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -35,11 +35,6 @@ OPTS = [
                help='Storage driver to use'),
 ]
 
-_CARBONARA_OPTS = [
-    cfg.StrOpt('coordination_url',
-               secret=True,
-               help='Coordination driver URL'),
-]
 
 LOG = daiquiri.getLogger(__name__)
 

--- a/gnocchi/tests/base.py
+++ b/gnocchi/tests/base.py
@@ -301,7 +301,7 @@ class TestCase(BaseTestCase):
         self.index = indexer.get_driver(self.conf)
 
         self.coord = metricd.get_coordinator_and_start(
-            self.conf.storage.coordination_url)
+            self.conf.coordination_url)
 
         # NOTE(jd) So, some driver, at least SQLAlchemy, can't create all
         # their tables in a single transaction even with the

--- a/gnocchi/tests/functional/fixtures.py
+++ b/gnocchi/tests/functional/fixtures.py
@@ -127,8 +127,7 @@ class ConfigFixture(fixture.GabbiFixture):
 
         self.index = index
 
-        self.coord = metricd.get_coordinator_and_start(
-            conf.storage.coordination_url)
+        self.coord = metricd.get_coordinator_and_start(conf.coordination_url)
         s = storage.get_driver(conf, self.coord)
         s.upgrade()
         i = incoming.get_driver(conf)


### PR DESCRIPTION
The coordination url is more used by the incoming driver for sacks than for the
storage. It has been there fore historical purpose. Move it out to DEFAULT.