### PR TITLE
storage: truncate aggregated time series before storing

### DIFF
--- a/doc/source/operating.rst
+++ b/doc/source/operating.rst
@@ -85,9 +85,9 @@ points over a |timespan|.
 If your |archive policy| defines a policy of 10 points with a |granularity| of
 1 second, the |time series| archive will keep up to 10 seconds, each
 representing an aggregation over 1 second. This means the |time series| will at
-maximum retain 10 seconds of data (sometimes a bit more) between the more
-recent point and the oldest point. That does not mean it will be 10 consecutive
-seconds: there might be a gap if data is fed irregularly.
+maximum retain 10 seconds of data between the more recent point and the oldest
+point. That does not mean it will be 10 consecutive seconds: there might be a
+gap if data is fed irregularly.
 
 **There is no expiry of data relative to the current timestamp. Data is only
 expired according to timespan.**

--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -531,8 +531,7 @@ class AggregatedTimeSerie(TimeSerie):
     COMPRESSED_SERIAL_LEN = struct.calcsize("<Hd")
     COMPRESSED_TIMESPAMP_LEN = struct.calcsize("<H")
 
-    def __init__(self, sampling, aggregation_method, ts=None, max_size=None,
-                 truncate=True):
+    def __init__(self, sampling, aggregation_method, ts=None):
         """A time serie that is downsampled.
 
         Used to represent the downsampled timeserie for a single
@@ -541,10 +540,7 @@ class AggregatedTimeSerie(TimeSerie):
         """
         super(AggregatedTimeSerie, self).__init__(ts)
         self.sampling = sampling
-        self.max_size = max_size
         self.aggregation_method = aggregation_method
-        if truncate:
-            self._truncate()
 
     def resample(self, sampling):
         return AggregatedTimeSerie.from_grouped_serie(
@@ -552,15 +548,10 @@ class AggregatedTimeSerie(TimeSerie):
 
     @classmethod
     def from_data(cls, sampling, aggregation_method, timestamps,
-                  values, max_size=None):
-        # TODO(gordc): we don't truncate here but we might want to.
-        # specifically, when we store_timeserie_split, we merge with existing
-        # serie but we don't truncate so we might merge stuff that is beyond
-        # policy (not visible because we follow policy and truncate on GET)
+                  values):
         return cls(sampling=sampling,
                    aggregation_method=aggregation_method,
-                   ts=make_timeseries(timestamps, values),
-                   max_size=max_size, truncate=False)
+                   ts=make_timeseries(timestamps, values))
 
     @staticmethod
     def _get_agg_method(aggregation_method):
@@ -574,6 +565,22 @@ class AggregatedTimeSerie(TimeSerie):
                 raise UnknownAggregationMethod(aggregation_method)
             aggregation_method_func_name = aggregation_method
         return aggregation_method_func_name, q
+
+    def truncate(self, oldest_point):
+        """Truncate the time series up to oldest_point excluded.
+
+        :param oldest_point: Oldest point to keep from, this excluded.
+        :type oldest_point: numpy.datetime64 or numpy.timedelta64
+        """
+        last = self.last
+        if last is None:
+            # There's nothing to truncate
+            return
+        if isinstance(oldest_point, numpy.timedelta64):
+            oldest_point = last - oldest_point
+        index = numpy.searchsorted(self.ts['timestamps'], oldest_point,
+                                   side='right')
+        self.ts = self.ts[index:]
 
     def split(self):
         # NOTE(sileht): We previously use groupby with
@@ -594,38 +601,33 @@ class AggregatedTimeSerie(TimeSerie):
             start = end
 
     @classmethod
-    def from_timeseries(cls, timeseries, sampling, aggregation_method,
-                        max_size=None):
+    def from_timeseries(cls, timeseries, sampling, aggregation_method):
         # NOTE(gordc): Indices must be unique across all timeseries. Also,
         # timeseries should be a list that is ordered within list and series.
         if not timeseries:
             timeseries = [make_timeseries([], [])]
         return cls(sampling=sampling,
                    aggregation_method=aggregation_method,
-                   ts=numpy.concatenate(timeseries), max_size=max_size)
+                   ts=numpy.concatenate(timeseries))
 
     @classmethod
-    def from_grouped_serie(cls, grouped_serie, sampling, aggregation_method,
-                           max_size=None, truncate=False):
+    def from_grouped_serie(cls, grouped_serie, sampling, aggregation_method):
         agg_name, q = cls._get_agg_method(aggregation_method)
         return cls(sampling, aggregation_method,
                    ts=cls._resample_grouped(grouped_serie, agg_name,
-                                            q),
-                   max_size=max_size, truncate=truncate)
+                                            q))
 
     def __eq__(self, other):
         return (isinstance(other, AggregatedTimeSerie)
                 and super(AggregatedTimeSerie, self).__eq__(other)
-                and self.max_size == other.max_size
                 and self.sampling == other.sampling
                 and self.aggregation_method == other.aggregation_method)
 
     def __repr__(self):
