### PR TITLE
indexer: fix upgrade when password contains a %

### DIFF
--- a/gnocchi/indexer/sqlalchemy.py
+++ b/gnocchi/indexer/sqlalchemy.py
@@ -304,7 +304,7 @@ class SQLAlchemyIndexer(indexer.IndexerDriver):
         cfg = config.Config(
             "%s/alembic/alembic.ini" % os.path.dirname(__file__))
         cfg.set_main_option('sqlalchemy.url',
-                            self.conf.database.connection)
+                            self.conf.database.connection.replace('%', '%%'))
         return cfg
 
     def get_engine(self):

--- a/gnocchi/tests/indexer/sqlalchemy/test_utils.py
+++ b/gnocchi/tests/indexer/sqlalchemy/test_utils.py
@@ -1,0 +1,25 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright © 2017 Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+from gnocchi import indexer
+from gnocchi.tests import base
+
+
+class TestUtils(base.TestCase):
+    def test_percent_in_url(self):
+        url = 'mysql+pymysql://user:pass%word@localhost/foobar'
+        self.conf.set_override('url', url, 'indexer')
+        alembic = indexer.get_driver(self.conf)._get_alembic_config()
+        self.assertEqual(url, alembic.get_main_option("sqlalchemy.url"))


### PR DESCRIPTION
oslo.config doesn't support %{} or %() variable interpolation while
ConfigParser does.

So when a password contains a '%', it's fine for oslo.config
But the Python ConfigParser will raise the exception.

Since alembic use ConfigParser and not oslo.config, we have to escape
the url ourself.

This is not a big deal since, we don't want alembic doing variable
interpolation.

(cherry picked from commit 344e382c260374569eea31673c99245fe513201b)