### PR TITLE
make rest docs more consumable

### DIFF
--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -35,6 +35,9 @@ temperature of a room or the number of bytes sent by a network interface.
 A |metric| only has a few properties: a UUID to identify it, a name, the
 |archive policy| that will be used to store and aggregate the |measures|.
 
+Create
+------
+
 To create a |metric|, the following API request should be used:
 
 {{ scenarios['create-metric']['doc'] }}
@@ -45,38 +48,49 @@ To create a |metric|, the following API request should be used:
   unchangeable. The definition of the |archive policy| can be changed through
   the :ref:`archive_policy endpoint<archive-policy-patch>` though.
 
+Read
+----
+
 Once created, you can retrieve the |metric| information:
 
 {{ scenarios['get-metric']['doc'] }}
+
+List
+----
 
 To retrieve the list of all the |metrics| created, use the following request:
 
 {{ scenarios['list-metric']['doc'] }}
 
-Metrics can be deleted through a request:
+Pagination
+~~~~~~~~~~
 
-{{ scenarios['delete-metric']['doc'] }}
-
-.. note::
-
-  Considering the large volume of |metrics| Gnocchi will store, query results
-  are limited to `max_limit` value set in the configuration file. Returned
-  results are ordered by |metrics|' id values. To retrieve the next page of
-  results, the id of a |metric| should be given as `marker` for the beginning
-  of the next page of results.
+Considering the large volume of |metrics| Gnocchi will store, query results
+are limited to `max_limit` value set in the configuration file. Returned
+results are ordered by |metrics|' id values. To retrieve the next page of
+results, the id of a |metric| should be given as `marker` for the beginning
+of the next page of results.
 
 Default ordering and limits as well as page start can be modified
 using query parameters:
 
 {{ scenarios['list-metric-pagination']['doc'] }}
 
-See also :ref:`Resource's named metrics <resource-named-metrics>`.
+Delete
+------
+
+Metrics can be deleted through a request:
+
+{{ scenarios['delete-metric']['doc'] }}
+
+See also :ref:`Resources <resources-endpoint>` for similar operations specific
+to metrics associated with a |resource|.
 
 Measures
 ========
 
-Push and retrieve
------------------
+Push
+----
 
 It is possible to send |measures| to the |metric|:
 
@@ -87,69 +101,12 @@ status code. It is possible to provide any number of |measures|.
 
 .. IMPORTANT::
 
-   While it is possible to send any number of (timestamp, value), it is still
-   needed to honor constraints defined by the |archive policy| used by the
+   While it is possible to send any number of (timestamp, value), they still
+   need to honor constraints defined by the |archive policy| used by the
    |metric|, such as the maximum |timespan|.
 
-Once |measures| are sent, it is possible to retrieve |aggregates| using *GET*
-on the same endpoint:
-
-{{ scenarios['get-measures']['doc'] }}
-
-Depending on the driver, there may be some lag after POSTing |measures| before
-they are processed and queryable. To ensure your query returns all |aggregates|
-that have been POSTed and processed, you can force any unprocessed |measures|
-to be handled:
-
-{{ scenarios['get-measures-refresh']['doc'] }}
-
-.. note::
-
-   Depending on the amount of data that is unprocessed, `refresh` may add
-   some overhead to your query.
-
-The list of points returned is composed of tuples with (timestamp,
-|granularity|, value) sorted by timestamp. The |granularity| is the |timespan|
-covered by aggregation for this point.
-
-It is possible to filter the |aggregates| over a time range by specifying the
-*start* and/or *stop* parameters to the query with timestamp. The timestamp
-format can be either a floating number (UNIX epoch) or an ISO8601 formated
-timestamp:
-
-{{ scenarios['get-measures-from']['doc'] }}
-
-By default, the aggregated values that are returned use the *mean*
-|aggregation method|. It is possible to request for any other method by
-specifying the *aggregation* query parameter:
-
-{{ scenarios['get-measures-max']['doc'] }}
-
-The list of |aggregation method| available is: *mean*, *sum*, *last*, *max*,
-*min*, *std*, *median*, *first*, *count* and *Npct* (with 0 < N < 100).
-
-They can be prefixed by "rate:" (like rate:last) to compute the rate of change
-before doing the aggregation.
-
-It's possible to provide the |granularity| argument to specify the
-|granularity| to retrieve, rather than all the |granularities| available:
-
-{{ scenarios['get-measures-granularity']['doc'] }}
-
-See also :ref:`Aggregation across metrics <aggregation-across-metrics>` and :ref:`Resource's named metrics <resource-named-metrics>` .
-
-In addition to |granularities| defined by the |archive policy|, |aggregates|
-can be resampled to a new |granularity|.
-
-{{ scenarios['get-measures-resample']['doc'] }}
-
-.. note::
-
-   Depending on the |aggregation method| and frequency of |measures|, resampled
-   data may lack accuracy as it is working against previously aggregated data.
-
-Batching
---------
+Batch
+~~~~~
 
 It is also possible to batch |measures| sending, i.e. send several |measures|
 for different |metrics| in a simple call:
