### PR TITLE
rest: fail properly if granularity is not a timespan

### DIFF
--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -486,6 +486,14 @@ class MetricController(rest.RestController):
             except Exception:
                 abort(400, "Invalid value for stop")
 
+        if granularity is not None:
+            try:
+                granularity = utils.to_timespan(granularity)
+            except ValueError:
+                abort(400, {"cause": "Attribute value error",
+                            "detail": "granularity",
+                            "reason": "Invalid granularity"})
+
         if resample:
             if not granularity:
                 abort(400, 'A granularity must be specified to resample')
@@ -511,9 +519,7 @@ class MetricController(rest.RestController):
                     start, stop, **param)
             return pecan.request.storage.get_measures(
                 self.metric, start, stop, aggregation,
-                utils.to_timespan(granularity)
-                if granularity is not None else None,
-                resample)
+                granularity, resample)
         except (storage.MetricDoesNotExist,
                 storage.GranularityDoesNotExist,
                 storage.AggregationDoesNotExist) as e:

--- a/gnocchi/tests/functional/gabbits/metric.yaml
+++ b/gnocchi/tests/functional/gabbits/metric.yaml
@@ -194,6 +194,16 @@ tests:
           - ["2015-03-06T14:33:57+00:00", 1.0, 43.1]
           - ["2015-03-06T14:34:12+00:00", 1.0, 12.0]
 
+    - name: get measurements from metric invalid granularity
+      GET: /v1/metric/$HISTORY['list valid metrics'].$RESPONSE['$[0].id']/measures?granularity=foobar
+      request_headers:
+        accept: application/json
+      status: 400
+      response_json_paths:
+        $.description.cause: Attribute value error
+        $.description.reason: Invalid granularity
+        $.description.detail: granularity
+
     - name: push measurements to metric again
       POST: /v1/metric/$HISTORY['list valid metrics'].$RESPONSE['$[0].id']/measures
       data:


### PR DESCRIPTION
The current code will fail with a 500 error.

(cherry picked from commit 63ea0aaa3a6b1c277f132afad157af5547b78b8b)