### PR TITLE
fix devstack coordination setup

### DIFF
--- a/devstack/plugin.sh
+++ b/devstack/plugin.sh
@@ -215,7 +215,7 @@ function configure_gnocchi {
     fi
 
     if [ -n "$GNOCCHI_COORDINATOR_URL" ]; then
-        iniset $GNOCCHI_CONF coordination_url "$GNOCCHI_COORDINATOR_URL"
+        iniset $GNOCCHI_CONF DEFAULT coordination_url "$GNOCCHI_COORDINATOR_URL"
     fi
 
     if is_service_enabled gnocchi-statsd ; then


### PR DESCRIPTION
it's missing the storage section so incorrectly setting
coordination_url as the section