### PR TITLE
rest: do not catch too wide exception

### DIFF
--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -687,7 +687,7 @@ class MetricsController(rest.RestController):
             if metrics and len(metrics) >= pagination_opts['limit']:
                 set_resp_link_hdr(str(metrics[-1].id), kwargs, pagination_opts)
             return metrics
-        except indexer.IndexerException as e:
+        except indexer.InvalidPagination as e:
             abort(400, six.text_type(e))
 
 


### PR DESCRIPTION
The only user-related problem that can be raised here is InvalidPagination. Any
other indexer exception would be a programming error, and should raise a 500
(and should be fixed). Do not convert blindly all IndexerException as it was
the user fault.