### PR TITLE
optimise percentile computation with pure numpy

### DIFF
--- a/gnocchi/tests/test_carbonara.py
+++ b/gnocchi/tests/test_carbonara.py
@@ -283,6 +283,8 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
                          ts[datetime64(2014, 1, 1, 12, 0, 0)][1])
 
     def _do_test_aggregation(self, name, v1, v2, v3):
+        # NOTE(gordc): test data must have a group of odd count to properly
+        # test 50pct test case.
         ts = carbonara.TimeSerie.from_data(
             [datetime64(2014, 1, 1, 12, 0, 0),
              datetime64(2014, 1, 1, 12, 0, 10),
@@ -322,6 +324,13 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
 
     def test_aggregation_median(self):
         self._do_test_aggregation('median', 3.0, 10.5, 3)
+
+    def test_aggregation_50pct(self):
+        self._do_test_aggregation('50pct', 3.0, 10.5, 3)
+
+    def test_aggregation_56pct(self):
+        self._do_test_aggregation('56pct', 3.4800000000000004,
+                                  10.8, 3.120000000000001)
 
     def test_aggregation_min(self):
         self._do_test_aggregation('min', 2, 8, 2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ oslo.config>=3.22.0
 oslo.policy>=0.3.0
 oslo.middleware>=3.22.0
 pytimeparse
-scipy>=0.18.1  # BSD
 pecan>=0.9
 futures; python_version < '3'
 jsonpatch

--- a/tox.ini
+++ b/tox.ini
@@ -158,7 +158,9 @@ setenv = GNOCCHI_STORAGE_DEPS=file
          GNOCCHI_TEST_DEBUG=1
 deps = {[testenv:docs]deps}
        sphinxcontrib-versioning
-# fox <= 4.1 doc
+# for <= 4.2 doc
+       scipy
+# for <= 4.1 doc
        pandas
 # for 3.x doc
        oslotest


### PR DESCRIPTION
i believe i figured out how percentile is computed. this does
something very similar to median (for obvious reasons). at highlevel:
- get the index the percentile would land on and assume it falls
between indices
- take the values of the indices it falls between and figure out
weight of each value.
- handle the percentiles that fall on an exact index.

this is ~30x better. it's actually a bit slower (3%-5%?) than the
median computation so it's debatable if we want to remove median code.

drop scipy. also remove numpy.lib.recfunctions as it doesn't seem to
used anywhere.