### PR TITLE
fix bad backports

### DIFF
--- a/gnocchi/tests/functional/gabbits/archive-rule.yaml
+++ b/gnocchi/tests/functional/gabbits/archive-rule.yaml
@@ -101,7 +101,7 @@ tests:
         metric_pattern: "disk.foo.*"
       status: 400
       response_strings:
-        - "Archive policy does not exist"
+        - "Archive policy not-exists does not exist"
 
     - name: missing auth archive policy rule
       POST: /v1/archive_policy_rule

--- a/gnocchi/tests/functional/gabbits/resource-type.yaml
+++ b/gnocchi/tests/functional/gabbits/resource-type.yaml
@@ -338,11 +338,6 @@ tests:
             type: uuid
             required: False
         - op: add
-          path: /attributes/new-optional-datetime
-          value:
-            type: datetime
-            required: False
-        - op: add
           path: /attributes/newstuff
           value:
             type: string


### PR DESCRIPTION
- 8303ce4254c213de2dbb6bb1d0b86050e4c3e665 incorrectly backported
datetime attribute which didn't exists.
- e3176cb77d0c2377a0504db065f9a75024493ccd incorrectly backported
bad test as it's matching a string that requires jsonify from
9545e50631c5b8f30635d958fcfff29ee711e245

no idea why either one passed checks originally.