### PR TITLE
rest: narrow down the response attributes

### DIFF
--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -452,6 +452,14 @@ query parameter:
 
 {{ scenarios['list-resource-generic-details']['doc'] }}
 
+Limit attributes
+~~~~~~~~~~~~~~~~
+
+To limit response attributes, use `attrs=id&attrs=started_at&attrs=user_id` in the query
+parameter:
+
+{{ scenarios['list-resource-generic-limit-attrs']['doc'] }}
+
 Pagination
 ~~~~~~~~~~
 
@@ -633,6 +641,14 @@ With details
 Details about the |resource| can also be retrieved at the same time:
 
 {{ scenarios['search-resource-for-user-details']['doc'] }}
+
+Limit attributes
+~~~~~~~~~~~~~~~~
+
+To limit response attributes, use `attrs=id&attrs=started_at&attrs=user_id` in the query
+parameter:
+
+{{ scenarios['search-resource-for-user-limit-attrs']['doc'] }}
 
 History
 ~~~~~~~

--- a/doc/source/rest.yaml
+++ b/doc/source/rest.yaml
@@ -367,6 +367,9 @@
 - name: list-resource-generic-details
   request: GET /v1/resource/generic?details=true HTTP/1.1
 
+- name: list-resource-generic-limit-attrs
+  request: GET /v1/resource/generic?attrs=id&attrs=started_at&attrs=user_id HTTP/1.1
+
 - name: list-resource-generic-pagination
   request: GET /v1/resource/generic?limit=2&sort=id:asc HTTP/1.1
 
@@ -387,6 +390,13 @@
 - name: search-resource-for-user-details
   request: |
     POST /v1/search/resource/generic?details=true HTTP/1.1
+    Content-Type: application/json
+
+    {"=": {"user_id": "{{ scenarios['create-resource-instance']['response'].json['user_id'] }}"}}
+
+- name: search-resource-for-user-limit-attrs
+  request: |
+    POST /v1/search/resource/generic?attrs=id&attrs=started_at&attrs=user_id HTTP/1.1
     Content-Type: application/json
 
     {"=": {"user_id": "{{ scenarios['create-resource-instance']['response'].json['user_id'] }}"}}

--- a/gnocchi/indexer/sqlalchemy_base.py
+++ b/gnocchi/indexer/sqlalchemy_base.py
@@ -198,7 +198,7 @@ class ResourceType(Base, GnocchiBase, resource_type.ResourceType):
 
 
 class ResourceJsonifier(indexer.Resource):
-    def jsonify(self):
+    def jsonify(self, attrs=None):
         d = dict(self)
         del d['revision']
         if 'metrics' not in sqlalchemy.inspect(self).unloaded:
@@ -212,7 +212,10 @@ class ResourceJsonifier(indexer.Resource):
                 self.creator.partition(":")
             )
 
-        return d
+        if attrs:
+            return {key: val for key, val in d.items() if key in attrs}
+        else:
+            return d
 
 
 class ResourceMixin(ResourceJsonifier):

--- a/gnocchi/tests/functional/gabbits/resource.yaml
+++ b/gnocchi/tests/functional/gabbits/resource.yaml
@@ -361,6 +361,56 @@ tests:
           $[0].user_id: 0fbb231484614b1a80131fc22f6afc9c
           $[-1].user_id: foobar
 
