### PR TITLE
aggregates: rework API output

### DIFF
--- a/gnocchi/rest/aggregates/api.py
+++ b/gnocchi/rest/aggregates/api.py
@@ -119,32 +119,42 @@ def OperationsSchema(v):
                              required=True)(v)
 
 
+class ReferencesList(list):
+    "A very simplified OrderedSet with list interface"
+
+    def append(self, ref):
+        if ref not in self:
+            super(ReferencesList, self).append(ref)
+
+    def extend(self, refs):
+        for ref in refs:
+            self.append(ref)
+
+
 def extract_references(nodes):
-    references = set()
+    references = ReferencesList()
     if nodes[0] == "metric":
         if isinstance(nodes[1], list):
             for subnodes in nodes[1:]:
-                references.add(tuple(subnodes))
+                references.append(tuple(subnodes))
         else:
-            references.add(tuple(nodes[1:]))
+            references.append(tuple(nodes[1:]))
     else:
         for subnodes in nodes[1:]:
             if isinstance(subnodes, list):
-                references |= extract_references(subnodes)
+                references.extend(extract_references(subnodes))
     return references
 
 
-def get_measures_or_abort(metrics_and_aggregations, operations, start,
-                          stop, granularity, needed_overlap, fill,
-                          ref_identifier):
+def get_measures_or_abort(references, operations, start,
+                          stop, granularity, needed_overlap, fill):
     try:
         return processor.get_measures(
             pecan.request.storage,
-            metrics_and_aggregations,
+            references,
             operations,
             start, stop,
-            granularity, needed_overlap, fill,
-            ref_identifier=ref_identifier)
+            granularity, needed_overlap, fill)
     except exceptions.UnAggregableTimeseries as e:
         api.abort(400, e)
     # TODO(sileht): We currently got only one metric for these exceptions but
@@ -187,7 +197,7 @@ class AggregatesController(rest.RestController):
 
         body = api.deserialize_and_validate(self.FetchSchema)
 
