### PR TITLE
set __ne__ method

### DIFF
--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -19,6 +19,7 @@
 import functools
 import itertools
 import math
+import operator
 import random
 import re
 import struct
@@ -484,27 +485,26 @@ class SplitKey(object):
         return hash(str(self.key.astype('datetime64[ns]')) +
                     str(self.sampling.astype('timedelta64[ns]')))
 
-    def __lt__(self, other):
+    def _compare(self, op, other):
         if isinstance(other, SplitKey):
             if self.sampling != other.sampling:
                 raise TypeError(
                     "Cannot compare %s with different sampling" %
                     self.__class__.__name__)
-            return self.key < other.key
+            return op(self.key, other.key)
         if isinstance(other, numpy.datetime64):
-            return self.key < other
+            return op(self.key, other)
         raise TypeError("Cannot compare %r with %r" % (self, other))
 
+    def __lt__(self, other):
+        return self._compare(operator.lt, other)
+
     def __eq__(self, other):
-        if isinstance(other, SplitKey):
-            if self.sampling != other.sampling:
-                raise TypeError(
-                    "Cannot compare %s with different sampling" %
-                    self.__class__.__name__)
-            return self.key == other.key
-        if isinstance(other, numpy.datetime64):
-            return self.key == other
-        raise TypeError("Cannot compare %r with %r" % (self, other))
+        return self._compare(operator.eq, other)
+
+    def __ne__(self, other):
+        # neither total_ordering nor py2 sets ne as the opposite of eq
+        return self._compare(operator.ne, other)
 
     def __str__(self):
         return str(float(self))

--- a/gnocchi/tests/test_carbonara.py
+++ b/gnocchi/tests/test_carbonara.py
@@ -786,6 +786,66 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
 
         self.assertGreaterEqual(key, numpy.datetime64("1970"))
 
+    def test_split_key_cmp(self):
+        dt1 = numpy.datetime64("2015-01-01T15:03")
+        dt1_1 = numpy.datetime64("2015-01-01T15:03")
+        dt2 = numpy.datetime64("2015-01-05T15:03")
+        td = numpy.timedelta64(60, 's')
+
+        self.assertEqual(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td),
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td))
+        self.assertEqual(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td),
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1_1, td))
+        self.assertNotEqual(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td),
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td))
+
+        self.assertLess(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td),
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td))
+        self.assertLessEqual(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td),
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td))
+
+        self.assertGreater(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td),
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td))
+        self.assertGreaterEqual(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td),
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td))
+
+    def test_split_key_cmp_negative(self):
+        dt1 = numpy.datetime64("2015-01-01T15:03")
+        dt1_1 = numpy.datetime64("2015-01-01T15:03")
+        dt2 = numpy.datetime64("2015-01-05T15:03")
+        td = numpy.timedelta64(60, 's')
+
+        self.assertFalse(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td) !=
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td))
+        self.assertFalse(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td) !=
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1_1, td))
+        self.assertFalse(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td) ==
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td))
+
+        self.assertFalse(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td) >=
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td))
+        self.assertFalse(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td) >
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td))
+
+        self.assertFalse(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td) <=
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td))
+        self.assertFalse(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td) <
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td))
+
     def test_split_key_next(self):
         self.assertEqual(
             numpy.datetime64("2015-03-06"),


### PR DESCRIPTION
neither total_ordering nor python2 sets a default __ne__ value
behaviuor opposite to __eq__. this only happens in python3[1] so we
need to set this.

[1] https://docs.python.org/3/whatsnew/3.0.html#operators-and-special-methods

Fixes: #658