### PR TITLE
rest: fix exception handling in batch measures

### DIFF
--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -1539,7 +1539,7 @@ class ResourcesMetricsMeasuresBatchController(rest.RestController):
                                 archive_policy_name=metric[
                                     'archive_policy_name'])
                         except indexer.NamedMetricAlreadyExists as e:
-                            already_exists_names.append(e.metric)
+                            already_exists_names.append(e.metric_name)
                         except indexer.NoSuchResource:
                             unknown_resources.append({
                                 'resource_id': six.text_type(resource_id),


### PR DESCRIPTION
This change have no tests, since the issue occurs only when the metric
is created by 2 HTTP calls in parallel.

Closes #552

(cherry picked from commit 7727d9aa65e2fdbc2dc6e228d64ab535a47a6a2e)