### PR TITLE
Pull request for get-measures-wants-granularities

### DIFF
--- a/gnocchi/rest/aggregates/api.py
+++ b/gnocchi/rest/aggregates/api.py
@@ -286,7 +286,8 @@ class AggregatesController(rest.RestController):
 
             return response
 
-    def _get_measures_by_name(self, resources, metric_wildcards, operations,
+    @staticmethod
+    def _get_measures_by_name(resources, metric_wildcards, operations,
                               start, stop, granularity, needed_overlap, fill,
                               details):
 

--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -197,29 +197,25 @@ class StorageDriver(object):
         """
         return name.split("_")[-1] == 'v%s' % v
 
-    def get_measures(self, metric, from_timestamp=None, to_timestamp=None,
-                     aggregation='mean', granularity=None, resample=None):
+    def get_measures(self, metric, granularities,
+                     from_timestamp=None, to_timestamp=None,
+                     aggregation='mean', resample=None):
         """Get a measure to a metric.
 
         :param metric: The metric measured.
+        :param granularities: The granularities to retrieve.
         :param from timestamp: The timestamp to get the measure from.
         :param to timestamp: The timestamp to get the measure to.
         :param aggregation: The type of aggregation to retrieve.
-        :param granularity: The granularity to retrieve.
         :param resample: The granularity to resample to.
         """
-        if granularity is None:
-            agg_timeseries = utils.parallel_map(
-                self._get_measures_timeserie,
-                ((metric, aggregation, ap.granularity,
-                  from_timestamp, to_timestamp)
-                 for ap in reversed(metric.archive_policy.definition)))
-        else:
-            agg_timeseries = [self._get_measures_timeserie(
-                metric, aggregation, granularity,
-                from_timestamp, to_timestamp)]
+        agg_timeseries = utils.parallel_map(
+            self._get_measures_timeserie,
+            ((metric, aggregation, granularity,
+              from_timestamp, to_timestamp)
+             for granularity in sorted(granularities, reverse=True)))
 
-        if resample and granularity:
+        if resample:
             agg_timeseries = list(map(lambda agg: agg.resample(resample),
                                       agg_timeseries))
 

--- a/gnocchi/tests/functional/gabbits/aggregates-with-metric-ids.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregates-with-metric-ids.yaml
@@ -663,9 +663,9 @@ tests:
       response_json_paths:
         $.code: 400
         $.description.cause: "Metrics can't being aggregated"
-        $.description.reason: "granularity '123' is missing"
+        $.description.reason: "Granularities are missing"
         $.description.detail:
-        - ["$HISTORY['create metric1'].$RESPONSE['$.id']", mean]
+        - ["$HISTORY['create metric1'].$RESPONSE['$.id']", mean, 123]
 
     - name: get unknown aggregation
       POST: /v1/aggregates

--- a/gnocchi/tests/test_aggregates.py
+++ b/gnocchi/tests/test_aggregates.py
@@ -986,7 +986,7 @@ class CrossMetricAggregated(base.TestCase):
                               [str(self.metric.id), "mean"],
                               [str(metric2.id), "mean"],
                           ]],
-                          granularity=numpy.timedelta64(12345456, 'ms'))
+                          granularities=[numpy.timedelta64(12345456, 'ms')])
 
     def test_add_and_get_measures_different_archives(self):
         metric2 = indexer.Metric(uuid.uuid4(),
@@ -1166,7 +1166,7 @@ class CrossMetricAggregated(base.TestCase):
             ]],
             from_timestamp=datetime64(2014, 1, 1, 12, 0, 0),
             to_timestamp=datetime64(2014, 1, 1, 12, 0, 1),
-            granularity=numpy.timedelta64(5, 'm'))["aggregated"]
+            granularities=[numpy.timedelta64(5, 'm')])["aggregated"]
 
         self.assertEqual([
             (datetime64(2014, 1, 1, 12, 0, 0),
@@ -1236,7 +1236,7 @@ class CrossMetricAggregated(base.TestCase):
              ["metric",
               [str(self.metric.id), "mean"],
               [str(metric2.id), "mean"]]],
-            granularity=numpy.timedelta64(1, 'h'))
+            granularities=[numpy.timedelta64(1, 'h')])
 
         self.assertEqual({
             str(self.metric.id): {
@@ -1273,7 +1273,7 @@ class CrossMetricAggregated(base.TestCase):
                    ["metric",
                     [str(self.metric.id), "mean"],
                     [str(metric2.id), "mean"]]], 2],
-            granularity=numpy.timedelta64(1, 'h'))
+            granularities=[numpy.timedelta64(1, 'h')])
 
         self.assertEqual({
             str(self.metric.id): {
@@ -1312,7 +1312,7 @@ class CrossMetricAggregated(base.TestCase):
               ["metric",
                [str(self.metric.id), "mean"],
                [str(metric2.id), "mean"]]]],
-            granularity=numpy.timedelta64(1, 'h'))
+            granularities=[numpy.timedelta64(1, 'h')])
 
         self.assertEqual({
             str(self.metric.id): {
@@ -1348,7 +1348,7 @@ class CrossMetricAggregated(base.TestCase):
             ["/", ["rolling", "sum", 2,
                    ["metric", [str(self.metric.id), "mean"],
                     [str(metric2.id), "mean"]]], 2],
-            granularity=numpy.timedelta64(5, 'm'))
+            granularities=[numpy.timedelta64(5, 'm')])
 
         self.assertEqual({
             str(self.metric.id): {
@@ -1391,7 +1391,7 @@ class CrossMetricAggregated(base.TestCase):
              processor.MetricReference(metric2, "mean")],
             ["*", ["metric", str(self.metric.id), "mean"],
                   ["metric", str(metric2.id), "mean"]],
-            granularity=numpy.timedelta64(1, 'h'))["aggregated"]
+            granularities=[numpy.timedelta64(1, 'h')])["aggregated"]
 
         self.assertEqual([
             (datetime64(2014, 1, 1, 12, 0, 0),
@@ -1417,7 +1417,7 @@ class CrossMetricAggregated(base.TestCase):
         values = processor.get_measures(
             self.storage, [processor.MetricReference(self.metric, "mean")],
             ["*", ["metric", str(self.metric.id), "mean"], 2],
-            granularity=numpy.timedelta64(1, 'h'))
+            granularities=[numpy.timedelta64(1, 'h')])
 
         self.assertEqual({str(self.metric.id): {
             "mean": [
@@ -1444,7 +1444,7 @@ class CrossMetricAggregated(base.TestCase):
         values = processor.get_measures(
             self.storage, [processor.MetricReference(self.metric, "mean")],
             ["*", 2, ["metric", str(self.metric.id), "mean"]],
-            granularity=numpy.timedelta64(1, 'h'))
+            granularities=[numpy.timedelta64(1, 'h')])
 
         self.assertEqual({str(self.metric.id): {
             "mean": [(datetime64(2014, 1, 1, 12, 0, 0),
@@ -1484,7 +1484,7 @@ class CrossMetricAggregated(base.TestCase):
                 ["*", ["metric", str(self.metric.id), "mean"],
                       ["metric", str(metric2.id), "mean"]],
             ],
-            granularity=numpy.timedelta64(1, 'h'))["aggregated"]
+            granularities=[numpy.timedelta64(1, 'h')])["aggregated"]
 
         self.assertEqual([
             (datetime64(2014, 1, 1, 13, 0, 0),
@@ -1529,7 +1529,7 @@ class CrossMetricAggregated(base.TestCase):
                 ],
                 10
             ],
-            granularity=numpy.timedelta64(1, 'h'))["aggregated"]
+            granularities=[numpy.timedelta64(1, 'h')])["aggregated"]
         self.assertEqual([
             (datetime64(2014, 1, 1, 12, 0, 0),
              numpy.timedelta64(1, 'h'), 1),
@@ -1563,7 +1563,7 @@ class CrossMetricAggregated(base.TestCase):
              processor.MetricReference(metric2, "mean")],
             ["abs", ["metric", [str(self.metric.id), "mean"],
                      [str(metric2.id), "mean"]]],
-            granularity=numpy.timedelta64(1, 'h'))
+            granularities=[numpy.timedelta64(1, 'h')])
 
         self.assertEqual({
             str(self.metric.id): {

--- a/gnocchi/tests/test_rest.py
+++ b/gnocchi/tests/test_rest.py
@@ -1637,9 +1637,15 @@ class ResourceTest(RestTest):
             "/v1/aggregation/resource/"
             + self.resource_type + "/metric/foo?aggregation=max",
             params={"=": {"name": name}},
-            status=400)
-        self.assertIn(b"Metrics can't being aggregated",
-                      result.body)
+            status=400,
+            headers={"Accept": "application/json"})
+        self.assertEqual("Metrics can't being aggregated",
+                         result.json['description']['cause'])
+        self.assertEqual("No granularity match",
+                         result.json['description']['reason'])
+        self.assertEqual(
+            sorted([[metric1['id'], 'max'], [metric2['id'], 'max']]),
+            sorted(result.json['description']['detail']))
 
     def test_get_res_named_metric_measure_aggregation_nooverlap(self):
         result = self.app.post_json("/v1/metric",

--- a/gnocchi/tests/test_statsd.py
+++ b/gnocchi/tests/test_statsd.py
@@ -45,6 +45,8 @@ class TestStatsd(tests_base.TestCase):
                                self.STATSD_USER_ID, "statsd")
         self.conf.set_override("archive_policy_name",
                                self.STATSD_ARCHIVE_POLICY_NAME, "statsd")
+        ap = self.ARCHIVE_POLICIES["medium"]
+        self.granularities = [d.granularity for d in ap.definition]
 
         self.stats = statsd.Stats(self.conf)
         # Replace storage/indexer with correct ones that have been upgraded
@@ -75,7 +77,7 @@ class TestStatsd(tests_base.TestCase):
             self.stats.indexer, self.stats.incoming,
             [str(metric.id)], sync=True)
 
-        measures = self.storage.get_measures(metric)
+        measures = self.storage.get_measures(metric, self.granularities)
         self.assertEqual([
             (datetime64(2015, 1, 7), numpy.timedelta64(1, 'D'), 1.0),
             (datetime64(2015, 1, 7, 13), numpy.timedelta64(1, 'h'), 1.0),
@@ -96,7 +98,7 @@ class TestStatsd(tests_base.TestCase):
             self.stats.indexer, self.stats.incoming,
             [str(metric.id)], sync=True)
 
-        measures = self.storage.get_measures(metric)
+        measures = self.storage.get_measures(metric, self.granularities)
         self.assertEqual([
             (datetime64(2015, 1, 7), numpy.timedelta64(1, 'D'), 1.5),
             (datetime64(2015, 1, 7, 13), numpy.timedelta64(1, 'h'), 1.5),
@@ -130,7 +132,7 @@ class TestStatsd(tests_base.TestCase):
             self.stats.indexer, self.stats.incoming,
             [str(metric.id)], sync=True)
 
-        measures = self.storage.get_measures(metric)
+        measures = self.storage.get_measures(metric, self.granularities)
         self.assertEqual([
             (datetime64(2015, 1, 7), numpy.timedelta64(1, 'D'), 1.0),
             (datetime64(2015, 1, 7, 13), numpy.timedelta64(1, 'h'), 1.0),
@@ -150,7 +152,7 @@ class TestStatsd(tests_base.TestCase):
             self.stats.indexer, self.stats.incoming,
             [str(metric.id)], sync=True)
 
-        measures = self.storage.get_measures(metric)
+        measures = self.storage.get_measures(metric, self.granularities)
         self.assertEqual([
             (datetime64(2015, 1, 7), numpy.timedelta64(1, 'D'), 28),
             (datetime64(2015, 1, 7, 13), numpy.timedelta64(1, 'h'), 28),


### PR DESCRIPTION
storage: force granularities to be specified
rest/aggregates: declare _get_measures_by_name as static
test_rest: enhance error checking in negative aggregation test