@@ -165,6 +122,82 @@ can try to create them as long as an |archive policy| rule matches:
 
 {{ scenarios['post-measures-batch-named-create']['doc'] }}
 
+Read
+----
+
+Once |measures| are sent, it is possible to retrieve |aggregates| using *GET*
+on the same endpoint:
+
+{{ scenarios['get-measures']['doc'] }}
+
+The list of points returned is composed of tuples with (timestamp,
+|granularity|, value) sorted by timestamp. The |granularity| is the |timespan|
+covered by aggregation for this point.
+
+Refresh
+~~~~~~~
+
+Depending on the driver, there may be some lag after pushing |measures| before
+they are processed and queryable. To ensure your query returns all |aggregates|
+that have been pushed and processed, you can force any unprocessed |measures|
+to be handled:
+
+{{ scenarios['get-measures-refresh']['doc'] }}
+
+.. note::
+
+   Depending on the amount of data that is unprocessed, `refresh` may add
+   some overhead to your query.
+
+Filter
+~~~~~~
+
+Time range
+``````````
+
+It is possible to filter the |aggregates| over a time range by specifying the
+*start* and/or *stop* parameters to the query with timestamp. The timestamp
+format can be either a floating number (UNIX epoch) or an ISO8601 formated
+timestamp:
+
+{{ scenarios['get-measures-from']['doc'] }}
+
+Aggregation
+```````````
+
+By default, the aggregated values that are returned use the *mean*
+|aggregation method|. It is possible to request for any other method defined
+by the policy by specifying the *aggregation* query parameter:
+
+{{ scenarios['get-measures-max']['doc'] }}
+
+Granularity
+```````````
+
+It's possible to provide the |granularity| argument to specify the
+|granularity| to retrieve, rather than all the |granularities| available:
+
+{{ scenarios['get-measures-granularity']['doc'] }}
+
+Resample
+~~~~~~~~
+
+In addition to |granularities| defined by the |archive policy|, |aggregates|
+can be resampled to a new |granularity|.
+
+{{ scenarios['get-measures-resample']['doc'] }}
+
+.. note::
+
+   Depending on the |aggregation method| and frequency of |measures|, resampled
+   data may lack accuracy as it is working against previously aggregated data.
+
+.. note::
+
+   Gnocchi has an :ref:;`aggregates <aggregates>` endpoint which provides
+   resampling as well as additional capabilities.
+
+
 Archive Policy
 ==============
 
@@ -172,13 +205,15 @@ When sending |measures| for a |metric| to Gnocchi, the values are dynamically
 aggregated. That means that Gnocchi does not store all sent |measures|, but
 aggregates them over a certain period of time.
 
-Gnocchi provides several |aggregation methods| (mean, min, max, sum…) that are
-builtin. Those can be prefix by `rate:` to compute the rate of change before
-doing the aggregation.
+Gnocchi provides several |aggregation methods| that are builtin. The list of
+|aggregation method| available is: *mean*, *sum*, *last*, *max*, *min*, *std*,
+*median*, *first*, *count* and *Npct* (with 0 < N < 100). Those can be prefix
+by `rate:` to compute the rate of change before doing the aggregation.
 
 An |archive policy| is defined by a list of items in the `definition` field.
-Each item is composed of the |timespan| and the level of precision that must be
-kept when aggregating data, determined using at least 2 of the points,
+Each item is composed of: the |timespan|; the |granularity|, which is the level
+of precision that must be kept when aggregating data; and the number of points.
+The |archive policy| is determined using at least 2 of the points,
 |granularity| and |timespan| fields. For example, an item might be defined
 as 12 points over 1 hour (one point every 5 minutes), or 1 point every 1 hour
 over 1 day (24 points).
