### PR TITLE
indexer: ap rule, catch invalid ap

### DIFF
--- a/gnocchi/indexer/sqlalchemy.py
+++ b/gnocchi/indexer/sqlalchemy.py
@@ -637,6 +637,10 @@ class SQLAlchemyIndexer(indexer.IndexerDriver):
         try:
             with self.facade.writer() as session:
                 session.add(apr)
+        except exception.DBReferenceError as e:
+            if e.constraint == 'fk_apr_ap_name_ap_name':
+                raise indexer.NoSuchArchivePolicy(archive_policy_name)
+            raise
         except exception.DBDuplicateEntry:
             raise indexer.ArchivePolicyRuleAlreadyExists(name)
         return apr

--- a/gnocchi/rest/__init__.py
+++ b/gnocchi/rest/__init__.py
@@ -326,6 +326,8 @@ class ArchivePolicyRulesController(rest.RestController):
             )
         except indexer.ArchivePolicyRuleAlreadyExists as e:
             abort(409, e)
+        except indexer.NoSuchArchivePolicy as e:
+            abort(400, e)
 
         location = "/archive_policy_rule/" + ap.name
         set_resp_location_hdr(location)

--- a/gnocchi/tests/functional/gabbits/archive-rule.yaml
+++ b/gnocchi/tests/functional/gabbits/archive-rule.yaml
@@ -88,6 +88,21 @@ tests:
         metric_pattern: "disk.foo.*"
       status: 400
 
+    - name: create archive policy rule with invalid archive policy
+      POST: /v1/archive_policy_rule
+      request_headers:
+        # User admin
+        authorization: "basic YWRtaW46"
+        accept: application/json
+        content-type: application/json
+      data:
+        name: test_rule
+        archive_policy_name: not-exists
+        metric_pattern: "disk.foo.*"
+      status: 400
+      response_strings:
+        - "Archive policy does not exist"
+
     - name: missing auth archive policy rule
       POST: /v1/archive_policy_rule
       request_headers:


### PR DESCRIPTION
This changes catch oslo.db error when archive policy
doesn't exists for an archive policy rule, and raise
ArchivePolicyNotFound instead.

Closes #627

(cherry picked from commit df2b64026c6ea697c47200a9fb7ec2b02622de92)