### PR TITLE
indexer: ap rule, catch invalid ap

### DIFF
--- a/gnocchi/indexer/__init__.py
+++ b/gnocchi/indexer/__init__.py
@@ -149,6 +149,12 @@ class NoSuchArchivePolicy(IndexerException):
             "Archive policy %s does not exist" % archive_policy)
         self.archive_policy = archive_policy
 
+    def jsonify(self):
+        return {
+            "cause": "Archive policy does not exist",
+            "detail": self.archive_policy,
+        }
+
 
 class UnsupportedArchivePolicyChange(IndexerException):
     """Error raised when modifying archive policy if not supported."""

--- a/gnocchi/indexer/sqlalchemy.py
+++ b/gnocchi/indexer/sqlalchemy.py
@@ -644,6 +644,10 @@ class SQLAlchemyIndexer(indexer.IndexerDriver):
         try:
             with self.facade.writer() as session:
                 session.add(apr)
+        except exception.DBReferenceError as e:
+            if e.constraint == 'fk_apr_ap_name_ap_name':
+                raise indexer.NoSuchArchivePolicy(archive_policy_name)
+            raise
         except exception.DBDuplicateEntry:
             raise indexer.ArchivePolicyRuleAlreadyExists(name)
         return apr

--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -378,6 +378,8 @@ class ArchivePolicyRulesController(rest.RestController):
             )
         except indexer.ArchivePolicyRuleAlreadyExists as e:
             abort(409, six.text_type(e))
+        except indexer.NoSuchArchivePolicy as e:
+            abort(400, e)
 
         location = "/archive_policy_rule/" + ap.name
         set_resp_location_hdr(location)

--- a/gnocchi/tests/functional/gabbits/archive-rule.yaml
+++ b/gnocchi/tests/functional/gabbits/archive-rule.yaml
@@ -88,6 +88,23 @@ tests:
         metric_pattern: "disk.foo.*"
       status: 400
 
+    - name: create archive policy rule with invalid archive policy
+      POST: /v1/archive_policy_rule
+      request_headers:
+        # User admin
+        authorization: "basic YWRtaW46"
+        accept: application/json
+        content-type: application/json
+      data:
+        name: test_rule
+        archive_policy_name: not-exists
+        metric_pattern: "disk.foo.*"
+      status: 400
+      response_json_paths:
+        $.code: 400
+        $.description.cause: "Archive policy does not exist"
+        $.description.detail: not-exists
+
     - name: missing auth archive policy rule
       POST: /v1/archive_policy_rule
       request_headers:


### PR DESCRIPTION
This changes catch oslo.db error when archive policy
doesn't exists for an archive policy rule, and raise
ArchivePolicyNotFound instead.

Closes #627