@@ -196,6 +231,9 @@ hour, and the last point processed has a timestamp of 14:34, it's possible to
 process |measures| back to 14:00 with a `back_window` of 0. If the
 `back_window` is set to 2, it will be possible to send |measures| with
 timestamp back to 12:00 (14:00 minus 2 times 1 hour).
+
+Create
+------
 
 The REST API allows to create |archive policies| in this way:
 
@@ -219,17 +257,26 @@ The list of |aggregation methods| can either be:
 If `*` is included in the list, it's substituted by the list of all supported
 |aggregation methods|.
 
+Read
+----
+
 Once the |archive policy| is created, the complete set of properties is
 computed and returned, with the URL of the |archive policy|. This URL can be
 used to retrieve the details of the |archive policy| later:
 
 {{ scenarios['get-archive-policy']['doc'] }}
 
+List
+----
+
 It is also possible to list |archive policies|:
 
 {{ scenarios['list-archive-policy']['doc'] }}
 
 .. _archive-policy-patch:
+
+Update
+------
 
 Existing |archive policies| can be modified to retain more or less data
 depending on requirements. If the policy coverage is expanded, |aggregates| are
@@ -241,6 +288,9 @@ not retroactively calculated as backfill to accommodate the new |timespan|:
 
    |Granularities| cannot be changed to a different rate. Also, |granularities|
    cannot be added or dropped from a policy.
+
+Delete
+------
 
 It is possible to delete an |archive policy| if it is not used by any |metric|:
 
@@ -272,6 +322,9 @@ multiple rules match, the longest matching rule is taken. For example, if two
 rules exists which match `*` and `disk.*`, a `disk.io.rate` |metric| would
 match the `disk.*` rule rather than `*` rule.
 
+Create
+------
+
 To create a rule, the following API request should be used:
 
 {{ scenarios['create-archive-policy-rule']['doc'] }}
@@ -282,43 +335,60 @@ The `metric_pattern` is used to pattern match so as some examples,
 - `disk.*` matches disk.io
 - `disk.io.*` matches disk.io.rate
 
+Read
+----
+
 Once created, you can retrieve the rule information:
 
 {{ scenarios['get-archive-policy-rule']['doc'] }}
+
+List
+----
 
 It is also possible to list |archive policy| rules. The result set is ordered
 by the `metric_pattern`, in reverse alphabetical order:
 
 {{ scenarios['list-archive-policy-rule']['doc'] }}
 
-It is possible to delete an |archive policy| rule:
-
-{{ scenarios['delete-archive-policy-rule']['doc'] }}
+Update
+------
 
 It is possible to rename an archive policy rule:
 
 {{ scenarios['rename-archive-policy-rule']['doc'] }}
 
+Delete
+------
+
+It is possible to delete an |archive policy| rule:
+
+{{ scenarios['delete-archive-policy-rule']['doc'] }}
+
+.. _resources-endpoint:
+
 Resources
 =========
-
-Creation
---------
 
 Gnocchi provides the ability to store and index |resources|. Each |resource|
 has a type. The basic type of |resources| is *generic*, but more specialized
 subtypes also exist, especially to describe OpenStack resources.
 
-The REST API allows to manipulate |resources|. To create a generic |resource|:
+Create
+------
+
+To create a generic |resource|:
 
 {{ scenarios['create-resource-generic']['doc'] }}
 
-The *id*, *user_id* and *project_id* attributes must be UUID. The timestamp
+The *id*, *user_id* and *project_id* attributes must be an UUID. The timestamp
 describing the lifespan of the |resource| are optional, and *started_at* is by
 default set to the current timestamp.
 
 It's possible to retrieve the |resource| by the URL provided in the `Location`
 header.
+
+Non-generic resources
+~~~~~~~~~~~~~~~~~~~~~
 
 More specialized |resources| can be created. For example, the *instance* is
 used to describe an OpenStack instance as managed by Nova_.
@@ -328,36 +398,92 @@ used to describe an OpenStack instance as managed by Nova_.
 All specialized types have their own optional and mandatory attributes,
 but they all include attributes from the generic type as well.
 
-It is possible to create |metrics| at the same time you create a |resource| to
-save some requests:
+.. _Nova: http://launchpad.net/nova
 
-{{ scenarios['create-resource-with-new-metrics']['doc'] }}
+With metrics
+~~~~~~~~~~~~
 
