### PR TITLE
metricd: expose respect_processing_delay option

### DIFF
--- a/doc/source/operating.rst
+++ b/doc/source/operating.rst
@@ -190,8 +190,23 @@ uses the 6 default |aggregation methods| (mean, min, max, sum, std, count) with
 the same "one year, one minute aggregations" resolution, the space used will go
 up to a maximum of 6 × 4.1 MiB = 24.6 MiB.
 
-How many metricd workers do we need to run
-==========================================
+Metricd
+=======
+
+Metricd is the daemon responsible for processing measures, computing their
+aggregates and storing them into the aggregate storage. It also handles a few
+other cleanup tasks, such as deleting metrics marked for deletion.
+
+Metricd therefore is responsible for most of the CPU usage and I/O job in
+Gnocchi. The archive policy of each metric will influence how fast it performs.
+
+In order to process new measures, metricd checks the incoming storage for new
+measures from time to time. The delay between each check is can be configured
+by changing the `[metricd]metric_processing_delay` configuration option.
+
+
+How many metricd workers do I need to run
+-----------------------------------------
 
 By default, `gnocchi-metricd` daemon spans all your CPU power in order to
 maximize CPU utilisation when computing |metric| aggregation. You can use the
@@ -205,7 +220,7 @@ increase the number of `gnocchi-metricd` daemons. You can run any number of
 metricd daemon on any number of servers.
 
 How to scale measure processing
-===============================
+-------------------------------
 
 Measurement data pushed to Gnocchi is divided into sacks for better
 distribution. The number of partitions is controlled by the `sacks` option
@@ -269,7 +284,7 @@ How to monitor Gnocchi
 
 The `/v1/status` endpoint of the HTTP API returns various information, such as
 the number of |measures| to process (|measures| backlog), which you can easily
-monitor (see `How many metricd workers do we need to run`_). The Gnocchi client
+monitor (see `How many metricd workers do I need to run`_). The Gnocchi client
 can show this output by running `gnocchi status`.
 
 Making sure that the HTTP server and `gnocchi-metricd` daemon are running and

--- a/doc/source/operating.rst
+++ b/doc/source/operating.rst
@@ -204,6 +204,11 @@ In order to process new measures, metricd checks the incoming storage for new
 measures from time to time. The delay between each check is can be configured
 by changing the `[metricd]metric_processing_delay` configuration option.
 
+Some incoming driver (only Redis currently) are able to inform metricd that new
+measures are available for processing. In that case, metricd will not respect
+the `[metricd]metric_processing_delay` parameter and start processing the new
+measures right away. This behaviour can be disabled by turning off the
+`[metricd]greedy` option.
 
 How many metricd workers do I need to run
 -----------------------------------------

--- a/gnocchi/cli/metricd.py
+++ b/gnocchi/cli/metricd.py
@@ -172,9 +172,10 @@ class MetricProcessor(MetricProcessBase):
                       'partitioning. Retrying: %s', e)
             raise tenacity.TryAgain(e)
 
-        filler = threading.Thread(target=self._fill_sacks_to_process)
-        filler.daemon = True
-        filler.start()
+        if self.conf.metricd.greedy:
+            filler = threading.Thread(target=self._fill_sacks_to_process)
+            filler.daemon = True
+            filler.start()
 
     @retry_on_exception.wraps
     def _fill_sacks_to_process(self):

--- a/gnocchi/incoming/__init__.py
+++ b/gnocchi/incoming/__init__.py
@@ -54,7 +54,7 @@ class IncomingDriver(object):
         return self._num_sacks
 
     @staticmethod
-    def __init__(conf):
+    def __init__(conf, greedy=True):
         pass
 
     def get_sack_prefix(self, num_sacks=None):
