### PR TITLE
incoming: only know about metric id

### DIFF
--- a/gnocchi/incoming/__init__.py
+++ b/gnocchi/incoming/__init__.py
@@ -107,13 +107,13 @@ class IncomingDriver(object):
         return numpy.array(list(measures),
                            dtype=TIMESERIES_ARRAY_DTYPE).tobytes()
 
-    def add_measures(self, metric, measures):
+    def add_measures(self, metric_id, measures):
         """Add a measure to a metric.
 
-        :param metric: The metric measured.
+        :param metric_id: The metric measured.
         :param measures: The actual measures.
         """
-        self.add_measures_batch({metric: measures})
+        self.add_measures_batch({metric_id: measures})
 
     def add_measures_batch(self, metrics_and_measures):
         """Add a batch of measures for some metrics.
@@ -124,12 +124,12 @@ class IncomingDriver(object):
         """
         utils.parallel_map(
             self._store_new_measures,
-            ((metric, self._encode_measures(measures))
-             for metric, measures
+            ((metric_id, self._encode_measures(measures))
+             for metric_id, measures
              in six.iteritems(metrics_and_measures)))
 
     @staticmethod
-    def _store_new_measures(metric, data):
+    def _store_new_measures(metric_id, data):
         raise exceptions.NotImplementedError
 
     def measures_report(self, details=True):
@@ -155,15 +155,15 @@ class IncomingDriver(object):
         raise exceptions.NotImplementedError
 
     @staticmethod
-    def delete_unprocessed_measures_for_metric_id(metric_id):
+    def delete_unprocessed_measures_for_metric(metric_id):
         raise exceptions.NotImplementedError
 
     @staticmethod
-    def process_measure_for_metric(metric):
+    def process_measure_for_metric(metric_id):
         raise exceptions.NotImplementedError
 
     @staticmethod
-    def has_unprocessed(metric):
+    def has_unprocessed(metric_id):
         raise exceptions.NotImplementedError
 
     def sack_for_metric(self, metric_id):

--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -457,7 +457,7 @@ class MetricController(rest.RestController):
             abort(400, "Invalid input for measures")
         if params:
             pecan.request.incoming.add_measures(
-                self.metric, MeasuresListSchema(params))
+                self.metric.id, MeasuresListSchema(params))
         pecan.response.status = 202
 
     @pecan.expose('json')