+    - name: list generic resources with attrs param
+      GET: /v1/resource/generic?attrs=id&attrs=started_at&attrs=user_id
+      response_json_paths:
+          $[0].`len`: 3
+          $[0].id: $RESPONSE['$[0].id']
+          $[0].started_at: $RESPONSE['$[0].started_at']
+          $[0].user_id: $RESPONSE['$[0].user_id']
+          $[1].`len`: 3
+
+    - name: list generic resources with invalid attrs param
+      GET: /v1/resource/generic?attrs=id&attrs=foo&attrs=bar
+      response_json_paths:
+          $[0].`len`: 1
+          $[0].id: $RESPONSE['$[0].id']
+          $[1].`len`: 1
+
+    - name: list generic resources without attrs param
+      GET: /v1/resource/generic
+      response_json_paths:
+          $[0].`len`: 13
+          $[1].`len`: 13
+
+    - name: list generic resources with attrs header
+      GET: /v1/resource/generic
+      request_headers:
+          Accept: "application/json; attrs=id+started_at+user_id"
+      response_json_paths:
+          $[0].`len`: 3
+          $[0].id: $RESPONSE['$[0].id']
+          $[0].started_at: $RESPONSE['$[0].started_at']
+          $[0].user_id: $RESPONSE['$[0].user_id']
+          $[1].`len`: 3
+
+    - name: list generic resources with invalid attrs header
+      GET: /v1/resource/generic
+      request_headers:
+          Accept: "application/json; attrs=id+foo+bar"
+      response_json_paths:
+          $[0].`len`: 1
+          $[0].id: $RESPONSE['$[0].id']
+          $[1].`len`: 1
+
+    - name: list generic resources without attrs header
+      GET: /v1/resource/generic
+      request_headers:
+          Accept: "application/json"
+      response_json_paths:
+          $[0].`len`: 13
+          $[1].`len`: 13
+
     - name: list all resources
       GET: /v1/resource/generic
       response_strings:

--- a/gnocchi/tests/functional/gabbits/search.yaml
+++ b/gnocchi/tests/functional/gabbits/search.yaml
@@ -201,3 +201,59 @@ tests:
           project_id: foobar
       response_json_paths:
         $.`len`: 3
+
+    - name: search all resource with attrs param
+      POST: /v1/search/resource/generic?attrs=id&attrs=started_at&attrs=user_id
+      data: {}
+      response_json_paths:
+        $[0].`len`: 3
+        $[0].id: $RESPONSE['$[0].id']
+        $[0].started_at: $RESPONSE['$[0].started_at']
+        $[0].user_id: $RESPONSE['$[0].user_id']
+        $[1].`len`: 3
+
+    - name: search all resource with invalid attrs param
+      POST: /v1/search/resource/generic?attrs=id&attrs=foo&attrs=bar
+      data: {}
+      response_json_paths:
+        $[0].`len`: 1
+        $[0].id: $RESPONSE['$[0].id']
+        $[1].`len`: 1
+
+    - name: search all resource without attrs param
+      POST: /v1/search/resource/generic
+      data: {}
+      response_json_paths:
+        $[0].`len`: 13
+        $[1].`len`: 13
+
+    - name: search all resource with attrs header
+      POST: /v1/search/resource/generic
+      data: {}
+      request_headers:
+        Accept: "application/json; attrs=id+started_at+user_id"
+      response_json_paths:
+        $[0].`len`: 3
+        $[0].id: $RESPONSE['$[0].id']
+        $[0].started_at: $RESPONSE['$[0].started_at']
+        $[0].user_id: $RESPONSE['$[0].user_id']
+        $[1].`len`: 3
+
+    - name: search all resource with invalid attrs header
+      POST: /v1/search/resource/generic
+      data: {}
+      request_headers:
+        Accept: "application/json; attrs=id+foo+bar"
+      response_json_paths:
+        $[0].`len`: 1
+        $[0].id: $RESPONSE['$[0].id']
+        $[1].`len`: 1
+
+    - name: search all resource without attrs header
+      POST: /v1/search/resource/generic
+      data: {}
+      request_headers:
+        Accept: "application/json"
+      response_json_paths:
+        $[0].`len`: 13
+        $[1].`len`: 13


### PR DESCRIPTION
To reduce the response size of search/list queries for gnocchi's grafana-datasource, I've added an `attrs` parameter.
```
GET /v1/resource/generic?attrs=id,type,user_id HTTP/1.1
POST /v1/search/resource/generic?attrs=id,type,user_id HTTP/1.1
```

Fixes #545 