@@ -189,4 +189,4 @@ def get_driver(conf):
     :param conf: incoming configuration only (not global)
     """
     return utils.get_driver_class('gnocchi.incoming', conf.incoming)(
-        conf.incoming)
+        conf.incoming, conf.metricd.greedy)

--- a/gnocchi/incoming/ceph.py
+++ b/gnocchi/incoming/ceph.py
@@ -30,7 +30,7 @@ class CephStorage(incoming.IncomingDriver):
 
     Q_LIMIT = 1000
 
-    def __init__(self, conf):
+    def __init__(self, conf, greedy=True):
         super(CephStorage, self).__init__(conf)
         self.rados, self.ioctx = ceph.create_rados_connection(conf)
         # NOTE(sileht): constants can't be class attributes because

--- a/gnocchi/incoming/file.py
+++ b/gnocchi/incoming/file.py
@@ -28,7 +28,7 @@ from gnocchi import utils
 
 
 class FileStorage(incoming.IncomingDriver):
-    def __init__(self, conf):
+    def __init__(self, conf, greedy=True):
         super(FileStorage, self).__init__(conf)
         self.basepath = conf.file_basepath
         self.basepath_tmp = os.path.join(self.basepath, 'tmp')

--- a/gnocchi/incoming/redis.py
+++ b/gnocchi/incoming/redis.py
@@ -23,9 +23,10 @@ from gnocchi import incoming
 
 class RedisStorage(incoming.IncomingDriver):
 
-    def __init__(self, conf):
+    def __init__(self, conf, greedy=True):
         super(RedisStorage, self).__init__(conf)
         self._client = redis.get_client(conf)
+        self.greedy = greedy
 
     def __str__(self):
         return "%s: %s" % (self.__class__.__name__, self._client)
@@ -55,7 +56,7 @@ class RedisStorage(incoming.IncomingDriver):
             sack_name = self.get_sack_name(self.sack_for_metric(metric.id))
             path = self._build_measure_path_with_sack(metric.id, sack_name)
             pipe.rpush(path, self._encode_measures(measures))
-            if sack_name not in notified_sacks:
+            if self.greedy and sack_name not in notified_sacks:
                 # value has no meaning, we just use this for notification
                 pipe.setnx(sack_name, 1)
                 notified_sacks.add(sack_name)

--- a/gnocchi/incoming/s3.py
+++ b/gnocchi/incoming/s3.py
@@ -31,7 +31,7 @@ botocore = s3.botocore
 
 class S3Storage(incoming.IncomingDriver):
 
-    def __init__(self, conf):
+    def __init__(self, conf, greedy=True):
         super(S3Storage, self).__init__(conf)
         self.s3, self._region_name, self._bucket_prefix = (
             s3.get_connection(conf)

--- a/gnocchi/incoming/swift.py
+++ b/gnocchi/incoming/swift.py
@@ -27,7 +27,7 @@ swift_utils = swift.swift_utils
 
 
 class SwiftStorage(incoming.IncomingDriver):
-    def __init__(self, conf):
+    def __init__(self, conf, greedy=True):
         super(SwiftStorage, self).__init__(conf)
         self.swift = swift.get_connection(conf)
 

--- a/gnocchi/opts.py
+++ b/gnocchi/opts.py
@@ -136,6 +136,11 @@ def list_opts():
                        deprecated_group='storage',
                        help="How many seconds to wait between "
                        "scheduling new metrics to process"),
+            cfg.BoolOpt(
+                'greedy', default=True,
+                help="Allow to bypass `metric_processing_delay` if metricd "
+                "is notified that measures are ready to be processed."
+            ),
             cfg.IntOpt('metric_reporting_delay',
                        deprecated_group='storage',
                        default=120,

--- a/releasenotes/notes/metricd-respect-processing-delay-option-b8cc9895dec75567.yaml
+++ b/releasenotes/notes/metricd-respect-processing-delay-option-b8cc9895dec75567.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Metricd exposes a new option called `greedy` (true by default) that allows
+    to control whether eager processing of new measures is enabled when
+    available.


### PR DESCRIPTION
This allows to disable eager processing of new measures.

Fixes #507