### PR TITLE
tests: remove useless response_headers field that breaks with Gabbi 1.39.0

### DIFF
--- a/gnocchi/tests/gabbi/gabbits/resource.yaml
+++ b/gnocchi/tests/gabbi/gabbits/resource.yaml
@@ -719,7 +719,6 @@ tests:
       data:
           electron.spin:
               archive_policy_name: medium
-      response_headers:
 
     - name: post metric at instance with empty definition
       POST: $LAST_URL


### PR DESCRIPTION
(cherry picked from commit 05b000babec14e9afdafd105f21b39b628e39f6f)