-Querying
---------
+Each |resource| can be linked to any number of |metrics| on creation:
+
+{{ scenarios['create-resource-instance-with-metrics']['doc'] }}
+
+It is also possible to create |metrics| at the same time you create a |resource|
+to save some requests:
+
+{{ scenarios['create-resource-instance-with-dynamic-metrics']['doc'] }}
+
+Read
+----
 
 To retrieve a |resource| by its URL provided by the `Location` header at
 creation time:
 
 {{ scenarios['get-resource-generic']['doc'] }}
 
-Modification
-------------
+List
+----
+
+All |resources| can be listed, either by using the `generic` type that will
+list all types of |resources|, or by filtering on their |resource| type:
+
+{{ scenarios['list-resource-generic']['doc'] }}
+
+Specific resource type
+~~~~~~~~~~~~~~~~~~~~~~
+
+No attributes specific to the |resource| type are retrieved when using the
+`generic` endpoint. To retrieve the details, either list using the specific
+|resource| type endpoint:
+
+{{ scenarios['list-resource-instance']['doc'] }}
+
+With details
+~~~~~~~~~~~~
+
+To retrieve a more detailed view of the resources, use `details=true` in the
+query parameter:
+
+{{ scenarios['list-resource-generic-details']['doc'] }}
+
+Pagination
+~~~~~~~~~~
+
+Similar to |metric| list, query results are limited to `max_limit` value set
+in the configuration file. Returned results represent a single page of data and
+are ordered by resouces' revision_start time and started_at values:
+
+{{ scenarios['list-resource-generic-pagination']['doc'] }}
+
+List resource metrics
+---------------------
+
+The |metrics| associated with a |resource| can be accessed and manipulated
+using the usual `/v1/metric` endpoint or using the named relationship with the
+|resource|:
+
+{{ scenarios['get-resource-named-metrics-measures']['doc'] }}
+
+Update
+------
 
 It's possible to modify a |resource| by re-uploading it partially with the
 modified fields:
 
 {{ scenarios['patch-resource']['doc'] }}
 
-History modification
---------------------
+It is also possible to associate additional |metrics| with a |resource|:
 
-And to retrieve its modification history:
+{{ scenarios['append-metrics-to-resource']['doc'] }}
+
+History
+-------
+
+And to retrieve a |resource|'s modification history:
 
 {{ scenarios['get-patched-instance-history']['doc'] }}
 
-Deletion
---------
+Delete
+------
 
 It is possible to delete a |resource| altogether:
 
@@ -365,6 +491,9 @@ It is possible to delete a |resource| altogether:
 
 It is also possible to delete a batch of |resources| based on attribute values,
 and returns a number of deleted |resources|.
+
+Batch
+~~~~~
 
 To delete |resources| based on ids:
 
@@ -382,160 +511,73 @@ or delete |resources| based on time:
   When a batch of |resources| are deleted, an attribute filter is required to
   avoid deletion of the entire database.
 
-Listing
--------
-
-All |resources| can be listed, either by using the `generic` type that will
-list all types of |resources|, or by filtering on their |resource| type:
-
-{{ scenarios['list-resource-generic']['doc'] }}
-
-No attributes specific to the |resource| type are retrieved when using the
-`generic` endpoint. To retrieve the details, either list using the specific
-|resource| type endpoint:
-
-{{ scenarios['list-resource-instance']['doc'] }}
-
-or using `details=true` in the query parameter:
-
-{{ scenarios['list-resource-generic-details']['doc'] }}
-
-.. note::
-
-  Similar to |metric| list, query results are limited to `max_limit` value set
-  in the configuration file.
-
-Returned results represent a single page of data and are ordered by resouces'
-revision_start time and started_at values:
-
-{{ scenarios['list-resource-generic-pagination']['doc'] }}
-
-.. _resource-named-metrics:
-
-Named metrics
--------------
-
-Each |resource| can be linked to any number of |metrics|. The |metrics|
-attributes is a key/value field where the key is the name of the relationship
-and the value is a |metric|:
-
-{{ scenarios['create-resource-instance-with-metrics']['doc'] }}
-
-It's also possible to create |metrics| dynamically while creating a |resource|:
-
-{{ scenarios['create-resource-instance-with-dynamic-metrics']['doc'] }}
-
-The |metric| associated with a |resource| can be accessed and manipulated using
-the usual `/v1/metric` endpoint or using the named relationship with the
-|resource|:
-
-{{ scenarios['get-resource-named-metrics-measures']['doc'] }}
-
-The same endpoint can be used to append |metrics| to a |resource|:
-
-{{ scenarios['append-metrics-to-resource']['doc'] }}
-
-.. _Nova: http://launchpad.net/nova
 
 Resource Types
 ==============
 
 Gnocchi is able to manage |resource| types with custom attributes.
 
