### PR TITLE
Retry and log on drivers initialization failure

### DIFF
--- a/gnocchi/incoming/__init__.py
+++ b/gnocchi/incoming/__init__.py
@@ -183,6 +183,7 @@ class IncomingDriver(object):
         pass
 
 
+@utils.retry_on_exception_and_log("Unable to initialize incoming driver")
 def get_driver(conf):
     """Return configured incoming driver only
 

--- a/gnocchi/indexer/__init__.py
+++ b/gnocchi/indexer/__init__.py
@@ -24,6 +24,7 @@ from six.moves.urllib import parse
 from stevedore import driver
 
 from gnocchi import exceptions
+from gnocchi import utils
 
 OPTS = [
     cfg.StrOpt('url',
@@ -98,6 +99,7 @@ class Metric(object):
     __hash__ = object.__hash__
 
 
+@utils.retry_on_exception_and_log("Unable to initialize indexer driver")
 def get_driver(conf):
     """Return the configured driver."""
     split = parse.urlsplit(conf.indexer.url)

--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -108,6 +108,7 @@ class SackLockTimeoutError(StorageError):
         pass
 
 
+@utils.retry_on_exception_and_log("Unable to initialize storage driver")
 def get_driver(conf, coord):
     """Return the configured driver."""
     return utils.get_driver_class('gnocchi.storage', conf.storage)(


### PR DESCRIPTION
This retries and logs all failure to connect to any of the driver (index,
storage, incoming and coordinator). The wait time is not changed (exponential
up to 1 minute), but now both the API and metricd uses it this mechanism.

The error is also logged, so that any failure that is not connection related
(e.g. Python module missing) is properly logged and the operator knows what he
going wrong:

2017-12-15 10:37:49,075 [9070] ERROR    gnocchi.utils: Unable to initialize coordination driver
Traceback (most recent call last):
  File "/Users/jd/Source/tenacity/tenacity/__init__.py", line 298, in call
    result = fn(*args, **kwargs)
  File "./gnocchi/cli/metricd.py", line 44, in get_coordinator_and_start
    coord.start(start_heart=True)
  File "/Users/jd/Source/tooz/tooz/coordination.py", line 423, in start
    self._start()
  File "/Users/jd/Source/tooz/tooz/drivers/mysql.py", line 139, in _start
    self._options)
  File "/Users/jd/Source/tooz/tooz/drivers/mysql.py", line 198, in get_connection
    cause=e)
  File "/Users/jd/Source/tooz/tooz/utils.py", line 225, in raise_with_cause
    excutils.raise_with_cause(exc_cls, message, *args, **kwargs)
  File "/usr/local/opt/python/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/oslo_utils/excutils.py", line 143, in raise_with_cause
    six.raise_from(exc_cls(message, *args, **kwargs), kwargs.get('cause'))
  File "/usr/local/opt/python/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/six.py", line 737, in raise_from
    raise value
ToozConnectionError: (2003, "Can't connect to MySQL server on 'localhost' ([Errno 61] Connection refused)")

Fixes #585