### PR TITLE
cap pandas

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ iso8601
 oslo.config>=3.22.0
 oslo.policy>=0.3.0
 oslo.middleware>=3.22.0
-pandas>=0.18.0
+pandas>=0.18.0,<0.21.0
 pytimeparse
 scipy>=0.18.1  # BSD
 pecan>=0.9


### PR DESCRIPTION
pandas 0.21.0 does not work with numpy<1.13.0. we remove pandas
in master already so let's just cap pandas instead of bumping numpy