### PR TITLE
storage: stop checking for archive policy aggregation methods match

### DIFF
--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -500,6 +500,15 @@ class MetricController(rest.RestController):
             except ValueError as e:
                 abort(400, six.text_type(e))
 
+        if aggregation not in self.metric.archive_policy.aggregation_methods:
+            abort(404, {
+                "cause": "Aggregation method does not exist for this metric",
+                "detail": {
+                    "metric": self.metric.id,
+                    "aggregation_method": aggregation,
+                },
+            })
+
         if (strtobool("refresh", refresh) and
                 pecan.request.incoming.has_unprocessed(self.metric.id)):
             try:
@@ -1825,8 +1834,19 @@ class AggregationController(rest.RestController):
             if number_of_metrics == 1:
                 # NOTE(sileht): don't do the aggregation if we only have one
                 # metric
+                metric = metrics[0]
+                if (aggregation
+                   not in metric.archive_policy.aggregation_methods):
+                    abort(404, {
+                        "cause":
+                        "Aggregation method does not exist for this metric",
+                        "detail": {
+                            "metric": str(metric.id),
+                            "aggregation_method": aggregation,
+                        },
+                    })
                 return pecan.request.storage.get_measures(
-                    metrics[0], start, stop, aggregation,
+                    metric, start, stop, aggregation,
                     granularity, resample)
             return processor.get_measures(
                 pecan.request.storage,

--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -199,11 +199,6 @@ class StorageDriver(object):
         :param granularity: The granularity to retrieve.
         :param resample: The granularity to resample to.
         """
-        if aggregation not in metric.archive_policy.aggregation_methods:
-            if granularity is None:
-                granularity = metric.archive_policy.definition[0].granularity
-            raise AggregationDoesNotExist(metric, aggregation, granularity)
-
         if granularity is None:
             agg_timeseries = utils.parallel_map(
                 self._get_measures_timeserie,

--- a/gnocchi/tests/functional/gabbits/metric.yaml
+++ b/gnocchi/tests/functional/gabbits/metric.yaml
@@ -366,8 +366,12 @@ tests:
     - name: get measure unknown aggregates
       GET: /v1/aggregation/metric?metric=$HISTORY['get metric list for aggregates'].$RESPONSE['$[0].id']&aggregation=last
       status: 404
-      response_strings:
-        - Aggregation method 'last' at granularity '1.0' for metric
+      request_headers:
+        accept: application/json
+      response_json_paths:
+        $.description.cause: Aggregation method does not exist for this metric
+        $.description.detail.metric: $HISTORY['get metric list for aggregates'].$RESPONSE['$[0].id']
+        $.description.detail.aggregation_method: last
 
     - name: aggregate measure unknown metric
       GET: /v1/aggregation/metric?metric=cee6ef1f-52cc-4a16-bbb5-648aedfd1c37

--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -833,9 +833,8 @@ class TestStorageDriver(tests_base.TestCase):
             incoming.Measure(datetime64(2014, 1, 1, 12, 9, 31), 4),
             incoming.Measure(datetime64(2014, 1, 1, 12, 12, 45), 44),
         ])
-        self.assertRaises(storage.AggregationDoesNotExist,
-                          self.storage.get_measures,
-                          self.metric, aggregation='last')
+        self.assertEqual(
+            [], self.storage.get_measures(self.metric, aggregation='last'))
 
     def test_search_value(self):
         metric2, __ = self._create_metric()


### PR DESCRIPTION
The storage API is currently responsible to check that requesting an
aggregation method for a metric is possible or not based on its archive policy.
This is out of its job actually, and it should just return an empty series if
it has nothing – or raise MetricDoesNotExist if the metric is unknown.

The API will take the job of doing this validation before hitting the storage
subsystem.