### PR TITLE
cleanup numpy+list usage

### DIFF
--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -418,7 +418,7 @@ class ArchivePolicyRuleController(rest.RestController):
 
 def MeasuresListSchema(measures):
     try:
-        times = utils.to_timestamps((m['timestamp'] for m in measures))
+        times = utils.to_timestamps([m['timestamp'] for m in measures])
     except TypeError:
         abort(400, "Invalid format for measures")
     except ValueError as e:
@@ -429,8 +429,7 @@ def MeasuresListSchema(measures):
     except Exception:
         abort(400, "Invalid input for a value")
 
-    return (incoming.Measure(t, v) for t, v in six.moves.zip(
-        times.tolist(), values))
+    return (incoming.Measure(t, v) for t, v in six.moves.zip(times, values))
 
 
 class MetricController(rest.RestController):

--- a/gnocchi/utils.py
+++ b/gnocchi/utils.py
@@ -75,7 +75,6 @@ unix_universal_start64 = numpy.datetime64("1970")
 
 def to_timestamps(values):
     try:
-        values = list(values)
         if len(values) == 0:
             return []
         if isinstance(values[0], (numpy.datetime64, datetime.datetime)):
@@ -98,7 +97,7 @@ def to_timestamps(values):
                     times = numpy.fromiter(
                         numpy.add(numpy.datetime64(utcnow()),
                                   [to_timespan(v, True) for v in values]),
-                        dtype='datetime64[ns]')
+                        dtype='datetime64[ns]', count=len(values))
                 else:
                     times = numpy.array(values, dtype='datetime64[ns]')
             else:
@@ -115,7 +114,7 @@ def to_timestamps(values):
 
 
 def to_timestamp(value):
-    return to_timestamps((value,))[0]
+    return to_timestamps([value])[0]
 
 
 def to_datetime(value):


### PR DESCRIPTION
- no real point creating a new list with tolist. zip can loop through
array
- to_timestamps requires a list so no point passing creating input
as generator
- numpy suggest to set 'count' when using fromiter. timeit shows
no real diff on small sizes