+Create
+------
+
 To create a new |resource| type:
 
 {{ scenarios['create-resource-type']['doc'] }}
+
+Read
+----
 
 Then to retrieve its description:
 
 {{ scenarios['get-resource-type']['doc'] }}
 
+List
+----
+
 All |resource| types can be listed like this:
 
 {{ scenarios['list-resource-type']['doc'] }}
 
-It can also be deleted if no more |resources| are associated to it:
-
-{{ scenarios['delete-resource-type']['doc'] }}
+Update
+------
 
 Attributes can be added or removed:
 
 {{ scenarios['patch-resource-type']['doc'] }}
 
-Creating |resource| type means creation of new tables on the indexer backend.
-This is heavy operation that will lock some tables for a short amount of times.
-When the |resource| type is created, its initial `state` is `creating`. When
-the new tables have been created, the state switches to `active` and the new
-|resource| type is ready to be used. If something unexpected occurs during this
-step, the state switches to `creation_error`.
+Delete
+------
 
-The same behavior occurs when the |resource| type is deleted. The state starts
-to switch to `deleting`, the |resource| type is no longer usable. Then the
-tables are removed and then finally the resource_type is really deleted from
-the database. If some unexpected error occurs the state switches to
-`deletion_error`.
+It can also be deleted if no more |resources| are associated to it:
 
-Searching for resources
-=======================
+{{ scenarios['delete-resource-type']['doc'] }}
 
-It's possible to search for |resources| using a query mechanism, using the
-`POST` method and uploading a JSON formatted query.
+.. note::
 
-When listing |resources|, it is possible to filter |resources| based on
-attributes values:
+   Creating |resource| type means creation of new tables on the indexer
+   backend. This is heavy operation that will lock some tables for a short
+   amount of time. When the |resource| type is created, its initial `state` is
+   `creating`. When the new tables have been created, the state switches to
+   `active` and the new |resource| type is ready to be used. If something
+   unexpected occurs during this step, the state switches to `creation_error`.
 
-{{ scenarios['search-resource-for-user']['doc'] }}
-
-Or even:
-
-{{ scenarios['search-resource-for-host-like']['doc'] }}
-
-Complex operators such as `and` and `or` are also available:
-
-{{ scenarios['search-resource-for-user-after-timestamp']['doc'] }}
-
-Details about the |resource| can also be retrieved at the same time:
-
-{{ scenarios['search-resource-for-user-details']['doc'] }}
-
-It's possible to search for old revisions of |resources| in the same ways:
-
-{{ scenarios['search-resource-history']['doc'] }}
-
-It is also possible to send the *history* parameter in the *Accept* header:
-
-{{ scenarios['search-resource-history-in-accept']['doc'] }}
-
-The timerange of the history can be set, too:
-
-{{ scenarios['search-resource-history-partial']['doc'] }}
-
-The supported operators are: equal to (`=`, `==` or `eq`), less than (`<` or
-`lt`), greater than (`>` or `gt`), less than or equal to (`<=`, `le` or `≤`)
-greater than or equal to (`>=`, `ge` or `≥`) not equal to (`!=`, `ne` or `≠`),
-value is in (`in`), value is like (`like`), or (`or` or `∨`), and (`and` or
-`∧`) and negation (`not`).
-
-The special attribute `lifespan` which is equivalent to `ended_at - started_at`
-is also available in the filtering queries.
-
-{{ scenarios['search-resource-lifespan']['doc'] }}
+   The same behavior occurs when the |resource| type is deleted. The state
+   starts to switch to `deleting`, the |resource| type is no longer usable.
+   Then the tables are removed and then finally the resource_type is really
+   deleted from the database. If some unexpected error occurs the state
+   switches to `deletion_error`.
 
 
-Searching for values in metrics
-===============================
 
-It is possible to search for values in |metrics|. For example, this will look
-for all values that are greater than or equal to 50 if we add 23 to them and
-that are not equal to 55. You have to specify the list of |metrics| to look
-into by using the `metric_id` query parameter several times.
+Search
+======
 