-        references = list(extract_references(body["operations"]))
+        references = extract_references(body["operations"])
         if not references:
             api.abort(400, {"cause": "Operations is invalid",
                             "reason": "At least one 'metric' is required",
@@ -208,10 +218,11 @@ class AggregatesController(rest.RestController):
                     attr_filter = policy_filter
 
             groupby = sorted(set(api.arg_to_list(groupby)))
+            sorts = groupby if groupby else api.RESOURCE_DEFAULT_PAGINATION
             resources = pecan.request.indexer.list_resources(
                 body["resource_type"],
                 attribute_filter=attr_filter,
-                sorts=groupby)
+                sorts=sorts)
             if not groupby:
                 return self._get_measures_by_name(
                     resources, references, body["operations"], start, stop,
@@ -232,8 +243,8 @@ class AggregatesController(rest.RestController):
 
         else:
             try:
-                metric_ids = [six.text_type(utils.UUID(m))
-                              for (m, a) in references]
+                metric_ids = set(six.text_type(utils.UUID(m))
+                                 for (m, a) in references)
             except ValueError as e:
                 api.abort(400, {"cause": "Invalid metric references",
                                 "reason": six.text_type(e),
@@ -255,24 +266,27 @@ class AggregatesController(rest.RestController):
                 api.enforce("get metric", metric)
 
             metrics_by_ids = dict((six.text_type(m.id), m) for m in metrics)
-            metrics_and_aggregations = [(metrics_by_ids[m], a)
-                                        for (m, a) in references]
-            return get_measures_or_abort(
-                metrics_and_aggregations, body["operations"],
-                start, stop, granularity, needed_overlap, fill,
-                ref_identifier="id")
+            references = [processor.MetricReference(metrics_by_ids[m], a)
+                          for (m, a) in references]
+            return {"references": references,
+                    "measures": get_measures_or_abort(
+                        references, body["operations"],
+                        start, stop, granularity, needed_overlap, fill)}
 
     def _get_measures_by_name(self, resources, metric_names, operations,
                               start, stop, granularity, needed_overlap, fill):
 
-        metrics_and_aggregations = list(filter(
-            lambda x: x[0] is not None, ([r.get_metric(metric_name), agg]
-                                         for (metric_name, agg) in metric_names
-                                         for r in resources)))
-        if not metrics_and_aggregations:
+        references = [
+            processor.MetricReference(r.get_metric(metric_name), agg, r)
+            for (metric_name, agg) in metric_names
+            for r in resources if r.get_metric(metric_name) is not None
+        ]
+
+        if not references:
             api.abort(400, {"cause": "Metrics not found",
                             "detail": set((m for (m, a) in metric_names))})
 
-        return get_measures_or_abort(metrics_and_aggregations, operations,
-                                     start, stop, granularity, needed_overlap,
-                                     fill, ref_identifier="name")
+        return {"references": references,
+                "measures": get_measures_or_abort(
+                    references, operations, start, stop, granularity,
+                    needed_overlap, fill)}

--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -1801,7 +1801,7 @@ class AggregationController(rest.RestController):
                     granularity, resample)
             return processor.get_measures(
                 pecan.request.storage,
-                [(m, aggregation) for m in metrics],
+                [processor.MetricReference(m, aggregation) for m in metrics],
                 operations, start, stop,
                 granularity, needed_overlap, fill)["aggregated"]
         except exceptions.UnAggregableTimeseries as e:

--- a/gnocchi/tests/functional/gabbits/aggregates-with-metric-ids.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregates-with-metric-ids.yaml
@@ -124,12 +124,17 @@ tests:
           - ["2015-03-06T14:35:15+00:00", 1.0, 15.0]
 
     - name: get aggregates
+      desc: we put metric2 twice to ensure we retrieve it once
       POST: /v1/aggregates
       data:
-        operations: ["metric", ["$HISTORY['create metric1'].$RESPONSE['$.id']", "mean"], ["$HISTORY['create metric2'].$RESPONSE['$.id']", "mean"]]
+        operations: ["metric", ["$HISTORY['create metric1'].$RESPONSE['$.id']", "mean"], ["$HISTORY['create metric2'].$RESPONSE['$.id']", "mean"],  ["$HISTORY['create metric2'].$RESPONSE['$.id']", "mean"]]
       response_json_paths:
-        $.`len`: 2
-        $."$HISTORY['create metric1'].$RESPONSE['$.id']_mean":
+        $.references.`len`: 2
+        $.references[0].id: $HISTORY['create metric1'].$RESPONSE['$.id']
+        $.references[1].id: $HISTORY['create metric2'].$RESPONSE['$.id']
+        $.references[0].archive_policy.name: cookies
+        $.references[1].archive_policy.name: cookies
+        $.measures."$HISTORY['create metric1'].$RESPONSE['$.id']".mean:
           - ["2015-03-06T14:33:00+00:00", 60.0, 43.1]
           - ["2015-03-06T14:34:00+00:00", 60.0, -2.0]
           - ["2015-03-06T14:35:00+00:00", 60.0, 10.0]
@@ -138,7 +143,7 @@ tests:
           - ["2015-03-06T14:34:15+00:00", 1.0, -16.0]
           - ["2015-03-06T14:35:12+00:00", 1.0, 9.0]
           - ["2015-03-06T14:35:15+00:00", 1.0, 11.0]
-        $."$HISTORY['create metric2'].$RESPONSE['$.id']_mean":
+        $.measures."$HISTORY['create metric2'].$RESPONSE['$.id']".mean:
           - ["2015-03-06T14:33:00+00:00", 60.0, 2.0]
           - ["2015-03-06T14:34:00+00:00", 60.0, 4.5]
           - ["2015-03-06T14:35:00+00:00", 60.0, 12.5]
@@ -156,14 +161,18 @@ tests:
       data:
         operations: ["metric", ["$HISTORY['create metric1'].$RESPONSE['$.id']", "mean"], ["$HISTORY['create metric2'].$RESPONSE['$.id']", "mean"]]
       response_json_paths:
-        $.`len`: 2
-        $."$HISTORY['create metric1'].$RESPONSE['$.id']_mean":
+        $.references.`len`: 2
+        $.references[0].id: $HISTORY['create metric1'].$RESPONSE['$.id']
+        $.references[1].id: $HISTORY['create metric2'].$RESPONSE['$.id']
+        $.references[0].archive_policy.name: cookies
+        $.references[1].archive_policy.name: cookies
+        $.measures."$HISTORY['create metric1'].$RESPONSE['$.id']".mean:
           - ["2015-03-06T14:34:00+00:00", 60.0, -2.0]
           - ["2015-03-06T14:35:00+00:00", 60.0, 10.0]
           - ["2015-03-06T14:34:12+00:00", 1.0, 12.0]
           - ["2015-03-06T14:34:15+00:00", 1.0, -16.0]
           - ["2015-03-06T14:35:12+00:00", 1.0, 9.0]
-        $."$HISTORY['create metric2'].$RESPONSE['$.id']_mean":
+        $.measures."$HISTORY['create metric2'].$RESPONSE['$.id']".mean:
           - ["2015-03-06T14:34:00+00:00", 60.0, 4.5]
           - ["2015-03-06T14:35:00+00:00", 60.0, 12.5]
           - ["2015-03-06T14:34:12+00:00", 1.0, 4.0]
@@ -175,12 +184,16 @@ tests:
       data:
         operations: ["metric", ["$HISTORY['create metric1'].$RESPONSE['$.id']", "max"], ["$HISTORY['create metric2'].$RESPONSE['$.id']", "min"]]
       response_json_paths:
-        $.`len`: 2
-        $."$HISTORY['create metric1'].$RESPONSE['$.id']_max":
+        $.references.`len`: 2
+        $.references[0].id: $HISTORY['create metric1'].$RESPONSE['$.id']
+        $.references[1].id: $HISTORY['create metric2'].$RESPONSE['$.id']
+        $.references[0].archive_policy.name: cookies
+        $.references[1].archive_policy.name: cookies
+        $.measures."$HISTORY['create metric1'].$RESPONSE['$.id']".max:
           - ["2015-03-06T14:33:00+00:00", 60.0, 43.1]
           - ["2015-03-06T14:34:00+00:00", 60.0, 12.0]
           - ["2015-03-06T14:35:00+00:00", 60.0, 11.0]
-        $."$HISTORY['create metric2'].$RESPONSE['$.id']_min":
+        $.measures."$HISTORY['create metric2'].$RESPONSE['$.id']".min:
           - ["2015-03-06T14:33:00+00:00", 60.0, 2.0]
           - ["2015-03-06T14:34:00+00:00", 60.0, 4.0]
           - ["2015-03-06T14:35:00+00:00", 60.0, 10.0]
@@ -190,8 +203,11 @@ tests:
       data:
         operations: ["+", ["metric", ["$HISTORY['create metric1'].$RESPONSE['$.id']", "mean"], ["$HISTORY['create metric2'].$RESPONSE['$.id']", "mean"]], 2.0]
       response_json_paths:
-        $.`len`: 2
-        $."$HISTORY['create metric1'].$RESPONSE['$.id']_mean":
+        $.references[0].id: $HISTORY['create metric1'].$RESPONSE['$.id']
+        $.references[1].id: $HISTORY['create metric2'].$RESPONSE['$.id']
+        $.references[0].archive_policy.name: cookies
+        $.references[1].archive_policy.name: cookies
+        $.measures."$HISTORY['create metric1'].$RESPONSE['$.id']".mean:
           - ["2015-03-06T14:33:00+00:00", 60.0, 45.1]
           - ["2015-03-06T14:34:00+00:00", 60.0, 0.0]
           - ["2015-03-06T14:35:00+00:00", 60.0, 12.0]
@@ -200,7 +216,7 @@ tests:
           - ["2015-03-06T14:34:15+00:00", 1.0, -14.0]
           - ["2015-03-06T14:35:12+00:00", 1.0, 11.0]
           - ["2015-03-06T14:35:15+00:00", 1.0, 13.0]
-        $."$HISTORY['create metric2'].$RESPONSE['$.id']_mean":
+        $.measures."$HISTORY['create metric2'].$RESPONSE['$.id']".mean:
           - ["2015-03-06T14:33:00+00:00", 60.0, 4.0]
           - ["2015-03-06T14:34:00+00:00", 60.0, 6.5]
           - ["2015-03-06T14:35:00+00:00", 60.0, 14.5]
@@ -219,12 +235,16 @@ tests:
           - 60
           - ["metric", ["$HISTORY['create metric1'].$RESPONSE['$.id']", "mean"], ["$HISTORY['create metric2'].$RESPONSE['$.id']", "mean"]]
       response_json_paths:
-        $.`len`: 2
-        $."$HISTORY['create metric1'].$RESPONSE['$.id']_mean":
+        $.references.`len`: 2
+        $.references[0].id: $HISTORY['create metric1'].$RESPONSE['$.id']
+        $.references[1].id: $HISTORY['create metric2'].$RESPONSE['$.id']
+        $.references[0].archive_policy.name: cookies
+        $.references[1].archive_policy.name: cookies
+        $.measures."$HISTORY['create metric1'].$RESPONSE['$.id']".mean:
           - ["2015-03-06T14:33:00+00:00", 60.0, 43.1]
           - ["2015-03-06T14:34:00+00:00", 60.0, -2.0]
           - ["2015-03-06T14:35:00+00:00", 60.0, 10.0]
-        $."$HISTORY['create metric2'].$RESPONSE['$.id']_mean":
+        $.measures."$HISTORY['create metric2'].$RESPONSE['$.id']".mean:
           - ["2015-03-06T14:33:00+00:00", 60.0, 2.0]
           - ["2015-03-06T14:34:00+00:00", 60.0, 4.5]
           - ["2015-03-06T14:35:00+00:00", 60.0, 12.5]
@@ -238,13 +258,17 @@ tests:
           - 2
           - ["metric", ["$HISTORY['create metric1'].$RESPONSE['$.id']", "mean"], ["$HISTORY['create metric2'].$RESPONSE['$.id']", "mean"]]
       response_json_paths:
-        $.`len`: 2
-        $."$HISTORY['create metric1'].$RESPONSE['$.id']_mean":
+        $.references.`len`: 2
+        $.references[0].id: $HISTORY['create metric1'].$RESPONSE['$.id']
+        $.references[1].id: $HISTORY['create metric2'].$RESPONSE['$.id']
+        $.references[0].archive_policy.name: cookies
+        $.references[1].archive_policy.name: cookies
+        $.measures."$HISTORY['create metric1'].$RESPONSE['$.id']".mean:
           - ["2015-03-06T14:34:12+00:00", 1.0, 27.55]
           - ["2015-03-06T14:34:15+00:00", 1.0, -2.0]
           - ["2015-03-06T14:35:12+00:00", 1.0, -3.5]
           - ["2015-03-06T14:35:15+00:00", 1.0, 10.0]
-        $."$HISTORY['create metric2'].$RESPONSE['$.id']_mean":
+        $.measures."$HISTORY['create metric2'].$RESPONSE['$.id']".mean:
           - ["2015-03-06T14:34:12+00:00", 1.0, 3.0]
           - ["2015-03-06T14:34:15+00:00", 1.0, 4.5]
           - ["2015-03-06T14:35:12+00:00", 1.0, 7.5]
@@ -256,8 +280,9 @@ tests:
       data:
         operations: "(metric $HISTORY['create metric1'].$RESPONSE['$.id'] mean)"
       response_json_paths:
-        $.`len`: 1
-        $."$HISTORY['create metric1'].$RESPONSE['$.id']_mean":
+        $.references.`len`: 1
+        $.references[0].id: $HISTORY['create metric1'].$RESPONSE['$.id']
+        $.measures."$HISTORY['create metric1'].$RESPONSE['$.id']".mean:
           - ["2015-03-06T14:33:00+00:00", 60.0, 43.1]
           - ["2015-03-06T14:34:00+00:00", 60.0, -2.0]
           - ["2015-03-06T14:35:00+00:00", 60.0, 10.0]
@@ -272,8 +297,9 @@ tests:
       data:
         operations: "(aggregate mean (metric $HISTORY['create metric1'].$RESPONSE['$.id'] mean))"
       response_json_paths:
-        $.`len`: 1
-        $."aggregated":
+        $.references.`len`: 1
+        $.references[0].id: $HISTORY['create metric1'].$RESPONSE['$.id']
+        $.measures.aggregated:
           - ["2015-03-06T14:33:00+00:00", 60.0, 43.1]
           - ["2015-03-06T14:34:00+00:00", 60.0, -2.0]
           - ["2015-03-06T14:35:00+00:00", 60.0, 10.0]
@@ -288,8 +314,10 @@ tests:
       data:
         operations: "(+ (metric ($HISTORY['create metric1'].$RESPONSE['$.id'] mean) ($HISTORY['create metric2'].$RESPONSE['$.id'] mean)) 2.0)"
       response_json_paths:
-        $.`len`: 2
-        $."$HISTORY['create metric1'].$RESPONSE['$.id']_mean":
+        $.references.`len`: 2
+        $.references[0].id: $HISTORY['create metric1'].$RESPONSE['$.id']
+        $.references[1].id: $HISTORY['create metric2'].$RESPONSE['$.id']
+        $.measures."$HISTORY['create metric1'].$RESPONSE['$.id']".mean:
           - ["2015-03-06T14:33:00+00:00", 60.0, 45.1]
           - ["2015-03-06T14:34:00+00:00", 60.0, 0.0]
           - ["2015-03-06T14:35:00+00:00", 60.0, 12.0]
@@ -298,7 +326,7 @@ tests:
           - ["2015-03-06T14:34:15+00:00", 1.0, -14.0]
           - ["2015-03-06T14:35:12+00:00", 1.0, 11.0]
           - ["2015-03-06T14:35:15+00:00", 1.0, 13.0]
-        $."$HISTORY['create metric2'].$RESPONSE['$.id']_mean":
+        $.measures."$HISTORY['create metric2'].$RESPONSE['$.id']".mean:
           - ["2015-03-06T14:33:00+00:00", 60.0, 4.0]
           - ["2015-03-06T14:34:00+00:00", 60.0, 6.5]
           - ["2015-03-06T14:35:00+00:00", 60.0, 14.5]
@@ -313,8 +341,10 @@ tests:
       data:
         operations: "(- (metric $HISTORY['create metric1'].$RESPONSE['$.id'] mean) (metric $HISTORY['create metric2'].$RESPONSE['$.id'] mean)))"
       response_json_paths:
-        $.`len`: 1
-        $."aggregated":
+        $.references.`len`: 2
+        $.references[0].id: $HISTORY['create metric1'].$RESPONSE['$.id']
+        $.references[1].id: $HISTORY['create metric2'].$RESPONSE['$.id']
+        $.measures.aggregated:
           - ["2015-03-06T14:33:00+00:00", 60.0, 41.1]
           - ["2015-03-06T14:34:00+00:00", 60.0, -6.5]
           - ["2015-03-06T14:35:00+00:00", 60.0, -2.5]
@@ -329,8 +359,10 @@ tests:
       data:
         operations: "(aggregate mean (metric ($HISTORY['create metric1'].$RESPONSE['$.id'] mean) ($HISTORY['create metric2'].$RESPONSE['$.id'] mean)))"
       response_json_paths:
-        $.`len`: 1
-        $."aggregated":
+        $.references.`len`: 2
+        $.references[0].id: $HISTORY['create metric1'].$RESPONSE['$.id']
+        $.references[1].id: $HISTORY['create metric2'].$RESPONSE['$.id']
+        $.measures.aggregated:
           - ["2015-03-06T14:33:00+00:00", 60.0, 22.55]
           - ["2015-03-06T14:34:00+00:00", 60.0, 1.25]
           - ["2015-03-06T14:35:00+00:00", 60.0, 11.25]
@@ -345,8 +377,10 @@ tests:
       data:
         operations: "(negative (absolute (aggregate mean (metric ($HISTORY['create metric1'].$RESPONSE['$.id'] mean) ($HISTORY['create metric2'].$RESPONSE['$.id'] mean)))))"
       response_json_paths:
-        $.`len`: 1
-        $."aggregated":
+        $.references.`len`: 2
+        $.references[0].id: $HISTORY['create metric1'].$RESPONSE['$.id']
+        $.references[1].id: $HISTORY['create metric2'].$RESPONSE['$.id']
+        $.measures.aggregated:
           - ["2015-03-06T14:33:00+00:00", 60.0, -22.55]
           - ["2015-03-06T14:34:00+00:00", 60.0, -1.25]
           - ["2015-03-06T14:35:00+00:00", 60.0, -11.25]
@@ -374,8 +408,10 @@ tests:
       data:
         operations: "(metric ($HISTORY['create metric1'].$RESPONSE['$.id'] mean) ($HISTORY['create metric2'].$RESPONSE['$.id'] mean))"
       response_json_paths:
-        $.`len`: 2
-        $."$HISTORY['create metric1'].$RESPONSE['$.id']_mean":
+        $.references.`len`: 2
+        $.references[0].id: $HISTORY['create metric1'].$RESPONSE['$.id']
+        $.references[1].id: $HISTORY['create metric2'].$RESPONSE['$.id']
+        $.measures."$HISTORY['create metric1'].$RESPONSE['$.id']".mean:
           - ["2015-03-06T14:33:00+00:00", 60.0, 43.1]
           - ["2015-03-06T14:34:00+00:00", 60.0, -2.0]
           - ["2015-03-06T14:35:00+00:00", 60.0, 10.0]
@@ -388,7 +424,7 @@ tests:
           - ["2015-03-06T14:35:15+00:00", 1.0, 11.0]
           - ['2015-03-06T14:37:00+00:00', 1.0, 15.0]
           - ['2015-03-06T14:38:00+00:00', 1.0, 15.0]
-        $."$HISTORY['create metric2'].$RESPONSE['$.id']_mean":
+        $.measures."$HISTORY['create metric2'].$RESPONSE['$.id']".mean:
           - ["2015-03-06T14:33:00+00:00", 60.0, 2.0]
           - ["2015-03-06T14:34:00+00:00", 60.0, 4.5]
           - ["2015-03-06T14:35:00+00:00", 60.0, 12.5]
@@ -407,8 +443,10 @@ tests:
       data:
         operations: "(metric ($HISTORY['create metric1'].$RESPONSE['$.id'] mean) ($HISTORY['create metric4'].$RESPONSE['$.id'] mean))"
       response_json_paths:
-        $.`len`: 2
-        $."$HISTORY['create metric1'].$RESPONSE['$.id']_mean":
+        $.references.`len`: 2
+        $.references[0].id: $HISTORY['create metric1'].$RESPONSE['$.id']
+        $.references[1].id: $HISTORY['create metric4'].$RESPONSE['$.id']
+        $.measures."$HISTORY['create metric1'].$RESPONSE['$.id']".mean:
           - ["2015-03-06T14:33:00+00:00", 60.0, 43.1]
           - ["2015-03-06T14:34:00+00:00", 60.0, -2.0]
           - ["2015-03-06T14:35:00+00:00", 60.0, 10.0]
@@ -421,7 +459,7 @@ tests:
           - ["2015-03-06T14:35:15+00:00", 1.0, 11.0]
           - ['2015-03-06T14:37:00+00:00', 1.0, 15.0]
           - ['2015-03-06T14:38:00+00:00', 1.0, 15.0]
-        $."$HISTORY['create metric4'].$RESPONSE['$.id']_mean":
+        $.measures."$HISTORY['create metric4'].$RESPONSE['$.id']".mean:
           - ["2017-04-06T14:33:00+00:00", 60.0, 20.0]
           - ["2017-04-06T14:34:00+00:00", 60.0, 10.0]
           - ["2017-04-06T14:33:57+00:00", 1.0, 20.0]
@@ -432,8 +470,10 @@ tests:
       data:
         operations: "(metric ($HISTORY['create metric1'].$RESPONSE['$.id'] mean) ($HISTORY['create metric4'].$RESPONSE['$.id'] mean))"
       response_json_paths:
-        $.`len`: 2
-        $."$HISTORY['create metric1'].$RESPONSE['$.id']_mean":
+        $.references.`len`: 2
+        $.references[0].id: $HISTORY['create metric1'].$RESPONSE['$.id']
+        $.references[1].id: $HISTORY['create metric4'].$RESPONSE['$.id']
+        $.measures."$HISTORY['create metric1'].$RESPONSE['$.id']".mean:
           - ["2015-03-06T14:33:00+00:00", 60.0, 43.1]
           - ["2015-03-06T14:34:00+00:00", 60.0, -2.0]
           - ["2015-03-06T14:35:00+00:00", 60.0, 10.0]
@@ -450,7 +490,7 @@ tests:
           - ['2015-03-06T14:38:00+00:00', 1.0, 15.0]
           - ["2017-04-06T14:33:57+00:00", 1.0, !AssertNAN ]
           - ["2017-04-06T14:34:12+00:00", 1.0, !AssertNAN ]
-        $."$HISTORY['create metric4'].$RESPONSE['$.id']_mean":
+        $.measures."$HISTORY['create metric4'].$RESPONSE['$.id']".mean:
           - ["2015-03-06T14:33:00+00:00", 60.0, !AssertNAN ]
           - ["2015-03-06T14:34:00+00:00", 60.0, !AssertNAN ]
           - ["2015-03-06T14:35:00+00:00", 60.0, !AssertNAN ]
@@ -467,19 +507,6 @@ tests:
           - ['2015-03-06T14:38:00+00:00', 1.0, !AssertNAN ]
           - ["2017-04-06T14:33:57+00:00", 1.0, 20.0]
           - ["2017-04-06T14:34:12+00:00", 1.0, 10.0]
-
-    - name: no overlap null light check due to previous xfail
-      POST: /v1/aggregates?fill=null
-      data:
-        operations: "(metric ($HISTORY['create metric1'].$RESPONSE['$.id'] mean) ($HISTORY['create metric4'].$RESPONSE['$.id'] mean))"
-      response_json_paths:
-        $.`len`: 2
-        $."$HISTORY['create metric1'].$RESPONSE['$.id']_mean".`len`: 16
-        $."$HISTORY['create metric4'].$RESPONSE['$.id']_mean".`len`: 16
-        $."$HISTORY['create metric1'].$RESPONSE['$.id']_mean"[0]: ["2015-03-06T14:33:00+00:00", 60.0, 43.1]
-        $."$HISTORY['create metric1'].$RESPONSE['$.id']_mean"[7]: ["2015-03-06T14:33:57+00:00", 1.0, 43.1]
-        $."$HISTORY['create metric4'].$RESPONSE['$.id']_mean"[5]: ["2017-04-06T14:33:00+00:00", 60.0, 20.0]
-        $."$HISTORY['create metric4'].$RESPONSE['$.id']_mean"[14]: ["2017-04-06T14:33:57+00:00", 1.0, 20.0]
 
 # Negative tests
 

--- a/gnocchi/tests/functional/gabbits/aggregates-with-metric-ids.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregates-with-metric-ids.yaml
@@ -123,12 +123,52 @@ tests:
           - ["2015-03-06T14:35:12+00:00", 1.0, 10.0]
           - ["2015-03-06T14:35:15+00:00", 1.0, 15.0]
 
-    - name: get aggregates
-      desc: we put metric2 twice to ensure we retrieve it once
+    - name: get measurements from metric3
+      GET: /v1/metric/$HISTORY['create metric3'].$RESPONSE['$.id']/measures?refresh=true
+      response_json_paths:
+        $: []
+
+    - name: get measurements from metric4
+      GET: /v1/metric/$HISTORY['create metric4'].$RESPONSE['$.id']/measures?refresh=true
+      response_json_paths:
+        $:
+          - ["2017-04-06T14:33:00+00:00", 60.0, 20.0]
+          - ["2017-04-06T14:34:00+00:00", 60.0, 10.0]
+          - ["2017-04-06T14:33:57+00:00", 1.0, 20.0]
+          - ["2017-04-06T14:34:12+00:00", 1.0, 10.0]
+
+    - name: get aggregates, no references
       POST: /v1/aggregates
+      data:
+        operations: ["metric", ["$HISTORY['create metric1'].$RESPONSE['$.id']", "mean"], ["$HISTORY['create metric2'].$RESPONSE['$.id']", "mean"]]
+      response_json_paths:
+        $.`len`: 1
+        $.measures."$HISTORY['create metric1'].$RESPONSE['$.id']".mean:
+          - ["2015-03-06T14:33:00+00:00", 60.0, 43.1]
+          - ["2015-03-06T14:34:00+00:00", 60.0, -2.0]
+          - ["2015-03-06T14:35:00+00:00", 60.0, 10.0]
+          - ["2015-03-06T14:33:57+00:00", 1.0, 43.1]
+          - ["2015-03-06T14:34:12+00:00", 1.0, 12.0]
+          - ["2015-03-06T14:34:15+00:00", 1.0, -16.0]
+          - ["2015-03-06T14:35:12+00:00", 1.0, 9.0]
+          - ["2015-03-06T14:35:15+00:00", 1.0, 11.0]
+        $.measures."$HISTORY['create metric2'].$RESPONSE['$.id']".mean:
+          - ["2015-03-06T14:33:00+00:00", 60.0, 2.0]
+          - ["2015-03-06T14:34:00+00:00", 60.0, 4.5]
+          - ["2015-03-06T14:35:00+00:00", 60.0, 12.5]
+          - ["2015-03-06T14:33:57+00:00", 1.0, 2.0]
+          - ["2015-03-06T14:34:12+00:00", 1.0, 4.0]
+          - ["2015-03-06T14:34:15+00:00", 1.0, 5.0]
+          - ["2015-03-06T14:35:12+00:00", 1.0, 10.0]
+          - ["2015-03-06T14:35:15+00:00", 1.0, 15.0]
+
+    - name: get aggregates with references
+      desc: we put metric2 twice to ensure we retrieve it once
+      POST: /v1/aggregates?details=true
       data:
         operations: ["metric", ["$HISTORY['create metric1'].$RESPONSE['$.id']", "mean"], ["$HISTORY['create metric2'].$RESPONSE['$.id']", "mean"],  ["$HISTORY['create metric2'].$RESPONSE['$.id']", "mean"]]
       response_json_paths:
+        $.`len`: 2
         $.references.`len`: 2
         $.references[0].id: $HISTORY['create metric1'].$RESPONSE['$.id']
         $.references[1].id: $HISTORY['create metric2'].$RESPONSE['$.id']
@@ -156,6 +196,7 @@ tests:
     - name: get aggregates start and stop
       POST: /v1/aggregates
       query_parameters:
+        details: true
         start: "2015-03-06T14:34:00"
         stop: "2015-03-06T14:35:13"
       data:
@@ -180,7 +221,7 @@ tests:
           - ["2015-03-06T14:35:12+00:00", 1.0, 10.0]
 
     - name: get aggregates granularity
-      POST: /v1/aggregates?granularity=60
+      POST: /v1/aggregates?granularity=60&details=true
       data:
         operations: ["metric", ["$HISTORY['create metric1'].$RESPONSE['$.id']", "max"], ["$HISTORY['create metric2'].$RESPONSE['$.id']", "min"]]
       response_json_paths:
@@ -199,7 +240,7 @@ tests:
           - ["2015-03-06T14:35:00+00:00", 60.0, 10.0]
 
     - name: get aggregates simple with array
-      POST: /v1/aggregates
+      POST: /v1/aggregates?details=true
       data:
         operations: ["+", ["metric", ["$HISTORY['create metric1'].$RESPONSE['$.id']", "mean"], ["$HISTORY['create metric2'].$RESPONSE['$.id']", "mean"]], 2.0]
       response_json_paths:
@@ -227,7 +268,7 @@ tests:
           - ["2015-03-06T14:35:15+00:00", 1.0, 17.0]
 
     - name: get aggregates resample
-      POST: /v1/aggregates?granularity=1
+      POST: /v1/aggregates?granularity=1&details=true
       data:
         operations:
           - resample
@@ -250,7 +291,7 @@ tests:
           - ["2015-03-06T14:35:00+00:00", 60.0, 12.5]
 
     - name: get aggregates rolling
-      POST: /v1/aggregates?granularity=1
+      POST: /v1/aggregates?granularity=1&details=true
       data:
         operations:
           - rolling
@@ -276,7 +317,7 @@ tests:
 
 
     - name: get one metric
-      POST: /v1/aggregates
+      POST: /v1/aggregates?details=true
       data:
         operations: "(metric $HISTORY['create metric1'].$RESPONSE['$.id'] mean)"
       response_json_paths:
@@ -293,7 +334,7 @@ tests:
           - ["2015-03-06T14:35:15+00:00", 1.0, 11.0]
 
     - name: get aggregates one metric
-      POST: /v1/aggregates
+      POST: /v1/aggregates?details=true
       data:
         operations: "(aggregate mean (metric $HISTORY['create metric1'].$RESPONSE['$.id'] mean))"
       response_json_paths:
@@ -310,7 +351,7 @@ tests:
           - ["2015-03-06T14:35:15+00:00", 1.0, 11.0]
 
     - name: get aggregates math with string
-      POST: /v1/aggregates
+      POST: /v1/aggregates?details=true
       data:
         operations: "(+ (metric ($HISTORY['create metric1'].$RESPONSE['$.id'] mean) ($HISTORY['create metric2'].$RESPONSE['$.id'] mean)) 2.0)"
       response_json_paths:
@@ -337,7 +378,7 @@ tests:
           - ["2015-03-06T14:35:15+00:00", 1.0, 17.0]
 
     - name: get aggregates substact
-      POST: /v1/aggregates
+      POST: /v1/aggregates?details=true
       data:
         operations: "(- (metric $HISTORY['create metric1'].$RESPONSE['$.id'] mean) (metric $HISTORY['create metric2'].$RESPONSE['$.id'] mean)))"
       response_json_paths:
@@ -355,7 +396,7 @@ tests:
           - ["2015-03-06T14:35:15+00:00", 1.0, -4.0]
 
     - name: get aggregates mean aggregate
-      POST: /v1/aggregates
+      POST: /v1/aggregates?details=true
       data:
         operations: "(aggregate mean (metric ($HISTORY['create metric1'].$RESPONSE['$.id'] mean) ($HISTORY['create metric2'].$RESPONSE['$.id'] mean)))"
       response_json_paths:
@@ -373,7 +414,7 @@ tests:
           - ["2015-03-06T14:35:15+00:00", 1.0, 13.0]
 
     - name: get aggregates negative absolute
-      POST: /v1/aggregates
+      POST: /v1/aggregates?details=true
       data:
         operations: "(negative (absolute (aggregate mean (metric ($HISTORY['create metric1'].$RESPONSE['$.id'] mean) ($HISTORY['create metric2'].$RESPONSE['$.id'] mean)))))"
       response_json_paths:
@@ -404,7 +445,7 @@ tests:
       GET: /v1/metric/$HISTORY['create metric1'].$RESPONSE['$.id']/measures?refresh=true
 
     - name: fill and no granularity
-      POST: /v1/aggregates?fill=123
+      POST: /v1/aggregates?fill=123&details=true
       data:
         operations: "(metric ($HISTORY['create metric1'].$RESPONSE['$.id'] mean) ($HISTORY['create metric2'].$RESPONSE['$.id'] mean))"
       response_json_paths:
@@ -439,7 +480,7 @@ tests:
           - ['2015-03-06T14:38:00+00:00', 1.0, 123.0]
 
     - name: no overlap dropna
-      POST: /v1/aggregates
+      POST: /v1/aggregates?details=true
       data:
         operations: "(metric ($HISTORY['create metric1'].$RESPONSE['$.id'] mean) ($HISTORY['create metric4'].$RESPONSE['$.id'] mean))"
       response_json_paths:
@@ -466,7 +507,7 @@ tests:
           - ["2017-04-06T14:34:12+00:00", 1.0, 10.0]
 
     - name: no overlap null
-      POST: /v1/aggregates?fill=null
+      POST: /v1/aggregates?fill=null&details=true
       data:
         operations: "(metric ($HISTORY['create metric1'].$RESPONSE['$.id'] mean) ($HISTORY['create metric4'].$RESPONSE['$.id'] mean))"
       response_json_paths:

--- a/gnocchi/tests/functional/gabbits/aggregates-with-resources.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregates-with-resources.yaml
@@ -113,6 +113,9 @@ tests:
           value: 45.41
       status: 202
 
+    - name: list resources
+      GET: /v1/resource/generic
+
     - name: aggregate metric
       POST: /v1/aggregates
       data:
@@ -123,10 +126,58 @@ tests:
         count: 10
         delay: 1
       response_json_paths:
-        $.aggregated:
+        $.references.`len`: 3
+        $.references[0]: $HISTORY['list resources'].$RESPONSE['$[0]']
+        $.references[1]: $HISTORY['list resources'].$RESPONSE['$[1]']
+        $.references[2]: $HISTORY['list resources'].$RESPONSE['$[2]']
+        $.measures.aggregated:
           - ['2015-03-06T14:30:00+00:00', 300.0, 60.251666666666665]
           - ['2015-03-06T14:33:57+00:00', 1.0, 98.7]
           - ['2015-03-06T14:34:12+00:00', 1.0, 21.80333333333333]
+
+    - name: batch get
+      POST: /v1/aggregates
+      data:
+        resource_type: generic
+        search: "user_id = '6c865dd0-7945-4e08-8b27-d0d7f1c2b667'"
+        operations: "(metric cpu.util mean)"
+      poll:
+        count: 10
+        delay: 1
+      response_json_paths:
+        $.references.`len`: 3
+        $.references[0]: $HISTORY['list resources'].$RESPONSE['$[0]']
+        $.references[1]: $HISTORY['list resources'].$RESPONSE['$[1]']
+        $.references[2]: $HISTORY['list resources'].$RESPONSE['$[2]']
+        $.measures."$HISTORY['list resources'].$RESPONSE['$[0].id']"."cpu.util".mean:
+          - ['2015-03-06T14:30:00+00:00', 300.0, 27.55]
+          - ['2015-03-06T14:33:57+00:00', 1.0, 43.1]
+          - ['2015-03-06T14:34:12+00:00', 1.0, 12.0]
+        $.measures."$HISTORY['list resources'].$RESPONSE['$[1].id']"."cpu.util".mean:
+          - ['2015-03-06T14:30:00+00:00', 300.0, 15.5]
+          - ['2015-03-06T14:33:57+00:00', 1.0, 23.0]
+          - ['2015-03-06T14:34:12+00:00', 1.0, 8.0]
+        $.measures."$HISTORY['list resources'].$RESPONSE['$[2].id']"."cpu.util".mean:
+          - ['2015-03-06T14:30:00+00:00', 300.0, 137.70499999999998]
+          - ['2015-03-06T14:33:57+00:00', 1.0, 230.0]
+          - ['2015-03-06T14:34:12+00:00', 1.0, 45.41]
+
+    - name: stupid but valid batch get
+      POST: /v1/aggregates
+      data:
+        resource_type: generic
+        search: "id = '4ed9c196-4c9f-4ba8-a5be-c9a71a82aac4'"
+        operations: "(metric (cpu.util mean) (cpu.util mean))"
+      poll:
+        count: 10
+        delay: 1
+      response_json_paths:
+        $.references.`len`: 1
+        $.references[0]: $HISTORY['list resources'].$RESPONSE['$[0]']
+        $.measures."$HISTORY['list resources'].$RESPONSE['$[0].id']"."cpu.util".mean:
+          - ['2015-03-06T14:30:00+00:00', 300.0, 27.55]
+          - ['2015-03-06T14:33:57+00:00', 1.0, 43.1]
+          - ['2015-03-06T14:34:12+00:00', 1.0, 12.0]
 
     - name: aggregate metric with groupby on project_id and user_id with aggregates API
       POST: /v1/aggregates?groupby=project_id&groupby=user_id
@@ -135,21 +186,24 @@ tests:
         search: "user_id = '6c865dd0-7945-4e08-8b27-d0d7f1c2b667'"
         operations: "(aggregate mean (metric cpu.util mean))"
       response_json_paths:
-        $:
-          - measures:
-              aggregated:
+        $.`len`: 2
+        $[0].measures.references.`len`: 2
+        $[0].measures.references[0]: $HISTORY['list resources'].$RESPONSE['$[1]']
+        $[0].measures.references[1]: $HISTORY['list resources'].$RESPONSE['$[0]']
+        $[0].measures.measures.aggregated:
               - ['2015-03-06T14:30:00+00:00', 300.0, 21.525]
               - ['2015-03-06T14:33:57+00:00', 1.0, 33.05]
               - ['2015-03-06T14:34:12+00:00', 1.0, 10.0]
-            group:
+        $[0].group:
               user_id: 6c865dd0-7945-4e08-8b27-d0d7f1c2b667
               project_id: c7f32f1f-c5ef-427a-8ecd-915b219c66e8
-          - measures:
-              aggregated:
+        $[1].measures.references.`len`: 1
+        $[1].measures.references[0]: $HISTORY['list resources'].$RESPONSE['$[2]']
+        $[1].measures.measures.aggregated:
               - ['2015-03-06T14:30:00+00:00', 300.0, 137.70499999999998]
               - ['2015-03-06T14:33:57+00:00', 1.0, 230.0]
               - ['2015-03-06T14:34:12+00:00', 1.0, 45.41]
-            group:
+        $[1].group:
               user_id: 6c865dd0-7945-4e08-8b27-d0d7f1c2b667
               project_id: ee4cfc41-1cdc-4d2f-9a08-f94111d80171
 

--- a/gnocchi/tests/functional/gabbits/aggregates-with-resources.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregates-with-resources.yaml
@@ -117,7 +117,7 @@ tests:
       GET: /v1/resource/generic
 
     - name: aggregate metric
-      POST: /v1/aggregates
+      POST: /v1/aggregates?details=true
       data:
         resource_type: generic
         search: "user_id = '6c865dd0-7945-4e08-8b27-d0d7f1c2b667'"
@@ -136,7 +136,7 @@ tests:
           - ['2015-03-06T14:34:12+00:00', 1.0, 21.80333333333333]
 
     - name: batch get
-      POST: /v1/aggregates
+      POST: /v1/aggregates?details=true
       data:
         resource_type: generic
         search: "user_id = '6c865dd0-7945-4e08-8b27-d0d7f1c2b667'"
@@ -163,7 +163,7 @@ tests:
           - ['2015-03-06T14:34:12+00:00', 1.0, 45.41]
 
     - name: stupid but valid batch get
-      POST: /v1/aggregates
+      POST: /v1/aggregates?details=true
       data:
         resource_type: generic
         search: "id = '4ed9c196-4c9f-4ba8-a5be-c9a71a82aac4'"
@@ -180,7 +180,7 @@ tests:
           - ['2015-03-06T14:34:12+00:00', 1.0, 12.0]
 
     - name: aggregate metric with groupby on project_id and user_id with aggregates API
-      POST: /v1/aggregates?groupby=project_id&groupby=user_id
+      POST: /v1/aggregates?groupby=project_id&groupby=user_id&details=true
       data:
         resource_type: generic
         search: "user_id = '6c865dd0-7945-4e08-8b27-d0d7f1c2b667'"

--- a/gnocchi/tests/functional/gabbits/aggregation.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregation.yaml
@@ -136,7 +136,7 @@ tests:
       data:
         operations: "(aggregate mean (resample mean 60 (metric ($HISTORY['get metric list'].$RESPONSE['$[0].id'] mean) ($HISTORY['get metric list'].$RESPONSE['$[1].id'] mean))))"
       response_json_paths:
-        $.aggregated:
+        $.measures.aggregated:
           - ['2015-03-06T14:33:00+00:00', 60.0, 23.1]
           - ['2015-03-06T14:34:00+00:00', 60.0, 7.0]
           - ['2015-03-06T14:35:00+00:00', 60.0, 5.0]
@@ -242,7 +242,7 @@ tests:
         search: {}
         operations: '(aggregate mean (metric agg_meter mean))'
       response_json_paths:
-        $.aggregated:
+        $.measures.aggregated:
           - ['2015-03-06T14:33:57+00:00', 1.0, 23.1]
           - ['2015-03-06T14:34:12+00:00', 1.0, 7.0]
           - ['2015-03-06T14:35:12+00:00', 1.0, 5.0]
@@ -261,7 +261,7 @@ tests:
         search: {}
         operations: '(aggregate mean (resample mean 60 (metric agg_meter mean)))'
       response_json_paths:
-        $.aggregated:
+        $.measures.aggregated:
           - ['2015-03-06T14:33:00+00:00', 60.0, 23.1]
           - ['2015-03-06T14:34:00+00:00', 60.0, 7.0]
           - ['2015-03-06T14:35:00+00:00', 60.0, 5.0]
@@ -273,7 +273,7 @@ tests:
         search: {}
         operations: '(aggregate mean (resample mean 60 (metric agg_meter mean)))'
       response_json_paths:
-        $.aggregated:
+        $.measures.aggregated:
           - ['2015-03-06T14:33:00+00:00', 60.0, 23.1]
           - ['2015-03-06T14:34:00+00:00', 60.0, 7.0]
           - ['2015-03-06T14:35:00+00:00', 60.0, 5.0]
@@ -308,7 +308,7 @@ tests:
           count: 10
           delay: 1
       response_json_paths:
-        $.aggregated:
+        $.measures.aggregated:
           - ['2015-03-06T14:30:00+00:00', 300.0, 15.05]
           - ['2015-03-06T14:33:57+00:00', 1.0, 23.1]
 
@@ -337,7 +337,7 @@ tests:
         search: {}
         operations: '(aggregate mean (metric agg_meter mean))'
       response_json_paths:
-        $.aggregated:
+        $.measures.aggregated:
           - ['2015-03-06T14:33:57+00:00', 1.0, 23.1]
           - ['2015-03-06T14:34:12+00:00', 1.0, 7.0]
           - ['2015-03-06T14:35:12+00:00', 1.0, 2.5]

--- a/gnocchi/tests/functional/gabbits/metric.yaml
+++ b/gnocchi/tests/functional/gabbits/metric.yaml
@@ -218,7 +218,7 @@ tests:
       data:
         operations: "(negative (resample mean 60 (metric $HISTORY['list valid metrics'].$RESPONSE['$[0].id'] mean)))"
       response_json_paths:
-        $."$HISTORY['list valid metrics'].$RESPONSE['$[0].id']_mean":
+        $.measures."$HISTORY['list valid metrics'].$RESPONSE['$[0].id']".mean:
           - ["2015-03-06T14:33:00+00:00", 60.0, -43.1]
           - ["2015-03-06T14:34:00+00:00", 60.0, -14.0]
           - ["2015-03-06T14:35:00+00:00", 60.0, -10.0]
@@ -240,7 +240,7 @@ tests:
       data:
         operations: "(absolute (metric $HISTORY['list valid metrics'].$RESPONSE['$[0].id'] mean))"
       response_json_paths:
-        $."$HISTORY['list valid metrics'].$RESPONSE['$[0].id']_mean":
+        $.measures."$HISTORY['list valid metrics'].$RESPONSE['$[0].id']".mean:
           - ["2015-03-06T14:33:57+00:00", 1.0, 43.1]
           - ["2015-03-06T14:34:12+00:00", 1.0, 12.0]
           - ["2015-03-06T14:34:15+00:00", 1.0, 16.0]
@@ -255,7 +255,7 @@ tests:
         operations: "(rolling mean 2 (metric $HISTORY['list valid metrics'].$RESPONSE['$[0].id'] mean))"
       status: 200
       response_json_paths:
-        $."$HISTORY['list valid metrics'].$RESPONSE['$[0].id']_mean":
+        $.measures."$HISTORY['list valid metrics'].$RESPONSE['$[0].id']".mean:
           - ["2015-03-06T14:34:12+00:00", 1.0, 27.55]
           - ["2015-03-06T14:34:15+00:00", 1.0, 14.0]
           - ["2015-03-06T14:35:12+00:00", 1.0, 12.5]
@@ -268,7 +268,7 @@ tests:
       data:
         operations: "(negative (absolute (metric $HISTORY['list valid metrics'].$RESPONSE['$[0].id'] mean)))"
       response_json_paths:
-        $."$HISTORY['list valid metrics'].$RESPONSE['$[0].id']_mean":
+        $.measures."$HISTORY['list valid metrics'].$RESPONSE['$[0].id']".mean:
           - ["2015-03-06T14:33:57+00:00", 1.0, -43.1]
           - ["2015-03-06T14:34:12+00:00", 1.0, -12.0]
           - ["2015-03-06T14:34:15+00:00", 1.0, -16.0]

--- a/releasenotes/notes/aggregates-api-output-change-2bc6620c7f595925.yaml
+++ b/releasenotes/notes/aggregates-api-output-change-2bc6620c7f595925.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Aggregates API output introduced in 4.1.0 doesn't allow for easy identification of which timeseries
+    is associated with what metrics/resources that have been queried. This have been fixed, but
+    the new output format is not backwards compatible with the format released in 4.1.0.


### PR DESCRIPTION
aggregates: rework API output
This design have some issue when two timeseries have the same names,
only the last one is dumped. Or if the same metric is asked
twice for whatever reason, measures have all timestamps duplicated.

This change the result to a new format:

For resources:
{
  "measures": { resource_id: {metric_name: {aggregation: MEASURES}}},
  "references": [RESOURCES_DETAILS]
}

For metrics
{
  "measures": {metric_id: {aggregation: MEASURES}},
  "references": [METRICS_DETAILS]
}

When the result is aggregtated we got:

For resources:
{
  "measures": { "aggregated": MEASURES},
  "references": [RESOURCES_DETAILS]
}
For metrics
{
  "measures": { "aggregated": MEASURES},
  "references": [METRICS_DETAILS]
}

Closes-bug: #477