### PR TITLE
service: fix utils.parallel_map number of workers setting

### DIFF
--- a/gnocchi/service.py
+++ b/gnocchi/service.py
@@ -52,7 +52,7 @@ def prepare_service(args=None, conf=None,
          default_config_files=default_config_files,
          version=pbr.version.VersionInfo('gnocchi').version_string())
 
-    utils.parallel_map.NUM_WORKERS = conf.parallel_operations
+    utils.parallel_map.MAX_WORKERS = conf.parallel_operations
 
     if not log_to_std and (conf.log_dir or conf.log_file):
         outputs = [daiquiri.output.File(filename=conf.log_file,

--- a/gnocchi/tests/test_utils.py
+++ b/gnocchi/tests/test_utils.py
@@ -12,6 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 import datetime
+import itertools
 import os
 import uuid
 
@@ -119,13 +120,21 @@ class StopWatchTest(tests_base.TestCase):
 
 class ParallelMap(tests_base.TestCase):
     def test_parallel_map_one(self):
-        utils.parallel_map.NUM_WORKERS = 1
-        self.assertEqual([1, 2, 3],
-                         utils.parallel_map(lambda x: x,
-                                            [[1], [2], [3]]))
+        utils.parallel_map.MAX_WORKERS = 1
+        starmap = itertools.starmap
+        with mock.patch("itertools.starmap") as sm:
+            sm.side_effect = starmap
+            self.assertEqual([1, 2, 3],
+                             utils.parallel_map(lambda x: x,
+                                                [[1], [2], [3]]))
+            sm.assert_called()
 
     def test_parallel_map_four(self):
-        utils.parallel_map.NUM_WORKERS = 4
-        self.assertEqual([1, 2, 3],
-                         utils.parallel_map(lambda x: x,
-                                            [[1], [2], [3]]))
+        utils.parallel_map.MAX_WORKERS = 4
+        starmap = itertools.starmap
+        with mock.patch("itertools.starmap") as sm:
+            sm.side_effect = starmap
+            self.assertEqual([1, 2, 3],
+                             utils.parallel_map(lambda x: x,
+                                                [[1], [2], [3]]))
+            sm.assert_not_called()


### PR DESCRIPTION
Naming variable is hard

Fixes #605