### PR TITLE
DNM: rest: port /v1/metric API to Falcon + Marshmallow + apispec (OpenAPI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ cover
 .coverage
 dist
 upgrade/
+doc/source/openapi.yml

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -29,8 +29,17 @@ import subprocess
 extensions = [
     'gnocchi.gendoc',
     'sphinxcontrib.httpdomain',
+    'sphinxcontrib.redoc',
     'sphinx.ext.autodoc',
     'reno.sphinxext',
+]
+
+redoc = [
+    {
+        'name': 'Gnocchi API',
+        'page': 'openapi',
+        'spec': 'openapi.yml',
+    },
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/gnocchi/rest/api-paste.ini
+++ b/gnocchi/rest/api-paste.ini
@@ -2,18 +2,21 @@
 use = egg:Paste#urlmap
 / = gnocchiversions_pipeline
 /v1 = gnocchiv1+noauth
+/v1/metric = gnocchiv1metric+noauth
 /healthcheck = healthcheck
 
 [composite:gnocchi+keystone]
 use = egg:Paste#urlmap
 / = gnocchiversions_pipeline
 /v1 = gnocchiv1+keystone
+/v1/metric = gnocchiv1metric+keystone
 /healthcheck = healthcheck
 
 [composite:gnocchi+remoteuser]
 use = egg:Paste#urlmap
 / = gnocchiversions_pipeline
 /v1 = gnocchiv1+noauth
+/v1/metric = gnocchiv1metric+noauth
 /healthcheck = healthcheck
 
 [pipeline:gnocchiv1+noauth]
@@ -21,6 +24,12 @@ pipeline = http_proxy_to_wsgi gnocchiv1
 
 [pipeline:gnocchiv1+keystone]
 pipeline = http_proxy_to_wsgi keystone_authtoken gnocchiv1
+
+[pipeline:gnocchiv1metric+noauth]
+pipeline = http_proxy_to_wsgi gnocchiv1metric
+
+[pipeline:gnocchiv1metric+keystone]
+pipeline = http_proxy_to_wsgi keystone_authtoken gnocchiv1metric
 
 [pipeline:gnocchiversions_pipeline]
 pipeline = http_proxy_to_wsgi gnocchiversions
@@ -32,6 +41,10 @@ root = gnocchi.rest.api.VersionsController
 [app:gnocchiv1]
 paste.app_factory = gnocchi.rest.app:app_factory
 root = gnocchi.rest.api.V1Controller
+
+[app:gnocchiv1metric]
+paste.app_factory = gnocchi.rest.app:app_falcon_factory
+root = gnocchi.rest.metric.make_app
 
 [filter:keystone_authtoken]
 use = egg:keystonemiddleware#auth_token

--- a/gnocchi/rest/app.py
+++ b/gnocchi/rest/app.py
@@ -155,3 +155,15 @@ def app_factory(global_config, **local_conf):
     global APPCONFIGS
     appconfig = APPCONFIGS.get(global_config.get('configkey'))
     return _setup_app(root=local_conf.get('root'), **appconfig)
+
+
+def app_falcon_factory(global_config, **local_conf):
+    global APPCONFIGS
+    appconfig = APPCONFIGS.get(global_config.get('configkey'))
+
+    parts = local_conf.get('root').split('.')
+    name = '.'.join(parts[:-1])
+    fromlist = parts[-1:]
+
+    module = __import__(name, fromlist=fromlist)
+    return getattr(module, parts[-1])(**appconfig)

--- a/gnocchi/rest/auth_helper.py
+++ b/gnocchi/rest/auth_helper.py
@@ -119,7 +119,7 @@ class BasicAuthHelper(object):
     @staticmethod
     def get_current_user(request):
         auth = werkzeug.http.parse_authorization_header(
-            request.headers.get("Authorization"))
+            request.headers.get("AUTHORIZATION"))
         if auth is None:
             api.abort(401)
         return auth.username

--- a/gnocchi/rest/metric.py
+++ b/gnocchi/rest/metric.py
@@ -1,0 +1,426 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright © 2017 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+import functools
+import uuid
+
+import falcon
+from falcon import status_codes
+from oslo_policy import policy
+import six
+from six.moves.urllib import parse as urllib_parse
+from stevedore import driver
+import voluptuous
+
+from gnocchi import archive_policy
+from gnocchi import indexer
+from gnocchi import json
+from gnocchi.rest import api
+from gnocchi import storage
+from gnocchi import utils
+
+
+def enforce(policy_enforcer, auth_info, rule, target):
+    """Return the user and project the request should be limited to.
+
+    :param policy_enforcer: The policy enforcer.
+    :param auth_info: The user credentials.
+    :param rule: The rule name.
+    :param target: The target to enforce on.
+
+    """
+    if not isinstance(target, dict):
+        if hasattr(target, "jsonify"):
+            target = target.jsonify()
+        else:
+            target = target.__dict__
+
+    # Flatten dict
+    target = dict(api.flatten_dict_to_keypairs(d=target, separator='.'))
+
+    if not policy_enforcer.enforce(rule, target, auth_info):
+        abort(403)
+
+
+def validate(schema, data, required=True):
+    try:
+        return voluptuous.Schema(schema, required=required)(data)
+    except voluptuous.Error as e:
+        abort(400, "Invalid input: %s" % e)
+
+
+def deserialize_and_validate(req, schema, required=True,
+                             expected_content_types=("application/json",)):
+    return validate(
+        schema,
+        deserialize(req, expected_content_types=expected_content_types),
+        required)
+
+
+def deserialize(req, expected_content_types=("application/json",)):
+    if req.content_type not in expected_content_types:
+        abort(415)
+    try:
+        return json.load(req.stream)
+    except Exception as e:
+        abort(400, "Unable to decode body: " + six.text_type(e))
+
+
+def get_pagination_options(params, max_limit, default):
+    try:
+        opts = voluptuous.Schema({
+            voluptuous.Required(
+                "limit", default=max_limit):
+            voluptuous.All(voluptuous.Coerce(int),
+                           voluptuous.Range(min=1),
+                           voluptuous.Clamp(
+                               min=1, max=max_limit)),
+            "marker": six.text_type,
+            voluptuous.Required("sort", default=default):
+            voluptuous.All(
+                voluptuous.Coerce(api.arg_to_list),
+                [six.text_type]),
+        }, extra=voluptuous.REMOVE_EXTRA)(params)
+    except voluptuous.Invalid as e:
+        abort(400, {"cause": "Argument value error",
+                    "reason": str(e)})
+    opts['sorts'] = opts['sort']
+    del opts['sort']
+    return opts
+
+
+def abort(status_code, detail=''):
+    if status_code == 404 and not detail:
+        raise RuntimeError("http code 404 must have 'detail' set")
+    if isinstance(detail, Exception):
+        detail = detail.jsonify()
+    raise falcon.HTTPError(getattr(status_codes, "HTTP_" + str(status_code)),
+                           description=detail)
+
+
+def set_resp_location_hdr(req, resp, location):
+    location = '%s%s' % (req.app, location)
+    # NOTE(sileht): according the pep-3333 the headers must be
+    # str in py2 and py3 even this is not the same thing in both
+    # version
+    # see: http://legacy.python.org/dev/peps/pep-3333/#unicode-issues
+    if six.PY2 and isinstance(location, six.text_type):
+        location = location.encode('utf-8')
+    location = urllib_parse.quote(location)
+    resp.set_header('Location', location)
+
+
+def set_resp_link_hdr(req, resp, marker, *args):
+    # NOTE(sileht): This comes from rfc5988.
+    # Setting prev, last is too costly/complicated, so just set next for now.
+    options = {}
+    for arg in args:
+        options.update(arg)
+    if "sorts" in options:
+        options["sort"] = options["sorts"]
+        del options["sorts"]
+    options["marker"] = marker
+    # NOTE(sileht): To always have the same orders
+    options = sorted(options.items())
+    params = urllib_parse.urlencode(options, doseq=True)
+    resp.add_link('%s://%s%s?%s' % (
+        req.scheme, req.netloc, req.app, params
+    ), "next")
+
+
+class MetricsResource(object):
+
+    MetricListSchema = voluptuous.Schema({
+        "user_id": six.text_type,
+        "project_id": six.text_type,
+        "creator": six.text_type,
+        "name": six.text_type,
+        "id": six.text_type,
+        "unit": six.text_type,
+        "archive_policy_name": six.text_type,
+        "status": voluptuous.Any("active", "delete"),
+    }, extra=voluptuous.REMOVE_EXTRA)
+
+    def __init__(self, policy_enforcer, auth_helper, indexer, max_limit):
+        self.policy_enforcer = policy_enforcer
+        self.auth_helper = auth_helper
+        self.indexer = indexer
+        self.max_limit = max_limit
+
+    def on_get(self, req, resp):
+        filtering = self.MetricListSchema(req.params)
+
+        # Compat with old user/project API
+        provided_user_id = filtering.pop('user_id', None)
+        provided_project_id = filtering.pop('project_id', None)
+        if provided_user_id is None and provided_project_id is None:
+            provided_creator = filtering.pop('creator', None)
+        else:
+            provided_creator = (
+                (provided_user_id or "")
+                + ":"
+                + (provided_project_id or "")
+            )
+
+        pagination_opts = get_pagination_options(
+            req.params, self.max_limit, api.METRIC_DEFAULT_PAGINATION)
+        attr_filters = []
+        if provided_creator is not None:
+            attr_filters.append({"=": {"creator": provided_creator}})
+
+        for k, v in six.iteritems(filtering):
+            attr_filters.append({"=": {k: v}})
+
+        policy_filter = self.auth_helper.get_metric_policy_filter(
+            req, "list metric")
+        resource_policy_filter = (
+            self.auth_helper.get_resource_policy_filter(
+                req, "list metric", resource_type=None,
+                prefix="resource")
+        )
+
+        try:
+            metrics = self.indexer.list_metrics(
+                attribute_filter={"and": attr_filters},
+                policy_filter=policy_filter,
+                resource_policy_filter=resource_policy_filter,
+                **pagination_opts)
+        except indexer.IndexerException as e:
+            abort(400, six.text_type(e))
+
+        if metrics and len(metrics) >= pagination_opts['limit']:
+            # HACK(jd) replace by req.path when the root is the API and not
+            # metric
+            set_resp_link_hdr(req, resp,
+                              str(metrics[-1].id), req.params, pagination_opts)
+
+        resp.body = json.dumps(metrics)
+
+    # NOTE(jd) Define this method as it was a voluptuous schema – it's just a
+    # smarter version of a voluptuous schema, no?
+    def MetricSchema(self, definition, auth_info, creator):
+        # First basic validation
+        schema = voluptuous.Schema({
+            "archive_policy_name": six.text_type,
+            "resource_id": functools.partial(api.ResourceID, creator=creator),
+            "name": six.text_type,
+            voluptuous.Optional("unit"):
+            voluptuous.All(six.text_type, voluptuous.Length(max=31)),
+        })
+        definition = schema(definition)
+        archive_policy_name = definition.get('archive_policy_name')
+
+        name = definition.get('name')
+        if name and '/' in name:
+            abort(400, "'/' is not supported in metric name")
+        if archive_policy_name is None:
+            try:
+                ap = self.indexer.get_archive_policy_for_metric(name)
+            except indexer.NoArchivePolicyRuleMatch:
+                # NOTE(jd) Since this is a schema-like function, we
+                # should/could raise ValueError, but if we do so, voluptuous
+                # just returns a "invalid value" with no useful message – so we
+                # prefer to use abort() to make sure the user has the right
+                # error message
+                abort(400, "No archive policy name specified "
+                      "and no archive policy rule found matching "
+                      "the metric name %s" % name)
+            else:
+                definition['archive_policy_name'] = ap.name
+
+        resource_id = definition.get('resource_id')
+        if resource_id is None:
+            original_resource_id = None
+        else:
+            if name is None:
+                abort(400,
+                      {"cause": "Attribute value error",
+                       "detail": "name",
+                       "reason": "Name cannot be null "
+                       "if resource_id is not null"})
+            original_resource_id, resource_id = resource_id
+
+        enforce(self.policy_enforcer, auth_info, "create metric", {
+            "creator": creator,
+            "archive_policy_name": archive_policy_name,
+            "resource_id": resource_id,
+            "original_resource_id": original_resource_id,
+            "name": name,
+            "unit": definition.get('unit'),
+        })
+
+        return definition
+
+    def on_post(self, req, resp):
+        creator = self.auth_helper.get_current_user(req)
+        auth_info = self.auth_helper.get_auth_info(req)
+        body = deserialize_and_validate(
+            req, functools.partial(self.MetricSchema,
+                                   auth_info=auth_info,
+                                   creator=creator))
+
+        resource_id = body.get('resource_id')
+        if resource_id is not None:
+            resource_id = resource_id[1]
+
+        try:
+            m = self.indexer.create_metric(
+                uuid.uuid4(),
+                creator,
+                resource_id=resource_id,
+                name=body.get('name'),
+                unit=body.get('unit'),
+                archive_policy_name=body['archive_policy_name'])
+        except indexer.NoSuchArchivePolicy as e:
+            abort(400, six.text_type(e))
+        except indexer.NamedMetricAlreadyExists as e:
+            abort(400, e)
+        set_resp_location_hdr(req, resp, "/" + str(m.id))
+        resp.status = 201
+        resp.body = json.dumps(m)
+
+
+class MetricResourceBase(object):
+    def __init__(self, policy_enforcer, auth_helper, indexer):
+        self.policy_enforcer = policy_enforcer
+        self.auth_helper = auth_helper
+        self.indexer = indexer
+
+    def _get_metric(self, enforce_rule, metric_id, req):
+        metrics = self.indexer.list_metrics(
+            attribute_filter={"=": {"id": metric_id}},
+            details=True)
+        if not metrics:
+            abort(404, six.text_type(indexer.NoSuchMetric(metric_id)))
+        metric = metrics[0]
+        auth_info = self.auth_helper.get_auth_info(req)
+        enforce(self.policy_enforcer, auth_info,
+                enforce_rule, json.to_primitive(metric))
+        return metric
+
+
+class MetricResource(MetricResourceBase):
+    def on_get(self, req, resp, metric_id):
+        metric = self._get_metric("get metric", metric_id, req)
+        resp.body = json.dumps(metric)
+
+    def on_delete(self, req, resp, metric_id):
+        metric = self._get_metric("get metric", metric_id, req)
+        try:
+            self.indexer.delete_metric(metric.id)
+        except indexer.NoSuchMetric as e:
+            abort(404, six.text_type(e))
+        resp.status = 204
+
+
+class MeasuresResource(MetricResourceBase):
+    def __init__(self, policy_enforcer, auth_helper, indexer,
+                 storage, incoming, operation_timeout):
+        super(MeasuresResource, self).__init__(
+            policy_enforcer, auth_helper, indexer)
+        self.storage = storage
+        self.incoming = incoming
+        self.operation_timeout = operation_timeout
+
+    def on_post(self, req, resp, metric_id):
+        metric = self._get_metric("post measures", metric_id, req)
+        params = deserialize(req)
+        if not isinstance(params, list):
+            abort(400, "Invalid input for measures")
+        if params:
+            self.incoming.add_measures(
+                metric, api.MeasuresListSchema(params))
+        resp.status = 202
+
+    def on_get(self, req, resp, metric_id):
+        metric = self._get_metric("get measures", metric_id, req)
+        aggregation = req.get_param("aggregation", default="mean")
+        if (aggregation not in
+           archive_policy.ArchivePolicy.VALID_AGGREGATION_METHODS):
+            msg = "Invalid aggregation value %(agg)s, must be one of %(std)s"
+            abort(400, msg % dict(
+                agg=aggregation,
+                std=archive_policy.ArchivePolicy.VALID_AGGREGATION_METHODS))
+
+        start = req.get_param("start")
+        if start is not None:
+            try:
+                start = utils.to_timestamp(start)
+            except Exception:
+                abort(400, "Invalid value for start")
+
+        stop = req.get_param("stop")
+        if stop is not None:
+            try:
+                stop = utils.to_timestamp(stop)
+            except Exception:
+                abort(400, "Invalid value for stop")
+
+        granularity = req.get_param("granularity")
+        if granularity is not None:
+            try:
+                granularity = utils.to_timespan(granularity)
+            except ValueError:
+                abort(400, {"cause": "Attribute value error",
+                            "detail": "granularity",
+                            "reason": "Invalid granularity"})
+
+        resample = req.get_param("resample")
+        if resample:
+            if not granularity:
+                abort(400, 'A granularity must be specified to resample')
+            try:
+                resample = utils.to_timespan(resample)
+            except ValueError as e:
+                abort(400, six.text_type(e))
+
+        refresh = req.get_param_as_bool("refresh",  blank_as_true=True)
+        if refresh and self.incoming.has_unprocessed(metric):
+            try:
+                self.storage.refresh_metric(
+                    self.indexer, self.incoming, metric,
+                    self.operation_timeout)
+            except storage.SackLockTimeoutError as e:
+                abort(503, six.text_type(e))
+        try:
+            measures = self.storage.get_measures(
+                metric, start, stop, aggregation,
+                granularity, resample)
+        except (storage.MetricDoesNotExist,
+                storage.GranularityDoesNotExist,
+                storage.AggregationDoesNotExist) as e:
+            abort(404, six.text_type(e))
+        resp.body = json.dumps(measures)
+
+
+def make_app(conf, indexer, storage, incoming,
+             not_implemented_middleware):
+    app = falcon.API()
+    policy_enforcer = policy.Enforcer(conf)
+    auth_helper = driver.DriverManager("gnocchi.rest.auth_helper",
+                                       conf.api.auth_mode,
+                                       invoke_on_load=True).driver
+    app.add_route('/',
+                  MetricsResource(policy_enforcer,
+                                  auth_helper, indexer,
+                                  conf.api.max_limit))
+    app.add_route('/{metric_id:uuid}',
+                  MetricResource(policy_enforcer,
+                                 auth_helper, indexer))
+    app.add_route('/{metric_id:uuid}/measures',
+                  MeasuresResource(policy_enforcer,
+                                   auth_helper, indexer, storage, incoming,
+                                   conf.api.operation_timeout))
+    return app

--- a/gnocchi/tests/functional/gabbits/metric-derived.yaml
+++ b/gnocchi/tests/functional/gabbits/metric-derived.yaml
@@ -78,8 +78,8 @@ tests:
       response_json_paths:
           $:
             - ['2015-03-06T14:34:00+00:00', 60.0, 2.0]
-            - ['2015-03-06T14:35:00+00:00', 60.0, 5.833333333333333]
-            - ['2015-03-06T14:36:00+00:00', 60.0, 9.166666666666666]
+            - ['2015-03-06T14:35:00+00:00', 60.0, 5.8333333333]
+            - ['2015-03-06T14:36:00+00:00', 60.0, 9.1666666667]
 
     - name: get measurements rate:95pct
       GET: /v1/metric/$HISTORY['create valid metric'].$RESPONSE['id']/measures?aggregation=rate:95pct
@@ -167,8 +167,8 @@ tests:
       response_json_paths:
           $:
             - ['2015-03-06T14:34:00+00:00', 60.0, 2.0]
-            - ['2015-03-06T14:35:00+00:00', 60.0, 5.833333333333333]
-            - ['2015-03-06T14:36:00+00:00', 60.0, 9.166666666666666]
+            - ['2015-03-06T14:35:00+00:00', 60.0, 5.8333333333]
+            - ['2015-03-06T14:36:00+00:00', 60.0, 9.1666666667]
 
     - name: get measurements rate:95pct second metric
       GET: /v1/metric/$HISTORY['create a second metric'].$RESPONSE['id']/measures?aggregation=rate:95pct

--- a/gnocchi/tests/functional/gabbits/metric-list.yaml
+++ b/gnocchi/tests/functional/gabbits/metric-list.yaml
@@ -137,7 +137,7 @@ tests:
         # User admin
         authorization: "basic YWRtaW46"
       response_headers:
-          Link: "<$SCHEME://$NETLOC/v1/metric?archive_policy_name=first_archive&limit=2&marker=$RESPONSE['$[1].id']&sort=name%3Adesc>; rel=\"next\""
+          Link: "<$SCHEME://$NETLOC/v1/metric?archive_policy_name=first_archive&limit=2&marker=$RESPONSE['$[1].id']&sort=name%3Adesc>; rel=next"
       response_json_paths:
           $.`len`: 2
           $[0].name: disk.io.rate

--- a/gnocchi/tests/functional/gabbits/metric.yaml
+++ b/gnocchi/tests/functional/gabbits/metric.yaml
@@ -95,14 +95,18 @@ tests:
 
     - name: create metric with name and over length unit
       POST: /v1/metric
+      request_headers:
+        accept: application/json
       data:
           name: "disk.io.rate"
           unit: "over_length_unit_over_length_unit"
       status: 400
-      response_strings:
-          # split to not match the u' in py2
-          - "Invalid input: length of value must be at most 31 for dictionary value @ data["
-          - "'unit']"
+      response_json_paths:
+        $.description:
+          - cause: Attribute value error
+            detail: unit
+            reason:
+              - Longer than maximum length 31.
 
     - name: create metric with name no rule
       POST: /v1/metric

--- a/gnocchi/tests/functional/gabbits/metric.yaml
+++ b/gnocchi/tests/functional/gabbits/metric.yaml
@@ -84,12 +84,14 @@ tests:
 
     - name: create metric with invalid name
       POST: /v1/metric
+      request_headers:
+        accept: application/json
       data:
           name: "disk/io/rate"
           unit: "B/s"
       status: 400
-      response_strings:
-        - "'/' is not supported in metric name"
+      response_json_paths:
+        $.description: '''/'' is not supported in metric name'
 
     - name: create metric with name and over length unit
       POST: /v1/metric

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ tooz>=1.38
 cachetools
 falcon
 marshmallow
+apispec

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ lz4>=0.9.0
 tooz>=1.38
 cachetools
 falcon
+marshmallow

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ pyparsing>=2.2.0
 lz4>=0.9.0
 tooz>=1.38
 cachetools
+falcon

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ doc =
     sphinx<1.6.0
     sphinx_rtd_theme
     sphinxcontrib-httpdomain
+    sphinxcontrib-redoc
     PyYAML
     Jinja2
     reno>=1.6.2


### PR DESCRIPTION
This is a PoC that I made in a few hours to port the metric API to Falcon. I
wanted to have a glimpse on how easy it would be – and it was very easy.

For now, I like how easier the routing is and how cleaner and easier to grasp
it is compared to Pecan. However, I don't see any killer feature yet.

This patch passes all the Gabbi test, and some of the test_rest tests. I don't
see a point yet in making test_rest pass, as it is good enough for what I was
trying to do.