### PR TITLE
Set default logging level for swiftclient to WARNING

### DIFF
--- a/gnocchi/service.py
+++ b/gnocchi/service.py
@@ -74,7 +74,7 @@ def prepare_service(args=None, conf=None,
                          "storage")
 
     log.set_defaults(default_log_levels=log.get_default_log_levels() +
-                     ["passlib.utils.compat=INFO"])
+                     ["passlib.utils.compat=INFO", "swiftclient=WARNING"])
     log.setup(conf, 'gnocchi')
     conf.log_opt_values(LOG, log.DEBUG)
 


### PR DESCRIPTION
oslo.log sets the default root level for logging to INFO (or DEBUG in debug
mode). This means swiftclient inherits of the log level INFO and logs out ton
of requests info with their curl command in Gnocchi's log files.

This makes sure oslo.log configures swiftclient to be in WARNING mode anyway so
only the important information are logged.

This bug is not present with daiquiri (Gnocchi >= 4.0) since Gnocchi leaves the
global logging level to WARNING (Python default) to avoid such issues and only
configure Gnocchi's own root level.