### PR TITLE
tests: Fix resource type with optional uuid

### DIFF
--- a/gnocchi/indexer/sqlalchemy_extension.py
+++ b/gnocchi/indexer/sqlalchemy_extension.py
@@ -44,7 +44,7 @@ class UUIDSchema(resource_type.UUIDSchema, SchemaMixin):
 
     def for_filling(self, dialect):
         if self.fill is None:
-            return False  # Don't set any server_default
+            return None
         return sqlalchemy.literal(
             self.satype.process_bind_param(self.fill, dialect))
 

--- a/gnocchi/tests/functional/gabbits/resource-type.yaml
+++ b/gnocchi/tests/functional/gabbits/resource-type.yaml
@@ -332,6 +332,28 @@ tests:
           content-type: application/json-patch+json
       data:
         - op: add
+          path: /attributes/new-optional-bool
+          value:
+            type: bool
+            required: False
+        - op: add
+          path: /attributes/new-optional-int
+          value:
+            type: number
+            required: False
+            min: 0
+            max: 255
+        - op: add
+          path: /attributes/new-optional-uuid
+          value:
+            type: uuid
+            required: False
+        - op: add
+          path: /attributes/new-optional-datetime
+          value:
+            type: datetime
+            required: False
+        - op: add
           path: /attributes/newstuff
           value:
             type: string
@@ -419,6 +441,20 @@ tests:
                   type: bool
                   required: false
               datetime:
+                  type: datetime
+                  required: False
+              new-optional-bool:
+                  type: bool
+                  required: False
+              new-optional-int:
+                  type: number
+                  required: False
+                  min: 0
+                  max: 255
+              new-optional-uuid:
+                  type: uuid
+                  required: False
+              new-optional-datetime:
                   type: datetime
                   required: False
               newstuff:
@@ -521,6 +557,20 @@ tests:
               datetime:
                   type: datetime
                   required: False
+              new-optional-bool:
+                  type: bool
+                  required: False
+              new-optional-int:
+                  type: number
+                  required: False
+                  min: 0
+                  max: 255
+              new-optional-uuid:
+                  type: uuid
+                  required: False
+              new-optional-datetime:
+                  type: datetime
+                  required: False
               newstuff:
                   type: string
                   required: False
@@ -564,7 +614,10 @@ tests:
           $.newstring: foobar
           $.newuuid: "00000000-0000-0000-0000-000000000000"
           $.newdatetime: "2017-10-10T10:10:10+00:00"
-
+          $.new-optional-bool: null
+          $.new-optional-int: null
+          $.new-optional-uuid: null
+          $.new-optional-datetime: null
 
     - name: control new attributes of existing resource history
       GET: /v1/resource/my_custom_resource/d11edfca-4393-4fda-b94d-b05a3a1b3747/history?sort=revision_end:asc-nullslast
@@ -579,6 +632,10 @@ tests:
           $[0].newstring: foobar
           $[0].newuuid: "00000000-0000-0000-0000-000000000000"
           $[0].newdatetime: "2017-10-10T10:10:10+00:00"
+          $[0].new-optional-bool: null
+          $[0].new-optional-int: null
+          $[0].new-optional-uuid: null
+          $[0].new-optional-datetime: null
           $[1].id: d11edfca-4393-4fda-b94d-b05a3a1b3747
           $[1].name: foo
           $[1].newstuff: null
@@ -588,6 +645,10 @@ tests:
           $[1].newstring: foobar
           $[1].newuuid: "00000000-0000-0000-0000-000000000000"
           $[1].newdatetime: "2017-10-10T10:10:10+00:00"
+          $[1].new-optional-bool: null
+          $[1].new-optional-int: null
+          $[1].new-optional-uuid: null
+          $[1].new-optional-datetime: null
 
 # Invalid patch
 
@@ -669,6 +730,20 @@ tests:
               newdatetime:
                   type: datetime
                   required: True
+              new-optional-bool:
+                  type: bool
+                  required: False
+              new-optional-int:
+                  type: number
+                  required: False
+                  min: 0
+                  max: 255
+              new-optional-uuid:
+                  type: uuid
+                  required: False
+              new-optional-datetime:
+                  type: datetime
+                  required: False
 
     - name: delete/add the same resource attribute
       PATCH: /v1/resource_type/my_custom_resource


### PR DESCRIPTION
This changes adds all missing tests for PATCH an optional attributes of
a resource type (Only string type was having tests).

And fix the bug where False is returned instead of None for uuid.

Closes-bug: #616