### PR TITLE
fix median aggregation

### DIFF
--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -148,14 +148,11 @@ class GroupedTimeSeries(object):
         return make_timeseries(self.tstamps, values)
 
     def median(self):
-        ordered = self._ts['values'].argsort()
-        uniq_inv = numpy.repeat(numpy.arange(self.counts.size), self.counts)
-        max_pos = numpy.zeros(self.tstamps.size, dtype=numpy.int)
-        max_pos[uniq_inv[ordered]] = numpy.arange(self._ts.size)
+        ordered = numpy.lexsort((self._ts['values'], self.indexes))
         # TODO(gordc): can use np.divmod when centos supports numpy 1.13
         mid_diff = numpy.floor_divide(self.counts, 2)
         odd = numpy.mod(self.counts, 2)
-        mid_floor = max_pos - mid_diff
+        mid_floor = (numpy.cumsum(self.counts) - 1) - mid_diff
         mid_ceil = mid_floor + (odd + 1) % 2
         return make_timeseries(
             self.tstamps, (self._ts['values'][ordered][mid_floor] +

--- a/gnocchi/tests/test_carbonara.py
+++ b/gnocchi/tests/test_carbonara.py
@@ -282,47 +282,56 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
         self.assertEqual(5.9000000000000004,
                          ts[datetime64(2014, 1, 1, 12, 0, 0)][1])
 
-    def _do_test_aggregation(self, name, v1, v2):
+    def _do_test_aggregation(self, name, v1, v2, v3):
         ts = carbonara.TimeSerie.from_data(
             [datetime64(2014, 1, 1, 12, 0, 0),
-             datetime64(2014, 1, 1, 12, 0, 4),
-             datetime64(2014, 1, 1, 12, 0, 9),
-             datetime64(2014, 1, 1, 12, 1, 4),
-             datetime64(2014, 1, 1, 12, 1, 6)],
-            [3, 6, 5, 8, 9])
+             datetime64(2014, 1, 1, 12, 0, 10),
+             datetime64(2014, 1, 1, 12, 0, 20),
+             datetime64(2014, 1, 1, 12, 0, 30),
+             datetime64(2014, 1, 1, 12, 0, 40),
+             datetime64(2014, 1, 1, 12, 1, 0),
+             datetime64(2014, 1, 1, 12, 1, 10),
+             datetime64(2014, 1, 1, 12, 1, 20),
+             datetime64(2014, 1, 1, 12, 1, 30),
+             datetime64(2014, 1, 1, 12, 1, 40),
+             datetime64(2014, 1, 1, 12, 1, 50),
+             datetime64(2014, 1, 1, 12, 2, 0),
+             datetime64(2014, 1, 1, 12, 2, 10)],
+            [3, 5, 2, 3, 5, 8, 11, 22, 10, 42, 9, 4, 2])
         ts = self._resample(ts, numpy.timedelta64(60, 's'), name)
 
-        self.assertEqual(2, len(ts))
+        self.assertEqual(3, len(ts))
         self.assertEqual(v1, ts[datetime64(2014, 1, 1, 12, 0, 0)][1])
         self.assertEqual(v2, ts[datetime64(2014, 1, 1, 12, 1, 0)][1])
+        self.assertEqual(v3, ts[datetime64(2014, 1, 1, 12, 2, 0)][1])
 
     def test_aggregation_first(self):
-        self._do_test_aggregation('first', 3, 8)
+        self._do_test_aggregation('first', 3, 8, 4)
 
     def test_aggregation_last(self):
-        self._do_test_aggregation('last', 5, 9)
+        self._do_test_aggregation('last', 5, 9, 2)
 
     def test_aggregation_count(self):
-        self._do_test_aggregation('count', 3, 2)
+        self._do_test_aggregation('count', 5, 6, 2)
 
     def test_aggregation_sum(self):
-        self._do_test_aggregation('sum', 14, 17)
+        self._do_test_aggregation('sum', 18, 102, 6)
 
     def test_aggregation_mean(self):
-        self._do_test_aggregation('mean', 4.666666666666667, 8.5)
+        self._do_test_aggregation('mean', 3.6, 17, 3)
 
     def test_aggregation_median(self):
-        self._do_test_aggregation('median', 5.0, 8.5)
+        self._do_test_aggregation('median', 3.0, 10.5, 3)
 
     def test_aggregation_min(self):
-        self._do_test_aggregation('min', 3, 8)
+        self._do_test_aggregation('min', 2, 8, 2)
 
     def test_aggregation_max(self):
-        self._do_test_aggregation('max', 6, 9)
+        self._do_test_aggregation('max', 5, 42, 4)
 
     def test_aggregation_std(self):
-        self._do_test_aggregation('std', 1.5275252316519465,
-                                  0.70710678118654757)
+        self._do_test_aggregation('std', 1.3416407864998738,
+                                  13.266499161421599, 1.4142135623730951)
 
     def test_aggregation_std_with_unique(self):
         ts = carbonara.TimeSerie.from_data(


### PR DESCRIPTION
i mucked up #602 and the tests didn't find it. basically, the ordered
array i thought i build was not ordered by group as required to
make the logic of finding max and finding diff to middle, it was just
ordered with no regard to group.

this fixes it and expands the test so it's a bit more coverage.

this unfortunately is slower than what we merged. this is ~1.3x faster
unlike what i claimed before as ~1.9x faster