### PR TITLE
devstack: redis on opensuse needs to have default config

### DIFF
--- a/devstack/plugin.sh
+++ b/devstack/plugin.sh
@@ -116,7 +116,14 @@ function _gnocchi_install_redis {
     else
         # This will fail (correctly) where a redis package is unavailable
         install_package redis
-        restart_service redis
+        if is_suse; then
+            # opensuse intsall multi-instance version of redis
+            # and admin is expected to install the required conf
+            cp /etc/redis/default.conf.example /etc/redis/default.conf
+            restart_service redis@default
+        else
+            restart_service redis
+        fi
     fi
 
     pip_install_gr redis


### PR DESCRIPTION
this patch adds a default config and uses template of version of
unitfile to restart redis