-{{ scenarios['search-value-in-metric']['doc'] }}
+Gnocchi's search API supports to the ability to execute a query across
+|resources| or |metrics|. This API provides a language to construct more
+complex matching contraints beyond basic filtering.
 
-And it is possible to search for values in |metrics| by using one or multiple
-|granularities|:
-
-{{ scenarios['search-value-in-metrics-by-granularity']['doc'] }}
+Usage
+-----
 
 You can specify a time range to look for by specifying the `start` and/or
 `stop` query parameter, and the |aggregation method| to use by specifying the
@@ -551,69 +593,104 @@ argument, and in this case the second argument passed is the value, or it.
 The operators or (`or` or `∨`), and (`and` or `∧`) and `not` are also
 supported, and take a list of arguments as parameters.
 
+.. _search-resource:
+
+Resource
+--------
+
+It's possible to search for |resources| using a query mechanism, using the
+`POST` method and uploading a JSON formatted query.
+
+Single filter
+~~~~~~~~~~~~~
+
+When listing |resources|, it is possible to filter |resources| based on
+attributes values:
+
+{{ scenarios['search-resource-for-user']['doc'] }}
+
+Or even:
+
+{{ scenarios['search-resource-for-host-like']['doc'] }}
+
+Multiple filters
+~~~~~~~~~~~~~~~~
+
+Complex operators such as `and` and `or` are also available:
+
+{{ scenarios['search-resource-for-user-after-timestamp']['doc'] }}
+
+With details
+~~~~~~~~~~~~
+
+Details about the |resource| can also be retrieved at the same time:
+
+{{ scenarios['search-resource-for-user-details']['doc'] }}
+
+History
+~~~~~~~
+
+It's possible to search for old revisions of |resources| in the same ways:
+
+{{ scenarios['search-resource-history']['doc'] }}
+
+It is also possible to send the *history* parameter in the *Accept* header:
+
+{{ scenarios['search-resource-history-in-accept']['doc'] }}
+
+Time range
+``````````
+
+The timerange of the history can be set, too:
+
+{{ scenarios['search-resource-history-partial']['doc'] }}
+
+Magic
+~~~~~
+
+The special attribute `lifespan` which is equivalent to `ended_at - started_at`
+is also available in the filtering queries.
+
+{{ scenarios['search-resource-lifespan']['doc'] }}
+
+Metric
+------
+
+It is possible to search for values in |metrics|. For example, this will look
+for all values that are greater than or equal to 50 if we add 23 to them and
+that are not equal to 55. You have to specify the list of |metrics| to look
+into by using the `metric_id` query parameter several times.
+
+{{ scenarios['search-value-in-metric']['doc'] }}
+
+And it is possible to search for values in |metrics| by using one or more
+|granularities|:
+
+{{ scenarios['search-value-in-metrics-by-granularity']['doc'] }}
+
+
 .. _aggregates:
 
-Aggregates: on the fly, measurements modification and aggregation
-===================================================================
+Dynamic Aggregates
+==================
 
-Gnocchi allows to do on-the-fly aggregation and modification of already
-aggregated data of |metrics|.
-
-It can be done by providing the list of |metrics| to aggregate:
-
-{{ scenarios['get-aggregates-by-metric-ids']['doc'] }}
-
-This example computes the mean aggregates with `all` metrics listed in
-`metrics` and then multiples it by `4`.
+Gnocchi supports the ability to make on-the-fly reaggregations of existing
+|metrics| and the ability to manipulate and transform |metrics| as required.
+This is accomplished by passing an `operations` value describing the actions
+to apply to the |metrics|.
 
 .. note::
 
    `operations` can also be passed as a string, for example:
    `"operations": "(aggregate mean (metric (metric-id aggregation) (metric-id aggregation))"`
 
