### PR TITLE
py3: pass a bytes type object to tooz coordinator

### DIFF
--- a/gnocchi/cli/metricd.py
+++ b/gnocchi/cli/metricd.py
@@ -132,7 +132,7 @@ class MetricReporting(MetricProcessBase):
 
 class MetricProcessor(MetricProcessBase):
     name = "processing"
-    GROUP_ID = "gnocchi-processing"
+    GROUP_ID = b"gnocchi-processing"
 
     def __init__(self, worker_id, conf):
         super(MetricProcessor, self).__init__(
@@ -162,7 +162,8 @@ class MetricProcessor(MetricProcessBase):
         try:
             self.partitioner = self.coord.join_partitioned_group(
                 self.GROUP_ID, partitions=200)
-            LOG.info('Joined coordination group: %s', self.GROUP_ID)
+            LOG.info('Joined coordination group: %s',
+                     self.GROUP_ID.decode())
         except tooz.NotImplemented:
             LOG.warning('Coordinator does not support partitioning. Worker '
                         'will battle against other workers for jobs.')


### PR DESCRIPTION
Ensure that a bytes type id is passed into tooz otherwise
metricd will fail to join the coordination group due to
an error concatenating the GROUP_ID with a str in tooz
when used with the memcached driver.

(cherry picked from commit 9beb7cf75969a5c496c7fafd7f4ee03ce3c05af7)