### PR TITLE
py3: pass a bytes type object to tooz coordinator

### DIFF
--- a/gnocchi/cli.py
+++ b/gnocchi/cli.py
@@ -181,7 +181,7 @@ class MetricReporting(MetricProcessBase):
 
 class MetricProcessor(MetricProcessBase):
     name = "processing"
-    GROUP_ID = "gnocchi-processing"
+    GROUP_ID = b"gnocchi-processing"
 
     def __init__(self, worker_id, conf):
         super(MetricProcessor, self).__init__(
@@ -207,7 +207,7 @@ class MetricProcessor(MetricProcessBase):
         try:
             self.partitioner = self.coord.join_partitioned_group(
                 self.GROUP_ID, partitions=200)
-            LOG.info('Joined coordination group: %s', self.GROUP_ID)
+            LOG.info('Joined coordination group: %s', self.GROUP_ID.decode())
 
             @periodics.periodic(spacing=self.conf.metricd.worker_sync_rate,
                                 run_immediately=True)


### PR DESCRIPTION
Ensure that a bytes type id is passed into tooz otherwise
metricd will fail to join the coordination group due to
an error concatenating the GROUP_ID with a str in tooz
when used with the memcached driver.

(cherry picked from commit 9beb7cf75969a5c496c7fafd7f4ee03ce3c05af7)