-Operations between metrics can also be done, such as:
-
-{{ scenarios['get-aggregates-between-metrics']['doc'] }}
-
-Aggregation across |metrics| have different behavior depending
-on whether boundary values are set (`start` and `stop`) and if `needed_overlap`
-is set.
-
-Gnocchi expects that time series have a certain percentage of timestamps in
-common. This percent is controlled by the `needed_overlap` needed_overlap,
-which by default expects 100% overlap. If this percentage is not reached, an
-error is returned.
-
-.. note::
-
-   If `start` or `stop` boundary is not set, Gnocchi will set the missing
-   boundary to the first or last timestamp common across all series.
-
-The ability to fill in missing points from a subset of time series is supported
-by specifying a `fill` value. Valid fill values include any float, `dropna` or
-`null`. In the case of `null`, Gnocchi will compute the aggregation using only
-the existing points. `dropna` is like `null` but remove NaN from the result.
-The `fill` parameter will not backfill timestamps which contain no points in
-any of the time series. Only timestamps which have datapoints in at least one
-of the time series is returned.
-
-{{ scenarios['get-aggregates-by-metric-ids-fill']['doc'] }}
-
-It's also possible to do that aggregation on |metrics| linked to |resources|.
-In order to select these |resources|, the following endpoint accepts a query
-such as the one described in `Searching for resources`_.
-
-{{ scenarios['get-aggregates-by-attributes-lookup']['doc'] }}
-
-It is possible to group the |resource| search results by any attribute of the
-requested |resource| type, and then compute the aggregation:
-
-{{ scenarios['get-aggregates-by-attributes-lookup-groupby']['doc'] }}
-
 List of supported <operations>
 ------------------------------
 
-getting one or more metrics::
+Get one or more metrics
+~~~~~~~~~~~~~~~~~~~~~~~
+
+::
 
    (metric <metric-id> <aggregation>)
    (metric ((<metric-id> <aggregation>), (<metric-id> <aggregation>), ...))
@@ -621,7 +698,15 @@ getting one or more metrics::
    metric-id: the id of a metric to retrieve
    aggregation: the aggregation method to retrieve
 
-rolling window aggregation::
+.. note::
+
+   When used alone, this provides the ability to retrieve multiple |metrics| in a
+   single request.
+
+Rolling window aggregation
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
 
    (rolling <aggregation method> <rolling window> (<operations>))
 
@@ -629,15 +714,20 @@ rolling window aggregation::
                        (mean, median, std, min, max, sum, var, count)
    rolling window: number of previous values to aggregate
 
+Aggregation across metrics
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-aggregation across metrics::
+::
 
    aggregate <aggregation method> ((<operations>), (<operations>), ...))
 
    aggregation method: the aggregation method to use to compute the aggregate between metrics
                        (mean, median, std, min, max, sum, var, count)
 
-resampling metrics::
+Resample
+~~~~~~~~
+
+::
 
    (resample <aggregation method> <granularity> (<operations>))
 
@@ -646,19 +736,28 @@ resampling metrics::
 
    granularity: the granularity (e.g.: 1d, 60s, ...)
 
-math operations::
+Math operations
+~~~~~~~~~~~~~~~
+
+::
 
    (<operator> <operations_or_float> <operations_or_float>)
 
    operator: %, mod, +, add, -, sub, *, ×, mul, /, ÷, div, **, ^, pow
 
-boolean operations::
+Boolean operations
+~~~~~~~~~~~~~~~~~~
+
+::
 
    (<operator> <operations_or_float> <operations_or_float>)
 
    operator: =, ==, eq, <, lt, >, gt, <=, ≤, le, =, ≥, ge, !=, ≠, ne
 
-function operations::
+Function operations
+~~~~~~~~~~~~~~~~~~~
+
+::
 
    (abs (<operations>))
    (absolute (<operations>))
@@ -670,8 +769,75 @@ function operations::
    (floor (<operations>))
    (ceil (<operations>))
 
+Cross-metric Usage
+------------------
 
