### PR TITLE
indexer: make sqlalchemy Metadata thread-safe

### DIFF
--- a/gnocchi/indexer/sqlalchemy_base.py
+++ b/gnocchi/indexer/sqlalchemy_base.py
@@ -33,7 +33,10 @@ from gnocchi import indexer
 from gnocchi import resource_type
 from gnocchi import utils
 
-Base = declarative.declarative_base()
+# NOTE(sileht): We create sqlalchemy.Table dynamicaly for
+# resource_type and the sqla.Metadata() is not thread-safe.
+# To avoid race between thread, we create one metadata per thread.
+Base = declarative.declarative_base(metadata=sqlalchemy.ThreadLocalMetaData())
 
 COMMON_TABLES_ARGS = {'mysql_charset': "utf8",
                       'mysql_engine': "InnoDB"}

--- a/gnocchi/tests/indexer/sqlalchemy/test_migrations.py
+++ b/gnocchi/tests/indexer/sqlalchemy/test_migrations.py
@@ -19,7 +19,6 @@ import mock
 import oslo_db.exception
 from oslo_db.sqlalchemy import test_migrations
 import six
-import sqlalchemy as sa
 import sqlalchemy_utils
 
 from gnocchi import indexer
@@ -70,20 +69,3 @@ class ModelsMigrationsSync(
         for rt in self.index.list_resource_types():
             if rt.state == "active":
                 self.index._RESOURCE_TYPE_MANAGER.get_classes(rt)
-
-    def filter_metadata_diff(self, diff):
-        tables_to_keep = []
-        for rt in self.index.list_resource_types():
-            if rt.name.startswith("indexer_test"):
-                tables_to_keep.extend([rt.tablename,
-                                       "%s_history" % rt.tablename])
-        new_diff = []
-        for line in diff:
-            if len(line) >= 2:
-                item = line[1]
-                # NOTE(sileht): skip resource types created for tests
-                if (isinstance(item, sa.Table)
-                        and item.name in tables_to_keep):
-                    continue
-            new_diff.append(line)
-        return new_diff


### PR DESCRIPTION
sqlalchemy provides a threadsafe version of Metadata() object.

Since we load resource type schema dynamically this will avoid race
where our cache is not synced.