### PR TITLE
Remove oslo.db from config generator

### DIFF
--- a/gnocchi/gnocchi-config-generator.conf
+++ b/gnocchi/gnocchi-config-generator.conf
@@ -1,7 +1,6 @@
 [DEFAULT]
 wrap_width = 79
 namespace = gnocchi
-namespace = oslo.db
 namespace = oslo.middleware.cors
 namespace = oslo.middleware.healthcheck
 namespace = oslo.middleware.http_proxy_to_wsgi


### PR DESCRIPTION
The oslo.db template included by `gnocchi-config-generator` contains many
variable and confused people configure Gnocchi for the first time, especially
because the [database]connection field is there and not used.

Do not expose those values in the template to keep things simple.