### PR TITLE
simplify uncompressed serialization path

### DIFF
--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -740,20 +740,13 @@ class AggregatedTimeSerie(TimeSerie):
         locs = numpy.insert(locs, 0, 0)
         locs = locs.astype(numpy.int, copy=False)
 
-        # Fill everything with zero
-        serial_dtype = [('b', '<?'), ('v', '<d')]
-        serial = numpy.zeros((e_offset,), dtype=serial_dtype)
+        # Fill everything with zero and set
+        serial = numpy.zeros((e_offset,), dtype=[('b', '<?'), ('v', '<d')])
+        serial['b'][locs] = numpy.ones_like(self.values, dtype='<?')
+        serial['v'][locs] = self.values
 
-        # Create a structured array with two dimensions
-        ones = numpy.ones_like(self.values, dtype='<?')
-        values = numpy.core.records.fromarrays((ones, self.values),
-                                               dtype=serial_dtype)
-
-        serial[locs] = values
-
-        payload = serial.tobytes()
         offset = int((first - start.key) / offset_div) * self.PADDED_SERIAL_LEN
-        return offset, payload
+        return offset, serial.tobytes()
 
     @staticmethod
     def _resample_grouped(grouped_serie, agg_name, q=None):


### PR DESCRIPTION
we don't need to construct an extra array to store intermediate
result. just zero'd ndarray we already built. this improves
serialization by ~2x