### PR TITLE
Using fixtures.MockPatch instead of mockpatch.Patch

### DIFF
--- a/gnocchi/tests/base.py
+++ b/gnocchi/tests/base.py
@@ -21,7 +21,6 @@ import uuid
 
 import fixtures
 from oslotest import base
-from oslotest import mockpatch
 import six
 from six.moves.urllib.parse import unquote
 try:
@@ -279,7 +278,7 @@ class TestCase(base.BaseTestCase):
     def setUp(self):
         super(TestCase, self).setUp()
         if swexc:
-            self.useFixture(mockpatch.Patch(
+            self.useFixture(fixtures.MockPatch(
                 'swiftclient.client.Connection',
                 FakeSwiftClient))
 


### PR DESCRIPTION
This module has been deprecated in favor of fixtures.MockPatch.

Change-Id: I52569c71989cbcb9ab34b7106e5d2a68abe204fb
(cherry picked from commit 35fe3b093ec97a83e41ca425b5d133202e60921b)