### PR TITLE
rest: fix some id search issue

### DIFF
--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -1286,6 +1286,9 @@ ResourceSearchSchemaAttributeValue = voluptuous.Any(
     six.text_type, float, int, bool, None)
 
 
+NotIDKey = voluptuous.All(six.text_type, voluptuous.NotIn(["id"]))
+
+
 def _ResourceSearchSchema():
     user = pecan.request.auth_helper.get_current_user(
         pecan.request)
@@ -1302,20 +1305,21 @@ def _ResourceSearchSchema():
                     u"<=", u"≤", u"le",
                     u">=", u"≥", u"ge",
                     u"!=", u"≠", u"ne",
-                    u"like"
                 ): voluptuous.All(
                     voluptuous.Length(min=1, max=1),
                     {"id": _ResourceUUID,
-                     six.text_type: ResourceSearchSchemaAttributeValue},
+                     NotIDKey: ResourceSearchSchemaAttributeValue},
                 ),
-                voluptuous.Any(
-                    u"in",
-                ): voluptuous.All(
+                u"like": voluptuous.All(
+                    voluptuous.Length(min=1, max=1),
+                    {NotIDKey: ResourceSearchSchemaAttributeValue},
+                ),
+                u"in": voluptuous.All(
                     voluptuous.Length(min=1, max=1),
                     {"id": voluptuous.All(
                         [_ResourceUUID],
                         voluptuous.Length(min=1)),
-                     six.text_type: voluptuous.All(
+                     NotIDKey: voluptuous.All(
                          [ResourceSearchSchemaAttributeValue],
                          voluptuous.Length(min=1))}
                 ),

--- a/gnocchi/tests/functional/gabbits/search.yaml
+++ b/gnocchi/tests/functional/gabbits/search.yaml
@@ -40,6 +40,29 @@ tests:
        - "expected a list for dictionary value @ data["
        - "'and']"
 
+    - name: search like id
+      POST: /v1/search/resource/generic
+      data:
+        like:
+          id: fa%
+      status: 400
+      response_strings:
+       - "Invalid input: extra keys not allowed @ data["
+       - "'like']["
+       - "'id']"
+
+    - name: search like list id
+      POST: /v1/search/resource/generic
+      data:
+        like:
+          id:
+            - fa%
+      status: 400
+      response_strings:
+       - "Invalid input: extra keys not allowed @ data["
+       - "'like']["
+       - "'id']"
+
     - name: search invalid ne value
       desc: attribute value for binary operator must not be dict or list
       POST: /v1/search/resource/generic


### PR DESCRIPTION
id key and like operator have some issue, due to the binary nature of
uuid.

This change avoids it.

Closes #450
Closes #491