### PR TITLE
rest: do not validate paging keys in metric listing

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -125,7 +125,9 @@ Configuring authentication
 
 The API server supports different authentication methods:
 
-* `basic` (the default) which uses the standard HTTP `Authorization` header.
+* `basic` (the default) which uses the standard HTTP `Authorization` header. By
+  default, only the user `admin` has some special permissions (e.g. create
+  archive policies). The password of the authentication is not used.
 
 * `keystone` to use `OpenStack Keystone`_. If you successfully installed the
   `keystone` flavor using `pip` (see :ref:`installation`), you can set
@@ -133,9 +135,9 @@ The API server supports different authentication methods:
   You also need to configure the `keystone_authtoken` section in `gnocchi.conf`
   with the proper value so Gnocchi is able to validate tokens.
 
-* `remoteuser` Gnocchi will look at the HTTP server REMOTE_USER environment
-   variable to get the username. Then the permissions model is the same as the
-   `basic` mode.
+* `remoteuser` where Gnocchi will look at the HTTP server `REMOTE_USER`
+  environment variable to get the username. Then the permissions model is the
+  same as the `basic` mode.
 
 .. _`OpenStack Keystone`: http://launchpad.net/keystone
 

--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -632,26 +632,23 @@ class MetricsController(rest.RestController):
         "user_id": six.text_type,
         "project_id": six.text_type,
         "creator": six.text_type,
-        "limit": six.text_type,
         "name": six.text_type,
         "id": six.text_type,
         "unit": six.text_type,
         "archive_policy_name": six.text_type,
         "status": voluptuous.Any("active", "delete"),
-        "sort": voluptuous.Any([six.text_type], six.text_type),
-        "marker": six.text_type,
-    })
+    }, extra=voluptuous.REMOVE_EXTRA)
 
     @classmethod
     @pecan.expose('json')
     def get_all(cls, **kwargs):
-        kwargs = cls.MetricListSchema(kwargs)
+        filtering = cls.MetricListSchema(kwargs)
 
         # Compat with old user/project API
-        provided_user_id = kwargs.pop('user_id', None)
-        provided_project_id = kwargs.pop('project_id', None)
+        provided_user_id = filtering.pop('user_id', None)
+        provided_project_id = filtering.pop('project_id', None)
         if provided_user_id is None and provided_project_id is None:
-            provided_creator = kwargs.pop('creator', None)
+            provided_creator = filtering.pop('creator', None)
         else:
             provided_creator = (
                 (provided_user_id or "")
@@ -665,10 +662,8 @@ class MetricsController(rest.RestController):
         if provided_creator is not None:
             attr_filters.append({"=": {"creator": provided_creator}})
 
-        for k, v in six.iteritems(kwargs):
-            # Ignore pagination option
-            if k not in ('limit', 'marker', 'sort'):
-                attr_filters.append({"=": {k: v}})
+        for k, v in six.iteritems(filtering):
+            attr_filters.append({"=": {k: v}})
 
         policy_filter = pecan.request.auth_helper.get_metric_policy_filter(
             pecan.request, "list metric")


### PR DESCRIPTION
The current code in metric listing tries to validate the paging keys with
voluptuous, but they are actually and correctly validated later by
get_pagination_options(). Let's stop trying to be smart here and ignore them.