### PR TITLE
rest: load details on metric to apply ACL correctly

### DIFF
--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -713,10 +713,7 @@ class NamedMetricController(rest.RestController):
 
     @pecan.expose()
     def _lookup(self, name, *remainder):
-        # NOTE(sileht): We want detail only when we GET /metric/<id>
-        # and not for /metric/<id>/measures
-        details = pecan.request.method == 'GET' and len(remainder) == 0
-        m = pecan.request.indexer.list_metrics(details=details,
+        m = pecan.request.indexer.list_metrics(details=True,
                                                name=name,
                                                resource_id=self.resource_id)
         if m:


### PR DESCRIPTION
The details on metrics need to be retrieved so the ACL can be correctly
applied.

Fixes #464

(cherry picked from commit 697bc413fbbe0a9a5fc320374a625b0fb5b3406e)