### PR TITLE
speed up min/max aggregates

### DIFF
--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -134,10 +134,18 @@ class GroupedTimeSeries(object):
             weights=self._ts['values']))
 
     def min(self):
-        return self._scipy_aggregate(ndimage.minimum)
+        ordered = self._ts['values'].argsort()
+        uniq_inv = numpy.repeat(numpy.arange(self.counts.size), self.counts)
+        values = numpy.zeros(self.tstamps.size)
+        values[uniq_inv[ordered][::-1]] = self._ts['values'][ordered][::-1]
+        return make_timeseries(self.tstamps, values)
 
     def max(self):
-        return self._scipy_aggregate(ndimage.maximum)
+        ordered = self._ts['values'].argsort()
+        uniq_inv = numpy.repeat(numpy.arange(self.counts.size), self.counts)
+        values = numpy.zeros(self.tstamps.size)
+        values[uniq_inv[ordered]] = self._ts['values'][ordered]
+        return make_timeseries(self.tstamps, values)
 
     def median(self):
         return self._scipy_aggregate(ndimage.median)


### PR DESCRIPTION
- sort values and set the appropriate index which effectively
makes each index take the last value (min/max depending on sort order)
- in theory, allows us to cache order so we can reuse computation if
both min and max aggregates defined.
- this is ~1.3x better