### PR TITLE
speed up median aggregate

### DIFF
--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -148,7 +148,18 @@ class GroupedTimeSeries(object):
         return make_timeseries(self.tstamps, values)
 
     def median(self):
-        return self._scipy_aggregate(ndimage.median)
+        ordered = self._ts['values'].argsort()
+        uniq_inv = numpy.repeat(numpy.arange(self.counts.size), self.counts)
+        max_pos = numpy.zeros(self.tstamps.size, dtype=numpy.int)
+        max_pos[uniq_inv[ordered]] = numpy.arange(self._ts.size)
+        # TODO(gordc): can use np.divmod when centos supports numpy 1.13
+        mid_diff = numpy.floor_divide(self.counts, 2)
+        odd = numpy.mod(self.counts, 2)
+        mid_floor = max_pos - mid_diff
+        mid_ceil = mid_floor + (odd + 1) % 2
+        return make_timeseries(
+            self.tstamps, (self._ts['values'][ordered][mid_floor] +
+                           self._ts['values'][ordered][mid_ceil]) / 2.0)
 
     def std(self):
         mean_ts = self.mean()


### PR DESCRIPTION
- find the position of max value of each range
- calculate distance to middle based on range counts
- get floor/ceiling of middle (same if odd count), add, and divide.
- ~1.9x faster in random case
  