-        return "<%s 0x%x sampling=%s max_size=%s agg_method=%s>" % (
+        return "<%s 0x%x sampling=%s agg_method=%s>" % (
             self.__class__.__name__,
             id(self),
             self.sampling,
-            self.max_size,
             self.aggregation_method,
         )
 
@@ -741,12 +743,6 @@ class AggregatedTimeSerie(TimeSerie):
         payload = serial.tobytes()
         offset = int((first - start.key) / offset_div) * self.PADDED_SERIAL_LEN
         return offset, payload
-
-    def _truncate(self):
-        """Truncate the timeserie."""
-        if self.max_size is not None:
-            # Remove empty points if any that could be added by aggregation
-            self.ts = self.ts[-self.max_size:]
 
     @staticmethod
     def _resample_grouped(grouped_serie, agg_name, q=None):

--- a/gnocchi/tests/test_aggregates.py
+++ b/gnocchi/tests/test_aggregates.py
@@ -53,8 +53,7 @@ class TestAggregatedTimeseries(base.BaseTestCase):
         agg_dict['return'] = (
             processor.MetricReference(metric, "mean", resource),
             carbonara.AggregatedTimeSerie.from_grouped_serie(
-                grouped, agg_dict['sampling'], agg_dict['agg'],
-                max_size=agg_dict.get('size'), truncate=True))
+                grouped, agg_dict['sampling'], agg_dict['agg']))
         if existing:
             existing[2].merge(agg_dict['return'][2])
             agg_dict['return'] = existing
@@ -90,7 +89,6 @@ class TestAggregatedTimeseries(base.BaseTestCase):
         tsb1 = carbonara.BoundTimeSerie(block_size=tsc1['sampling'])
         tsc2 = carbonara.AggregatedTimeSerie(
             sampling=numpy.timedelta64(60, 's'),
-            max_size=50,
             aggregation_method='mean')
 
         tsb1.set_values(numpy.array([(datetime64(2014, 1, 1, 12, 3, 0), 4)],
@@ -721,6 +719,15 @@ class TestAggregatedTimeseries(base.BaseTestCase):
              numpy.timedelta64(300, 's'), 6.0),
             (datetime64(2014, 1, 1, 12, 5),
              numpy.timedelta64(300, 's'), 5.1666666666666661),
+            (numpy.datetime64('2014-01-01T11:46:00.000000000'),
+             numpy.timedelta64(60, 's'),
+             5.0),
+            (numpy.datetime64('2014-01-01T11:47:00.000000000'),
+             numpy.timedelta64(60, 's'),
+             6.5),
+            (numpy.datetime64('2014-01-01T11:50:00.000000000'),
+             numpy.timedelta64(60, 's'),
+             50.5),
             (datetime64(2014, 1, 1, 11, 54),
              numpy.timedelta64(60, 's'), 4.5),
             (datetime64(2014, 1, 1, 11, 56),

--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -271,7 +271,6 @@ class TestStorageDriver(tests_base.TestCase):
         self.trigger_processing()
 
         self.assertEqual([
-            (datetime64(2014, 1, 1), numpy.timedelta64(1, 'D'), 39.75),
             (datetime64(2015, 1, 1), numpy.timedelta64(1, 'D'), 69),
             (datetime64(2015, 1, 1, 12), numpy.timedelta64(1, 'h'), 69),
             (datetime64(2015, 1, 1, 12), numpy.timedelta64(5, 'm'), 69),

--- a/releasenotes/notes/carbonara-truncate-timespan-3694b96449709083.yaml
+++ b/releasenotes/notes/carbonara-truncate-timespan-3694b96449709083.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Gnocchi now strictly respects the archive policy configured timespan when
+    storing aggregates. Before, it could keep up to the number of points
+    defined in the archive policy, keeping more than the configured timespan.
+    The timespan duration is now strictly respected. Gnocchi only keeps the
+    points between the last aggregated timestamp and the last aggregated
+    timestamp minus the duration of the archive policy timespan.


### PR DESCRIPTION
The current truncation code in AggregatedTimeSerie truncate on object
initialize only. That means that split up to POINTS_PER_SPLIT points are
stored, and that data is read and _truncated_ at this point.

When new points are added (existing merge), it's possible that the number of
points grows more than the number of points defined by the archive policy,
storing too many points. That's hidden because when re-read, the
AggregatedTimeSerie is truncated again.

However, that makes the storage driver store too much data.

This patches remove the max_size attribute from carbonara.AggregatedTimeSerie
and simply expose a truncate() method that can be used to truncate each split
based on the oldest point that is defined by the archive policy.