### PR TITLE
redis: enhance error message is redis is not installed

### DIFF
--- a/gnocchi/common/redis.py
+++ b/gnocchi/common/redis.py
@@ -73,7 +73,7 @@ CLIENT_INT_ARGS = frozenset([
 
 def get_client(conf):
     if redis is None:
-        raise RuntimeError("python-redis unavailable")
+        raise RuntimeError("Redis Python module is unavailable")
     parsed_url = parse.urlparse(conf.redis_url)
     options = parse.parse_qs(parsed_url.query)
 


### PR DESCRIPTION
There's is a python-redis on PyPI, and that's not what we want.
Let's not be confusing.

(cherry picked from commit c89ebb5fb4b06297f8374df86b3e75d51afec494)