### PR TITLE
Remove unused tox targets

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -127,21 +127,6 @@ whitelist_externals = bash
 commands = flake8
            bashate -v devstack/plugin.sh
 
-[testenv:py27-gate]
-setenv = GNOCCHI_TEST_PATH=gnocchi/tests/functional_live
-         GABBI_LIVE=1
-passenv = {[testenv]passenv} GNOCCHI_SERVICE* GNOCCHI_AUTHORIZATION
-sitepackages = True
-basepython = python2.7
-commands = {toxinidir}/tools/pretty_tox.sh '{posargs}'
-
-# This target provides a shortcut to running just the gabbi tests.
-[testenv:py27-gabbi]
-deps = .[test,postgresql,file]
-setenv = GNOCCHI_TEST_PATH=gnocchi/tests/functional
-basepython = python2.7
-commands = pifpaf -g GNOCCHI_INDEXER_URL run postgresql -- {toxinidir}/tools/pretty_tox.sh '{posargs}'
-
 [testenv:py27-cover]
 commands = pifpaf -g GNOCCHI_INDEXER_URL run postgresql -- python setup.py testr --coverage --testr-args="{posargs}"
 


### PR DESCRIPTION
py27-gate is not used anymore and I don't think anyone uses py27-gabbi, you can
just filter the test by name easily.