### PR TITLE
tests: Fix resource type with optional uuid

### DIFF
--- a/gnocchi/indexer/sqlalchemy_extension.py
+++ b/gnocchi/indexer/sqlalchemy_extension.py
@@ -43,7 +43,7 @@ class UUIDSchema(resource_type.UUIDSchema, SchemaMixin):
 
     def for_filling(self, dialect):
         if self.fill is None:
-            return False  # Don't set any server_default
+            return None
         return sqlalchemy.literal(
             self.satype.process_bind_param(self.fill, dialect))
 

--- a/gnocchi/tests/functional/gabbits/resource-type.yaml
+++ b/gnocchi/tests/functional/gabbits/resource-type.yaml
@@ -321,6 +321,28 @@ tests:
           content-type: application/json-patch+json
       data:
         - op: add
+          path: /attributes/new-optional-bool
+          value:
+            type: bool
+            required: False
+        - op: add
+          path: /attributes/new-optional-int
+          value:
+            type: number
+            required: False
+            min: 0
+            max: 255
+        - op: add
+          path: /attributes/new-optional-uuid
+          value:
+            type: uuid
+            required: False
+        - op: add
+          path: /attributes/new-optional-datetime
+          value:
+            type: datetime
+            required: False
+        - op: add
           path: /attributes/newstuff
           value:
             type: string
@@ -400,6 +422,17 @@ tests:
               bool:
                   type: bool
                   required: false
+              new-optional-bool:
+                  type: bool
+                  required: False
+              new-optional-int:
+                  type: number
+                  required: False
+                  min: 0
+                  max: 255
+              new-optional-uuid:
+                  type: uuid
+                  required: False
               newstuff:
                   type: string
                   required: False
@@ -494,6 +527,17 @@ tests:
               bool:
                   type: bool
                   required: false
+              new-optional-bool:
+                  type: bool
+                  required: False
+              new-optional-int:
+                  type: number
+                  required: False
+                  min: 0
+                  max: 255
+              new-optional-uuid:
+                  type: uuid
+                  required: False
               newstuff:
                   type: string
                   required: False
@@ -533,6 +577,9 @@ tests:
           $.newint: 15
           $.newstring: foobar
           $.newuuid: "00000000-0000-0000-0000-000000000000"
+          $.new-optional-bool: null
+          $.new-optional-int: null
+          $.new-optional-uuid: null
 
     - name: control new attributes of existing resource history
       GET: /v1/resource/my_custom_resource/d11edfca-4393-4fda-b94d-b05a3a1b3747/history?sort=revision_end:asc-nullslast
@@ -546,6 +593,9 @@ tests:
           $[0].newint: 15
           $[0].newstring: foobar
           $[0].newuuid: "00000000-0000-0000-0000-000000000000"
+          $[0].new-optional-bool: null
+          $[0].new-optional-int: null
+          $[0].new-optional-uuid: null
           $[1].id: d11edfca-4393-4fda-b94d-b05a3a1b3747
           $[1].name: foo
           $[1].newstuff: null
@@ -554,6 +604,9 @@ tests:
           $[1].newint: 15
           $[1].newstring: foobar
           $[1].newuuid: "00000000-0000-0000-0000-000000000000"
+          $[1].new-optional-bool: null
+          $[1].new-optional-int: null
+          $[1].new-optional-uuid: null
 
 # Invalid patch
 
@@ -629,6 +682,17 @@ tests:
               newuuid:
                   type: uuid
                   required: True
+              new-optional-bool:
+                  type: bool
+                  required: False
+              new-optional-int:
+                  type: number
+                  required: False
+                  min: 0
+                  max: 255
+              new-optional-uuid:
+                  type: uuid
+                  required: False
 
     - name: delete/add the same resource attribute
       PATCH: /v1/resource_type/my_custom_resource


### PR DESCRIPTION
tests: Fix resource type with optional uuid

This changes adds all missing tests for PATCH an optional attributes of
a resource type (Only string type was having tests).

And fix the bug where False is returned instead of None for uuid.

Closes-bug: #616
(cherry picked from commit 13a0123)