### PR TITLE
doc: disable build of stable/3.?

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -182,7 +182,7 @@ scv_sort = ('semver',)
 scv_show_banner = True
 scv_banner_main_ref = 'stable/4.1'
 scv_priority = 'branches'
-scv_whitelist_branches = ('master', '^stable/([3-9]\.)')
+scv_whitelist_branches = ('master', '^stable/([4-9]\.)')
 scv_whitelist_tags = ("^$",)
 
 here = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
Those builds are currently broken due to incompatibility between the lz4
dependencies of master and stable/3.?.

While it would be boring but fixable, I imagine it's now better to just ignore
those doc. 3.1 is now more than 1 year old, we can expect most people to
upgrade by now.

Fixes #614