### PR TITLE
tests: remove useless response_headers field that breaks with Gabbi 1.39.0

### DIFF
--- a/gnocchi/tests/gabbi/gabbits/resource.yaml
+++ b/gnocchi/tests/gabbi/gabbits/resource.yaml
@@ -691,7 +691,6 @@ tests:
       data:
           electron.spin:
               archive_policy_name: medium
-      response_headers:
 
     - name: post metric at instance with empty definition
       POST: $LAST_URL


### PR DESCRIPTION
(cherry picked from commit 05b000b)