### PR TITLE
Ban keystonemiddleware 4.19

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ classifier =
 
 [extras]
 keystone =
-    keystonemiddleware>=4.0.0
+    keystonemiddleware>=4.0.0,!=4.19.0
 mysql =
     pymysql
     oslo.db>=4.8.0,!=4.13.1,!=4.13.2,!=4.15.0
@@ -65,7 +65,7 @@ test =
     testtools>=0.9.38
     WebTest>=2.0.16
     doc8
-    keystonemiddleware>=4.0.0
+    keystonemiddleware>=4.0.0,!=4.19.0
     wsgi_intercept>=1.4.1
 test-swift =
     python-swiftclient


### PR DESCRIPTION
Last keystonemiddleware have some missing dependencies.
https://review.openstack.org/526624

Ban this version for now

(cherry picked from commit 989bf8db891a3fe7ab768f2d04a34ccb772c184c)