### PR TITLE
Simplify Ceph flavor

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -23,8 +23,8 @@ The list of variants available is:
 * `postgresql` – provides PostgreSQL indexer support
 * `swift` – provides OpenStack Swift storage support
 * `s3` – provides Amazon S3 storage support
-* `ceph_recommended_lib` – provides Ceph (>= 0.80) storage support
-* `ceph_alternative_lib` – provides Ceph (>= 12.2.0) storage support
+* `ceph` – provides Ceph (>= 0.80) storage support
+* `ceph_alternative` – provides Ceph (>= 12.2.0) storage support
 * `redis` – provides Redis storage support
 * `prometheus` – provides Prometheus Remote Write support
 * `doc` – documentation building support

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,9 +40,9 @@ redis =
     redis>=2.10.0 # MIT
 swift =
     python-swiftclient>=3.1.0
-ceph_recommended_lib =
+ceph =
     cradox>=1.2.0
-ceph_alternative_lib =
+ceph_alternative =
     python-rados>=12.2.0 # not available on pypi
 prometheus =
     python-snappy

--- a/tox.ini
+++ b/tox.ini
@@ -19,8 +19,8 @@ setenv =
     postgresql: GNOCCHI_TEST_INDEXER_DRIVERS=postgresql
     mysql: GNOCCHI_TEST_INDEXER_DRIVERS=mysql
 
-    GNOCCHI_STORAGE_DEPS=file,swift,test-swift,s3,ceph,ceph_recommended_lib,redis
-    ceph: GNOCCHI_STORAGE_DEPS=ceph,ceph_recommended_lib
+    GNOCCHI_STORAGE_DEPS=file,swift,test-swift,s3,ceph,redis
+    ceph: GNOCCHI_STORAGE_DEPS=ceph
     swift: GNOCCHI_STORAGE_DEPS=swift,test-swift
     file: GNOCCHI_STORAGE_DEPS=file
     redis: GNOCCHI_STORAGE_DEPS=redis


### PR DESCRIPTION
Now that the `ceph` flavor is gone, let's use `ceph` for the recommended
approach and `ceph_alternative` for the other one.