### PR TITLE
remove optional datetime resourcetype patch

### DIFF
--- a/gnocchi/tests/functional/gabbits/resource-type.yaml
+++ b/gnocchi/tests/functional/gabbits/resource-type.yaml
@@ -338,11 +338,6 @@ tests:
             type: uuid
             required: False
         - op: add
-          path: /attributes/new-optional-datetime
-          value:
-            type: datetime
-            required: False
-        - op: add
           path: /attributes/newstuff
           value:
             type: string


### PR DESCRIPTION
this was originally incorrectly backported in d2ed3846b7e99b59de96827afc71a27b031225c6.
it fails as expected now. why? i don't know.