### PR TITLE
Only install futures on Python 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ oslo.middleware>=3.22.0
 pandas>=0.18.0
 scipy>=0.18.1  # BSD
 pecan>=0.9
-futures
+futures; python_version < '3'
 jsonpatch
 cotyledon>=1.5.0
 six


### PR DESCRIPTION
New futures release breaks entirely on Python 3:
 futures requires Python '>=2.6, <3' but the running Python is 3.5.2

Anyway it's a good idea to not install on Python 3.

(cherry picked from commit 77d1f3b29af325c7f07ba0371ea789d0bccb2311)