-.. _aggregation-across-metrics:
+Aggregation across multiple |metrics| have different behavior depending
+on whether boundary values are set (`start` and `stop`) and if `needed_overlap`
+is set.
+
+Overlap percentage
+~~~~~~~~~~~~~~~~~~
+
+Gnocchi expects that time series have a certain percentage of timestamps in
+common. This percent is controlled by the `needed_overlap` needed_overlap,
+which by default expects 100% overlap. If this percentage is not reached, an
+error is returned.
+
+.. note::
+
+   If `start` or `stop` boundary is not set, Gnocchi will set the missing
+   boundary to the first or last timestamp common across all series.
+
+Backfill
+~~~~~~~~
+
+The ability to fill in missing points from a subset of time series is supported
+by specifying a `fill` value. Valid fill values include any float, `dropna` or
+`null`. In the case of `null`, Gnocchi will compute the aggregation using only
+the existing points. `dropna` is like `null` but remove NaN from the result.
+The `fill` parameter will not backfill timestamps which contain no points in
+any of the time series. Only timestamps which have datapoints in at least one
+of the time series is returned.
+
+{{ scenarios['get-aggregates-by-metric-ids-fill']['doc'] }}
+
+
+Search and aggregate
+--------------------
+
+It's also possible to do that aggregation on |metrics| linked to |resources|.
+In order to select these |resources|, the following endpoint accepts a query
+such as the one described in the :ref:`resource search API <search-resource>`.
+
+{{ scenarios['get-aggregates-by-attributes-lookup']['doc'] }}
+
+Groupby
+~~~~~~~
+
+It is possible to group the |resource| search results by any attribute of the
+requested |resource| type, and then compute the aggregation:
+
+{{ scenarios['get-aggregates-by-attributes-lookup-groupby']['doc'] }}
+
+Examples
+--------
+
+Aggregate then math
+~~~~~~~~~~~~~~~~~~~
+
+The following computes the mean aggregates with `all` metrics listed in
+`metrics` and then multiples it by `4`.
+
+{{ scenarios['get-aggregates-by-metric-ids']['doc'] }}
+
+Between metrics
+~~~~~~~~~~~~~~~
+
+Operations between metrics can also be done, such as:
+
+{{ scenarios['get-aggregates-between-metrics']['doc'] }}
+
 
 Aggregation across metrics (deprecated)
 =======================================
@@ -704,7 +870,7 @@ parameter:
 
 It's also possible to do that aggregation on |metrics| linked to |resources|.
 In order to select these |resources|, the following endpoint accepts a query
-such as the one described in `Searching for resources`_.
+such as the one described in the :ref:`resource search API <search-resource>`.
 
 {{ scenarios['get-across-metrics-measures-by-attributes-lookup']['doc'] }}
 
@@ -758,6 +924,7 @@ can differ between deployments. It is possible to get the supported list of
 
 Status
 ======
+
 The overall status of the Gnocchi installation can be retrieved via an API call
 reporting values such as the number of new |measures| to process for each
 |metric|:

--- a/doc/source/rest.yaml
+++ b/doc/source/rest.yaml
@@ -314,18 +314,6 @@
       "project_id": "BD3A1E52-1C62-44CB-BF04-660BD88CD74D"
     }
 
-- name: create-resource-with-new-metrics
-  request: |
-    POST /v1/resource/generic HTTP/1.1
-    Content-Type: application/json
-
-    {
-      "id": "AB68DA77-FA82-4E67-ABA9-270C5A98CBCB",
-      "user_id": "BD3A1E52-1C62-44CB-BF04-660BD88CD74D",
-      "project_id": "BD3A1E52-1C62-44CB-BF04-660BD88CD74D",
-      "metrics": {"temperature": {"archive_policy_name": "low"}}
-    }
-
 - name: create-resource-type-instance
   request: |
     POST /v1/resource_type HTTP/1.1
@@ -569,12 +557,6 @@
     Content-Type: application/json
 
     {
-      "{{ scenarios['create-resource-with-new-metrics']['response'].json['id'] }}": {
-        "temperature": [
-            { "timestamp": "2014-10-06T14:34:12", "value": 17 },
-            { "timestamp": "2014-10-06T14:34:20", "value": 18 }
-        ]
-      },
       "{{ scenarios['create-resource-instance-with-dynamic-metrics']['response'].json['id'] }}": {
         "cpu.util": [
             { "timestamp": "2014-10-06T14:34:12", "value": 12 },
@@ -595,7 +577,7 @@
     Content-Type: application/json
 
     {
-      "{{ scenarios['create-resource-with-new-metrics']['response'].json['id'] }}": {
+      "{{ scenarios['create-resource-instance-with-dynamic-metrics']['response'].json['id'] }}": {
         "disk.io.test": [
             { "timestamp": "2014-10-06T14:34:12", "value": 71 },
             { "timestamp": "2014-10-06T14:34:20", "value": 81 }


### PR DESCRIPTION
- divide metric section into crud tasks
- divide measures section into crud tasks
- divide archive-policy section into crud tasks
- divide archive-policy-rule section into crud tasks
- divide resources section into crud tasks
- divide resource-type section into crud tasks

- create common search section
  - create anchors for each functionality
- better highlight aggregates API

- remove redundant create-resource-with-new-metrics example