### PR TITLE
Pull request for stable-4.1-no-doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ cache:
 env:
   - TARGET: pep8
   - TARGET: docs
-  - TARGET: docs-gnocchi.xyz
 
   - TARGET: py27-mysql-ceph-upgrade-from-3.1
   - TARGET: py35-postgresql-file-upgrade-from-3.1

--- a/gnocchi/service.py
+++ b/gnocchi/service.py
@@ -52,7 +52,7 @@ def prepare_service(args=None, conf=None,
          default_config_files=default_config_files,
          version=pbr.version.VersionInfo('gnocchi').version_string())
 
-    utils.parallel_map.NUM_WORKERS = conf.parallel_operations
+    utils.parallel_map.MAX_WORKERS = conf.parallel_operations
 
     if not log_to_std and (conf.log_dir or conf.log_file):
         outputs = [daiquiri.output.File(filename=conf.log_file,

--- a/gnocchi/tests/functional/gabbits/resource.yaml
+++ b/gnocchi/tests/functional/gabbits/resource.yaml
@@ -499,7 +499,6 @@ tests:
       data:
           electron.spin:
               archive_policy_name: medium
-      response_headers:
       response_json_paths:
           $[/name][1].name: electron.spin
           $[/name][1].resource_id: 85c44741-cc60-4033-804e-2d3098c7d2e9

--- a/gnocchi/tests/test_utils.py
+++ b/gnocchi/tests/test_utils.py
@@ -12,6 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 import datetime
+import itertools
 import os
 import uuid
 
@@ -119,13 +120,21 @@ class StopWatchTest(tests_base.TestCase):
 
 class ParallelMap(tests_base.TestCase):
     def test_parallel_map_one(self):
-        utils.parallel_map.NUM_WORKERS = 1
-        self.assertEqual([1, 2, 3],
-                         utils.parallel_map(lambda x: x,
-                                            [[1], [2], [3]]))
+        utils.parallel_map.MAX_WORKERS = 1
+        starmap = itertools.starmap
+        with mock.patch("itertools.starmap") as sm:
+            sm.side_effect = starmap
+            self.assertEqual([1, 2, 3],
+                             utils.parallel_map(lambda x: x,
+                                                [[1], [2], [3]]))
+            sm.assert_called()
 
     def test_parallel_map_four(self):
-        utils.parallel_map.NUM_WORKERS = 4
-        self.assertEqual([1, 2, 3],
-                         utils.parallel_map(lambda x: x,
-                                            [[1], [2], [3]]))
+        utils.parallel_map.MAX_WORKERS = 4
+        starmap = itertools.starmap
+        with mock.patch("itertools.starmap") as sm:
+            sm.side_effect = starmap
+            self.assertEqual([1, 2, 3],
+                             utils.parallel_map(lambda x: x,
+                                                [[1], [2], [3]]))
+            sm.assert_not_called()


### PR DESCRIPTION
doc: do not test gnocchi.xyz build on stable branch
service: fix utils.parallel_map number of workers setting
tests: remove useless response_headers field that breaks with Gabbi 1.39.0