### PR TITLE
api: add a metric policy filter mechanism

### DIFF
--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -28,7 +28,6 @@ import six
 from six.moves.urllib import parse as urllib_parse
 import tenacity
 import voluptuous
-import webob.exc
 import werkzeug.http
 
 from gnocchi import archive_policy
@@ -655,15 +654,6 @@ class MetricsController(rest.RestController):
                 + ":"
                 + (provided_project_id or "")
             )
-        try:
-            enforce("list all metric", {})
-        except webob.exc.HTTPForbidden:
-            enforce("list metric", {})
-            creator = pecan.request.auth_helper.get_current_user(
-                pecan.request)
-            if provided_creator and creator != provided_creator:
-                abort(403, "Insufficient privileges to filter by user/project")
-            provided_creator = creator
 
         pagination_opts = get_pagination_options(kwargs,
                                                  METRIC_DEFAULT_PAGINATION)
@@ -673,6 +663,12 @@ class MetricsController(rest.RestController):
 
         for k, v in six.iteritems(kwargs):
             attr_filters.append({"=": {k: v}})
+
+        policy_filter = pecan.request.auth_helper.get_metric_policy_filter(
+            pecan.request, "list metric")
+
+        if policy_filter:
+            attr_filters.append(policy_filter)
 
         try:
             metrics = pecan.request.indexer.list_metrics(

--- a/gnocchi/rest/policy.json
+++ b/gnocchi/rest/policy.json
@@ -35,8 +35,7 @@
     "delete metric": "rule:admin_or_creator",
     "get metric": "rule:admin_or_creator or rule:metric_owner",
     "search metric": "rule:admin_or_creator or rule:metric_owner",
-    "list metric": "",
-    "list all metric": "role:admin",
+    "list metric": "rule:admin_or_creator or rule:metric_owner",
 
     "get measures":  "rule:admin_or_creator or rule:metric_owner",
     "post measures":  "rule:admin_or_creator"

--- a/gnocchi/tests/functional/gabbits/metric-list.yaml
+++ b/gnocchi/tests/functional/gabbits/metric-list.yaml
@@ -89,7 +89,7 @@ tests:
     - name: list metrics
       GET: /v1/metric
       response_json_paths:
-          $.`len`: 2
+          $.`len`: 4
 
     - name: list metrics by id
       GET: /v1/metric?id=$HISTORY['create metric 1'].$RESPONSE['id']


### PR DESCRIPTION
Use the auth_helper plugin mechanism to filter metric listing rather than an
hardcoded rule.

The Keystone rule is identical than before and filters based on
created_by_project_id fake-attribute.

The basic/remoteuser rule is changed to mimic the one for resources, i.e., no
filtering is enforced.