### PR TITLE
bump voluptuous requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cotyledon>=1.5.0
 six
 stevedore
 ujson
-voluptuous>=0.6
+voluptuous>=0.8.10
 werkzeug
 trollius; python_version < '3.4'
 tenacity>=4.6.0


### PR DESCRIPTION
NotIn was added in 0.8.10:
https://github.com/alecthomas/voluptuous/commit/f2241ce5edf6e16b3f3456f08f9b5bd7afe64a8d