### PR TITLE
rest: reduce number of index queries

### DIFF
--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -1515,15 +1515,24 @@ class ResourcesMetricsMeasuresBatchController(rest.RestController):
         unknown_metrics = []
         unknown_resources = []
         body_by_rid = {}
+
+        attribute_filter = {"or": []}
+        for original_resource_id, resource_id in body:
+            names = list(body[(original_resource_id, resource_id)].keys())
+            attribute_filter["or"].append({"and": [
+                {"=": {"resource_id": resource_id}},
+                {"in": {"name": names}}]})
+
+        all_metrics = collections.defaultdict(list)
+        for metric in pecan.request.indexer.list_metrics(
+                attribute_filter=attribute_filter):
+            all_metrics[metric.resource_id].append(metric)
+
         for original_resource_id, resource_id in body:
             body_by_rid[resource_id] = body[(original_resource_id,
                                              resource_id)]
             names = list(body[(original_resource_id, resource_id)].keys())
-            metrics = pecan.request.indexer.list_metrics(
-                attribute_filter={"and": [
-                    {"=": {"resource_id": resource_id}},
-                    {"in": {"name": names}},
-                ]})
+            metrics = all_metrics[resource_id]
 
             known_names = [m.name for m in metrics]
             if strtobool("create_metrics", create_metrics):


### PR DESCRIPTION
I've noticed that "/v1/batch/resources/metrics/measures" endpoint executes database queries many times. Since ceilometer-agent-notification daemons often post batch data for many resources which have a same metric name, it is a bottleneck.