@@ -501,7 +501,7 @@ class MetricController(rest.RestController):
                 abort(400, six.text_type(e))
 
         if (strtobool("refresh", refresh) and
-                pecan.request.incoming.has_unprocessed(self.metric)):
+                pecan.request.incoming.has_unprocessed(self.metric.id)):
             try:
                 pecan.request.storage.refresh_metric(
                     pecan.request.indexer, pecan.request.incoming, self.metric,
@@ -1596,7 +1596,7 @@ class ResourcesMetricsMeasuresBatchController(rest.RestController):
             enforce("post measures", metric)
 
         pecan.request.incoming.add_measures_batch(
-            dict((metric,
+            dict((metric.id,
                  body_by_rid[metric.resource_id][metric.name])
                  for metric in known_metrics))
 
@@ -1629,7 +1629,7 @@ class MetricsMeasuresBatchController(rest.RestController):
             enforce("post measures", metric)
 
         pecan.request.incoming.add_measures_batch(
-            dict((metric, body[metric.id]) for metric in
+            dict((metric.id, body[metric.id]) for metric in
                  metrics))
 
         pecan.response.status = 202
@@ -1815,7 +1815,7 @@ class AggregationController(rest.RestController):
             if strtobool("refresh", refresh):
                 metrics_to_update = [
                     m for m in metrics
-                    if pecan.request.incoming.has_unprocessed(m)]
+                    if pecan.request.incoming.has_unprocessed(m.id)]
                 for m in metrics_to_update:
                     try:
                         pecan.request.storage.refresh_metric(
@@ -2047,7 +2047,7 @@ class PrometheusWriteController(rest.RestController):
                 enforce("post measures", metric)
 
             measures_to_batch.update(
-                dict((metric, measures[metric.name]) for metric in
+                dict((metric.id, measures[metric.name]) for metric in
                      metrics if metric.name in measures))
 
         pecan.request.incoming.add_measures_batch(measures_to_batch)

--- a/gnocchi/rest/influxdb.py
+++ b/gnocchi/rest/influxdb.py
@@ -245,7 +245,7 @@ class InfluxDBController(rest.RestController):
                     api.enforce("post measures", metric)
 
                 measures_to_batch.update(
-                    dict((metric, metrics_and_measures[metric.name])
+                    dict((metric.id, metrics_and_measures[metric.name])
                          for metric in metrics
                          if metric.name in metrics_and_measures))
 

--- a/gnocchi/statsd.py
+++ b/gnocchi/statsd.py
@@ -113,7 +113,7 @@ class Stats(object):
                         name=metric_name,
                         resource_id=self.conf.statsd.resource_id)
                     self.metrics[metric_name] = metric
-                self.incoming.add_measures(metric, (measure,))
+                self.incoming.add_measures(metric.id, (measure,))
             except Exception as e:
                 LOG.error("Unable to add measure %s: %s",
                           metric_name, e)

--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -403,7 +403,7 @@ class StorageDriver(object):
         #              is going to process it anymore.
         lock.release()
         self._delete_metric(metric)
-        incoming.delete_unprocessed_measures_for_metric_id(metric.id)
+        incoming.delete_unprocessed_measures_for_metric(metric.id)
         LOG.debug("Deleted metric %s", metric)
 
     @staticmethod
@@ -464,7 +464,7 @@ class StorageDriver(object):
             # NOTE(gordc): must lock at sack level
             try:
                 LOG.debug("Processing measures for %s", metric)
-                with incoming.process_measure_for_metric(metric) \
+                with incoming.process_measure_for_metric(metric.id) \
                         as measures:
                     self._compute_and_store_timeseries(metric, measures)
                 LOG.debug("Measures for metric %s processed", metric)

--- a/gnocchi/tests/test_aggregates.py
+++ b/gnocchi/tests/test_aggregates.py
@@ -931,13 +931,13 @@ class CrossMetricAggregated(base.TestCase):
     def test_get_measures_unknown_aggregation(self):
         metric2 = indexer.Metric(uuid.uuid4(),
                                  self.archive_policies['low'])
-        self.incoming.add_measures(self.metric, [
+        self.incoming.add_measures(self.metric.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 1), 69),
             incoming.Measure(datetime64(2014, 1, 1, 12, 7, 31), 42),
             incoming.Measure(datetime64(2014, 1, 1, 12, 9, 31), 4),
             incoming.Measure(datetime64(2014, 1, 1, 12, 12, 45), 44),
         ])
-        self.incoming.add_measures(metric2, [
+        self.incoming.add_measures(metric2.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 1), 69),
             incoming.Measure(datetime64(2014, 1, 1, 12, 7, 31), 42),
             incoming.Measure(datetime64(2014, 1, 1, 12, 9, 31), 4),
@@ -957,13 +957,13 @@ class CrossMetricAggregated(base.TestCase):
     def test_get_measures_unknown_granularity(self):
         metric2 = indexer.Metric(uuid.uuid4(),
                                  self.archive_policies['low'])
-        self.incoming.add_measures(self.metric, [
+        self.incoming.add_measures(self.metric.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 1), 69),
             incoming.Measure(datetime64(2014, 1, 1, 12, 7, 31), 42),
             incoming.Measure(datetime64(2014, 1, 1, 12, 9, 31), 4),
             incoming.Measure(datetime64(2014, 1, 1, 12, 12, 45), 44),
         ])
-        self.incoming.add_measures(metric2, [
+        self.incoming.add_measures(metric2.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 1), 69),
             incoming.Measure(datetime64(2014, 1, 1, 12, 7, 31), 42),
             incoming.Measure(datetime64(2014, 1, 1, 12, 9, 31), 4),
@@ -984,13 +984,13 @@ class CrossMetricAggregated(base.TestCase):
     def test_add_and_get_measures_different_archives(self):
         metric2 = indexer.Metric(uuid.uuid4(),
                                  self.archive_policies['no_granularity_match'])
-        self.incoming.add_measures(self.metric, [
+        self.incoming.add_measures(self.metric.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 1), 69),
             incoming.Measure(datetime64(2014, 1, 1, 12, 7, 31), 42),
             incoming.Measure(datetime64(2014, 1, 1, 12, 9, 31), 4),
             incoming.Measure(datetime64(2014, 1, 1, 12, 12, 45), 44),
         ])
-        self.incoming.add_measures(metric2, [
+        self.incoming.add_measures(metric2.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 1), 69),
             incoming.Measure(datetime64(2014, 1, 1, 12, 7, 31), 42),
             incoming.Measure(datetime64(2014, 1, 1, 12, 9, 31), 4),
@@ -1010,13 +1010,13 @@ class CrossMetricAggregated(base.TestCase):
 
     def test_add_and_get_measures(self):
         metric2, __ = self._create_metric()
-        self.incoming.add_measures(self.metric, [
+        self.incoming.add_measures(self.metric.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 1), 69),
             incoming.Measure(datetime64(2014, 1, 1, 12, 7, 31), 42),
             incoming.Measure(datetime64(2014, 1, 1, 12, 9, 31), 4),
             incoming.Measure(datetime64(2014, 1, 1, 12, 12, 45), 44),
         ])
-        self.incoming.add_measures(metric2, [
+        self.incoming.add_measures(metric2.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 5), 9),
             incoming.Measure(datetime64(2014, 1, 1, 12, 7, 41), 2),
             incoming.Measure(datetime64(2014, 1, 1, 12, 10, 31), 4),
@@ -1168,14 +1168,14 @@ class CrossMetricAggregated(base.TestCase):
 
     def test_add_and_get_measures_with_holes(self):
         metric2, __ = self._create_metric()
-        self.incoming.add_measures(self.metric, [
+        self.incoming.add_measures(self.metric.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 1), 69),
             incoming.Measure(datetime64(2014, 1, 1, 12, 7, 31), 42),
             incoming.Measure(datetime64(2014, 1, 1, 12, 5, 31), 8),
             incoming.Measure(datetime64(2014, 1, 1, 12, 9, 31), 4),
             incoming.Measure(datetime64(2014, 1, 1, 12, 12, 45), 42),
         ])
-        self.incoming.add_measures(metric2, [
+        self.incoming.add_measures(metric2.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 5), 9),
             incoming.Measure(datetime64(2014, 1, 1, 12, 7, 31), 2),
             incoming.Measure(datetime64(2014, 1, 1, 12, 9, 31), 6),
@@ -1207,13 +1207,13 @@ class CrossMetricAggregated(base.TestCase):
 
     def test_resample(self):
         metric2, __ = self._create_metric()
-        self.incoming.add_measures(self.metric, [
+        self.incoming.add_measures(self.metric.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 1), 69),
             incoming.Measure(datetime64(2014, 1, 1, 13, 1, 31), 42),
             incoming.Measure(datetime64(2014, 1, 1, 14, 2, 31), 4),
             incoming.Measure(datetime64(2014, 1, 1, 15, 3, 45), 44),
         ])
-        self.incoming.add_measures(metric2, [
+        self.incoming.add_measures(metric2.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 5), 9),
             incoming.Measure(datetime64(2014, 1, 1, 13, 1, 41), 2),
             incoming.Measure(datetime64(2014, 1, 1, 14, 2, 31), 4),
@@ -1244,13 +1244,13 @@ class CrossMetricAggregated(base.TestCase):
 
     def test_resample_minus_2_on_right(self):
         metric2, __ = self._create_metric()
-        self.incoming.add_measures(self.metric, [
+        self.incoming.add_measures(self.metric.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 1), 69),
             incoming.Measure(datetime64(2014, 1, 1, 13, 1, 31), 42),
             incoming.Measure(datetime64(2014, 1, 1, 14, 2, 31), 4),
             incoming.Measure(datetime64(2014, 1, 1, 15, 3, 45), 44),
         ])
-        self.incoming.add_measures(metric2, [
+        self.incoming.add_measures(metric2.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 5), 9),
             incoming.Measure(datetime64(2014, 1, 1, 13, 1, 41), 2),
             incoming.Measure(datetime64(2014, 1, 1, 14, 2, 31), 4),
@@ -1281,13 +1281,13 @@ class CrossMetricAggregated(base.TestCase):
 
     def test_resample_minus_2_on_left(self):
         metric2, __ = self._create_metric()
-        self.incoming.add_measures(self.metric, [
+        self.incoming.add_measures(self.metric.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 1), 69),
             incoming.Measure(datetime64(2014, 1, 1, 13, 1, 31), 42),
             incoming.Measure(datetime64(2014, 1, 1, 14, 2, 31), 4),
             incoming.Measure(datetime64(2014, 1, 1, 15, 3, 45), 44),
         ])
-        self.incoming.add_measures(metric2, [
+        self.incoming.add_measures(metric2.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 5), 9),
             incoming.Measure(datetime64(2014, 1, 1, 13, 1, 41), 2),
             incoming.Measure(datetime64(2014, 1, 1, 14, 2, 31), 4),
@@ -1320,13 +1320,13 @@ class CrossMetricAggregated(base.TestCase):
 
     def test_rolling(self):
         metric2, __ = self._create_metric()
-        self.incoming.add_measures(self.metric, [
+        self.incoming.add_measures(self.metric.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 1), 69),
             incoming.Measure(datetime64(2014, 1, 1, 12, 5, 31), 42),
             incoming.Measure(datetime64(2014, 1, 1, 12, 10, 31), 4),
             incoming.Measure(datetime64(2014, 1, 1, 12, 15, 45), 44),
         ])
-        self.incoming.add_measures(metric2, [
+        self.incoming.add_measures(metric2.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 5), 9),
             incoming.Measure(datetime64(2014, 1, 1, 12, 5, 41), 2),
             incoming.Measure(datetime64(2014, 1, 1, 12, 10, 31), 4),
@@ -1364,13 +1364,13 @@ class CrossMetricAggregated(base.TestCase):
 
     def test_binary_operator_with_two_references(self):
         metric2, __ = self._create_metric()
-        self.incoming.add_measures(self.metric, [
+        self.incoming.add_measures(self.metric.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 1), 69),
             incoming.Measure(datetime64(2014, 1, 1, 13, 1, 31), 42),
             incoming.Measure(datetime64(2014, 1, 1, 14, 2, 31), 4),
             incoming.Measure(datetime64(2014, 1, 1, 15, 3, 45), 44),
         ])
-        self.incoming.add_measures(metric2, [
+        self.incoming.add_measures(metric2.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 5), 9),
             incoming.Measure(datetime64(2014, 1, 1, 13, 1, 41), 2),
             incoming.Measure(datetime64(2014, 1, 1, 14, 2, 31), 4),
@@ -1399,7 +1399,7 @@ class CrossMetricAggregated(base.TestCase):
 
     def test_binary_operator_ts_on_left(self):
         metric2, __ = self._create_metric()
-        self.incoming.add_measures(self.metric, [
+        self.incoming.add_measures(self.metric.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 1), 69),
             incoming.Measure(datetime64(2014, 1, 1, 13, 1, 31), 42),
             incoming.Measure(datetime64(2014, 1, 1, 14, 2, 31), 4),
@@ -1426,7 +1426,7 @@ class CrossMetricAggregated(base.TestCase):
 
     def test_binary_operator_ts_on_right(self):
         metric2, __ = self._create_metric()
-        self.incoming.add_measures(self.metric, [
+        self.incoming.add_measures(self.metric.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 1), 69),
             incoming.Measure(datetime64(2014, 1, 1, 13, 1, 31), 42),
             incoming.Measure(datetime64(2014, 1, 1, 14, 2, 31), 4),
@@ -1452,13 +1452,13 @@ class CrossMetricAggregated(base.TestCase):
 
     def test_mix(self):
         metric2, __ = self._create_metric()
-        self.incoming.add_measures(self.metric, [
+        self.incoming.add_measures(self.metric.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 1), 69),
             incoming.Measure(datetime64(2014, 1, 1, 13, 1, 31), 42),
             incoming.Measure(datetime64(2014, 1, 1, 14, 2, 31), 4),
             incoming.Measure(datetime64(2014, 1, 1, 15, 3, 45), 44),
         ])
-        self.incoming.add_measures(metric2, [
+        self.incoming.add_measures(metric2.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 5), 9),
             incoming.Measure(datetime64(2014, 1, 1, 13, 1, 41), 2),
             incoming.Measure(datetime64(2014, 1, 1, 14, 2, 31), 4),
@@ -1490,13 +1490,13 @@ class CrossMetricAggregated(base.TestCase):
 
     def test_bool(self):
         metric2, __ = self._create_metric()
-        self.incoming.add_measures(self.metric, [
+        self.incoming.add_measures(self.metric.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 1), 69),
             incoming.Measure(datetime64(2014, 1, 1, 13, 1, 31), 42),
             incoming.Measure(datetime64(2014, 1, 1, 14, 2, 31), 4),
             incoming.Measure(datetime64(2014, 1, 1, 15, 3, 45), 44),
         ])
-        self.incoming.add_measures(metric2, [
+        self.incoming.add_measures(metric2.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 5), 9),
             incoming.Measure(datetime64(2014, 1, 1, 13, 1, 41), 2),
             incoming.Measure(datetime64(2014, 1, 1, 14, 2, 31), 4),
@@ -1536,13 +1536,13 @@ class CrossMetricAggregated(base.TestCase):
 
     def test_unary_operator(self):
         metric2, _ = self._create_metric()
-        self.incoming.add_measures(self.metric, [
+        self.incoming.add_measures(self.metric.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 1), -69),
             incoming.Measure(datetime64(2014, 1, 1, 13, 1, 31), 42),
             incoming.Measure(datetime64(2014, 1, 1, 14, 2, 31), -4),
             incoming.Measure(datetime64(2014, 1, 1, 15, 3, 45), 44),
         ])
-        self.incoming.add_measures(metric2, [
+        self.incoming.add_measures(metric2.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 5), -9),
             incoming.Measure(datetime64(2014, 1, 1, 13, 1, 41), -2),
             incoming.Measure(datetime64(2014, 1, 1, 14, 2, 31), 4),

--- a/gnocchi/tests/test_incoming.py
+++ b/gnocchi/tests/test_incoming.py
@@ -59,7 +59,7 @@ class TestIncomingDriver(tests_base.TestCase):
             # NOTE(jd) Retry to send measures. It cannot be done only once as
             # there might be a race condition between the threads
             self.incoming.finish_sack_processing(sack_to_find)
-            self.incoming.add_measures(self.metric, [
+            self.incoming.add_measures(self.metric.id, [
                 incoming.Measure(numpy.datetime64("2014-01-01 12:00:01"), 69),
             ])
         else:


### PR DESCRIPTION
The current code passes Metric objects to the incoming subsystem, but it
actually knows only about metric ids. That's why it only uses metric.id
everywhere.

Let's simplify that and make the incoming subsystem completely agnostic with
the representation model of the metric outside of it.