### PR TITLE
cli: load uwsgi plugins if needed

### DIFF
--- a/gnocchi/cli/api.py
+++ b/gnocchi/cli/api.py
@@ -82,6 +82,8 @@ def api():
     workers = utils.get_default_workers()
 
     args = [
+        "--if-not-plugin", "python", "--plugin", "python", "--endif",
+        "--if-not-plugin", "http", "--plugin", "http", "--endif",
         "--http", "%s:%d" % (conf.host or conf.api.host,
                              conf.port or conf.api.port),
         "--master",


### PR DESCRIPTION
Some distro build uwsgi with dynamic plugins.

This change makes our cli working with and without uwsgi dynamic
plugins.

Closes #478

(cherry picked from commit 032e8b13c3002d9a9658541051a3e40e76b69d91)