### PR TITLE
set __ne__ method

### DIFF
--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -22,6 +22,7 @@ import itertools
 import logging
 import math
 import numbers
+import operator
 import random
 import re
 import struct
@@ -377,19 +378,22 @@ class SplitKey(object):
     def __hash__(self):
         return hash(self.key)
 
-    def __lt__(self, other):
+    def _compare(self, op, other):
         if isinstance(other, SplitKey):
-            return self.key < other.key
+            return op(self.key, other.key)
         if isinstance(other, pandas.Timestamp):
-            return self.key * 10e8 < other.value
-        return self.key < other
+            return op(self.key * 10e8, other.value)
+        return op(self.key, other)
+
+    def __lt__(self, other):
+        return self._compare(operator.lt, other)
 
     def __eq__(self, other):
-        if isinstance(other, SplitKey):
-            return self.key == other.key
-        if isinstance(other, pandas.Timestamp):
-            return self.key * 10e8 == other.value
-        return self.key == other
+        return self._compare(operator.eq, other)
+
+    def __ne__(self, other):
+        # neither total_ordering nor py2 sets ne as the opposite of eq
+        return self._compare(operator.ne, other)
 
     def __str__(self):
         return str(float(self))

--- a/gnocchi/tests/test_carbonara.py
+++ b/gnocchi/tests/test_carbonara.py
@@ -949,6 +949,66 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
 
         self.assertGreaterEqual(key, pandas.Timestamp(0))
 
+    def test_split_key_cmp(self):
+        dt1 = datetime.datetime(2015, 1, 1, 15, 3)
+        dt1_1 = datetime.datetime(2015, 1, 1, 15, 3)
+        dt2 = datetime.datetime(2015, 1, 5, 15, 3)
+        td = 60
+
+        self.assertEqual(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td),
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td))
+        self.assertEqual(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td),
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1_1, td))
+        self.assertNotEqual(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td),
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td))
+
+        self.assertLess(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td),
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td))
+        self.assertLessEqual(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td),
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td))
+
+        self.assertGreater(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td),
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td))
+        self.assertGreaterEqual(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td),
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td))
+
+    def test_split_key_cmp_negative(self):
+        dt1 = datetime.datetime(2015, 1, 1, 15, 3)
+        dt1_1 = datetime.datetime(2015, 1, 1, 15, 3)
+        dt2 = datetime.datetime(2015, 1, 5, 15, 3)
+        td = 60
+
+        self.assertFalse(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td) !=
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td))
+        self.assertFalse(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td) !=
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1_1, td))
+        self.assertFalse(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td) ==
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td))
+
+        self.assertFalse(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td) >=
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td))
+        self.assertFalse(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td) >
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td))
+
+        self.assertFalse(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td) <=
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td))
+        self.assertFalse(
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td) <
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td))
+
     def test_split_key_next(self):
         self.assertEqual(
             datetime.datetime(2015, 3, 6),


### PR DESCRIPTION
neither total_ordering nor python2 sets a default __ne__ value
behaviuor opposite to __eq__. this only happens in python3[1] so we
need to set this.

[1] https://docs.python.org/3/whatsnew/3.0.html#operators-and-special-methods

Fixes: #658

(cherry picked from commit 70cc23c4289b97c8fb3e0f12d5dadc00549516f3)