### PR TITLE
rest: fix error handling on resource conflict

### DIFF
--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -1980,12 +1980,12 @@ def get_or_create_resource_and_metrics(
             return pecan.request.indexer.create_resource(
                 resource_type, rid, creator, **kwargs
             ).metrics
-        except indexer.ResourceAlreadyExists:
+        except indexer.ResourceAlreadyExists as e:
             # NOTE(sileht): ensure the rid is not registered whitin another
             # resource type.
             r = pecan.request.indexer.get_resource('generic', rid)
             if r.type != resource_type:
-                abort(409, six.text_type(e))
+                abort(409, e)
             raise
 
 

--- a/gnocchi/tests/functional/gabbits/influxdb.yaml
+++ b/gnocchi/tests/functional/gabbits/influxdb.yaml
@@ -109,3 +109,22 @@ tests:
 
     - name: check metric created different tag resource id and slash replaced
       GET: /v1/resource/influxdbtest/myvalue/metric/cpu.field@path=_foobar
+
+    - name: create a generic resource for conflict
+      POST: /v1/resource/generic
+      data:
+        id: conflict
+      status: 201
+
+    - name: write lines with conflicting resource
+      POST: /v1/influxdb/write?db=influxdbtest
+      request_headers:
+        content-type: text/plain
+        accept: application/json
+      data:
+        "mymetric,host=conflict,mytag=myvalue field=123 1510581804179554816"
+      status: 409
+      response_json_paths:
+        $.title: "Conflict"
+        $.description.cause: "Resource already exists"
+        $.description.detail: "da19a545-af76-5081-9a88-f370baab66c6"


### PR DESCRIPTION
The current code convert an nonexistent variable into a string. Facepalm.

Let's return the correct exception into the correct format, and test it for
real using InfluxDB. The same will apply to Prometheus anyway.