### PR TITLE
Pull request for expose-workers-api

### DIFF
--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -27,10 +27,12 @@ import pyparsing
 import six
 from six.moves.urllib import parse as urllib_parse
 import tenacity
+import tooz
 import voluptuous
 import werkzeug.http
 
 from gnocchi import archive_policy
+from gnocchi.cli import metricd
 from gnocchi import incoming
 from gnocchi import indexer
 from gnocchi import json
@@ -1960,6 +1962,11 @@ class StatusController(rest.RestController):
     def get(details=True):
         enforce("get status", {})
         try:
+            members_req = pecan.request.coordinator.get_members(
+                metricd.MetricProcessor.GROUP_ID)
+        except tooz.NotImplemented:
+            members_req = None
+        try:
             report = pecan.request.incoming.measures_report(
                 strtobool("details", details))
         except incoming.ReportGenerationError:
@@ -1967,6 +1974,11 @@ class StatusController(rest.RestController):
         report_dict = {"storage": {"summary": report['summary']}}
         if 'details' in report:
             report_dict["storage"]["measures_to_process"] = report['details']
+        report_dict['metricd'] = {}
+        if members_req:
+            report_dict['metricd']['processors'] = members_req.get()
+        else:
+            report_dict['metricd']['processors'] = None
         return report_dict
 
 

--- a/gnocchi/rest/app.py
+++ b/gnocchi/rest/app.py
@@ -83,6 +83,7 @@ class GnocchiHook(pecan.hooks.PecanHook):
                         # entirely.
                         self.backends[name] = (
                             metricd.get_coordinator_and_start(
+                                str(uuid.uuid4()),
                                 self.conf.coordination_url)
                         )
                     elif name == "storage":

--- a/gnocchi/tests/base.py
+++ b/gnocchi/tests/base.py
@@ -301,6 +301,7 @@ class TestCase(BaseTestCase):
         self.index = indexer.get_driver(self.conf)
 
         self.coord = metricd.get_coordinator_and_start(
+            str(uuid.uuid4()),
             self.conf.coordination_url)
 
         # NOTE(jd) So, some driver, at least SQLAlchemy, can't create all

--- a/gnocchi/tests/functional/fixtures.py
+++ b/gnocchi/tests/functional/fixtures.py
@@ -22,6 +22,7 @@ import tempfile
 import threading
 import time
 from unittest import case
+import uuid
 import warnings
 
 import daiquiri
@@ -143,7 +144,8 @@ class ConfigFixture(fixture.GabbiFixture):
 
         self.index = index
 
-        self.coord = metricd.get_coordinator_and_start(conf.coordination_url)
+        self.coord = metricd.get_coordinator_and_start(str(uuid.uuid4()),
+                                                       conf.coordination_url)
         s = storage.get_driver(conf, self.coord)
         s.upgrade()
         i = incoming.get_driver(conf)

--- a/gnocchi/tests/functional/gabbits/base.yaml
+++ b/gnocchi/tests/functional/gabbits/base.yaml
@@ -132,6 +132,7 @@ tests:
     authorization: "basic YWRtaW46"
   response_json_paths:
     $.storage.`len`: 2
+    $.metricd.`len`: 1
 
 - name: get status, no details
   GET: /v1/status?details=False
@@ -140,3 +141,4 @@ tests:
     authorization: "basic YWRtaW46"
   response_json_paths:
     $.storage.`len`: 1
+    $.metricd.`len`: 1

--- a/gnocchi/tests/test_rest.py
+++ b/gnocchi/tests/test_rest.py
@@ -190,6 +190,8 @@ class RestTest(tests_base.TestCase, testscenarios.TestWithScenarios):
             return self.index
         elif name == "incoming":
             return self.incoming
+        elif name == "coordinator":
+            return self.coord
         else:
             raise RuntimeError("Invalid driver type: %s" % name)
 


### PR DESCRIPTION
metricd: use human readable member id
rest: export the available metricd processors in status
rest: store coordinator in pecan.request