### PR TITLE
rest: don't return body on 202

### DIFF
--- a/gnocchi/gendoc.py
+++ b/gnocchi/gendoc.py
@@ -41,6 +41,9 @@ def _format_json(txt):
 
 def _extract_body(req_or_resp):
     # TODO(jd) Make this a Sphinx option
+    if not req_or_resp.body:
+        return ""
+
     if req_or_resp.content_type == "application/json":
         body = _format_json(req_or_resp.body)
     else:

--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -1612,7 +1612,7 @@ class MetricsMeasuresBatchController(rest.RestController):
         {utils.UUID: MeasuresListSchema}
     )
 
-    @pecan.expose()
+    @pecan.expose("json")
     def post(self):
         body = deserialize_and_validate(self.MeasuresBatchSchema)
         metrics = pecan.request.indexer.list_metrics(

--- a/gnocchi/tests/functional/gabbits/batch-measures.yaml
+++ b/gnocchi/tests/functional/gabbits/batch-measures.yaml
@@ -36,6 +36,8 @@ tests:
           - timestamp: "2015-03-06T14:34:12"
             value: 12
       status: 202
+      response_headers:
+        content-length: 0
 
     - name: push measurements to unknown metrics
       POST: /v1/batch/metrics/measures
@@ -122,6 +124,8 @@ tests:
           - timestamp: "2015-03-06T14:34:12"
             value: 12
       status: 202
+      response_headers:
+        content-length: 0
 
     - name: push measurements to two named metrics
       POST: /v1/batch/resources/metrics/measures
@@ -149,6 +153,8 @@ tests:
             - timestamp: "2015-03-06T14:34:12"
               value: 12
       status: 202
+      response_headers:
+        content-length: 0
 
     - name: create archive policy rule for auto
       POST: /v1/archive_policy_rule
@@ -171,6 +177,8 @@ tests:
             - timestamp: "2015-03-06T14:34:12"
               value: 12
       status: 202
+      response_headers:
+        content-length: 0
 
     - name: get created metric to check creation
       GET: /v1/resource/generic/46c9418d-d63b-4cdd-be89-8f57ffc5952e/metric/auto.test

--- a/gnocchi/tests/functional/gabbits/metric.yaml
+++ b/gnocchi/tests/functional/gabbits/metric.yaml
@@ -167,6 +167,8 @@ tests:
           - timestamp: 1425652437.0
             value: 43.1
       status: 202
+      response_headers:
+        content-length: 0
 
     - name: push measurements to metric
       POST: /v1/metric/$HISTORY['list valid metrics'].$RESPONSE['$[0].id']/measures

--- a/gnocchi/tests/functional/gabbits/resource.yaml
+++ b/gnocchi/tests/functional/gabbits/resource.yaml
@@ -481,6 +481,8 @@ tests:
           - timestamp: "2015-03-06T14:34:12"
             value: 12
       status: 202
+      response_headers:
+        content-length: 0
 
     - name: request cpuutil measures again
       GET: $LAST_URL


### PR DESCRIPTION
Batch endpoint tell pecan body is a json, but we don't return body.
So pecan generates the body "null"

This change fixes that.

It also adds tests to ensure the all 202 don't have body set.

Closes #463