### PR TITLE
storage: pass Aggregation object to storage get_measures()

### DIFF
--- a/gnocchi/archive_policy.py
+++ b/gnocchi/archive_policy.py
@@ -27,6 +27,9 @@ from gnocchi import aggregation
 from gnocchi import utils
 
 
+ATTRGETTER_GRANULARITY = operator.attrgetter("granularity")
+
+
 class ArchivePolicy(object):
 
     DEFAULT_AGGREGATION_METHODS = ()
@@ -93,6 +96,17 @@ class ArchivePolicy(object):
             if d.granularity == granularity:
                 return aggregation.Aggregation(
                     method, d.granularity, d.timespan)
+
+    def get_aggregations_for_method(self, method):
+        """Return a list of aggregation for a method.
+
+        List is sorted by granularity, desc.
+
+        :param method: Aggregation method.
+        """
+        return [aggregation.Aggregation(method, d.granularity, d.timespan)
+                for d in sorted(self.definition,
+                                key=ATTRGETTER_GRANULARITY, reverse=True)]
 
     @property
     def aggregations(self):

--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -17,6 +17,7 @@
 import collections
 import functools
 import itertools
+import operator
 import uuid
 
 import jsonpatch
@@ -48,6 +49,9 @@ try:
     PROMETHEUS_SUPPORTED = True
 except ImportError:
     PROMETHEUS_SUPPORTED = False
+
+
+ATTRGETTER_GRANULARITY = operator.attrgetter("granularity")
 
 
 def arg_to_list(value):
@@ -530,6 +534,17 @@ class MetricController(rest.RestController):
                 },
             })
 
+        aggregations = []
+        for g in sorted(granularity, reverse=True):
+            agg = self.metric.archive_policy.get_aggregation(
+                aggregation, g)
+            if agg is None:
+                abort(404, six.text_type(
+                    storage.AggregationDoesNotExist(
+                        self.metric, aggregation, g)
+                ))
+            aggregations.append(agg)
+
         if (strtobool("refresh", refresh) and
                 pecan.request.incoming.has_unprocessed(self.metric.id)):
             try:
@@ -540,8 +555,7 @@ class MetricController(rest.RestController):
                 abort(503, six.text_type(e))
         try:
             return pecan.request.storage.get_measures(
-                self.metric, granularity, start, stop, aggregation,
-                resample)
+                self.metric, aggregations, start, stop, resample)[aggregation]
         except (storage.MetricDoesNotExist,
                 storage.AggregationDoesNotExist) as e:
             abort(404, six.text_type(e))
@@ -1880,6 +1894,19 @@ class AggregationController(rest.RestController):
                          for metric in metrics),
                     'No granularity match'))
 
+        aggregations = set()
+        for metric in metrics:
+            for g in granularity:
+                agg = metric.archive_policy.get_aggregation(
+                    aggregation, g)
+                if agg is None:
+                    abort(404, six.text_type(
+                        storage.AggregationDoesNotExist(metric, aggregation, g)
+                    ))
+                aggregations.add(agg)
+        aggregations = sorted(aggregations, key=ATTRGETTER_GRANULARITY,
+                              reverse=True)
+
         operations = ["aggregate", reaggregation, []]
         if resample:
             operations[2].extend(
@@ -1920,8 +1947,7 @@ class AggregationController(rest.RestController):
                         },
                     })
                 return pecan.request.storage.get_measures(
-                    metric, granularity, start, stop, aggregation,
-                    resample)
+                    metric, aggregations, start, stop, resample)[aggregation]
             return processor.get_measures(
                 pecan.request.storage,
                 [processor.MetricReference(m, aggregation) for m in metrics],

--- a/gnocchi/tests/test_statsd.py
+++ b/gnocchi/tests/test_statsd.py
@@ -46,7 +46,7 @@ class TestStatsd(tests_base.TestCase):
         self.conf.set_override("archive_policy_name",
                                self.STATSD_ARCHIVE_POLICY_NAME, "statsd")
         ap = self.ARCHIVE_POLICIES["medium"]
-        self.granularities = [d.granularity for d in ap.definition]
+        self.aggregations = ap.get_aggregations_for_method("mean")
 
         self.stats = statsd.Stats(self.conf)
         # Replace storage/indexer with correct ones that have been upgraded
@@ -77,12 +77,12 @@ class TestStatsd(tests_base.TestCase):
             self.stats.indexer, self.stats.incoming,
             [str(metric.id)], sync=True)
 
-        measures = self.storage.get_measures(metric, self.granularities)
-        self.assertEqual([
+        measures = self.storage.get_measures(metric, self.aggregations)
+        self.assertEqual({"mean": [
             (datetime64(2015, 1, 7), numpy.timedelta64(1, 'D'), 1.0),
             (datetime64(2015, 1, 7, 13), numpy.timedelta64(1, 'h'), 1.0),
             (datetime64(2015, 1, 7, 13, 58), numpy.timedelta64(1, 'm'), 1.0)
-        ], measures)
+        ]}, measures)
 
         utcnow.return_value = utils.datetime_utc(2015, 1, 7, 13, 59, 37)
         # This one is going to be ignored
@@ -98,13 +98,13 @@ class TestStatsd(tests_base.TestCase):
             self.stats.indexer, self.stats.incoming,
             [str(metric.id)], sync=True)
 
-        measures = self.storage.get_measures(metric, self.granularities)
-        self.assertEqual([
+        measures = self.storage.get_measures(metric, self.aggregations)
+        self.assertEqual({"mean": [
             (datetime64(2015, 1, 7), numpy.timedelta64(1, 'D'), 1.5),
             (datetime64(2015, 1, 7, 13), numpy.timedelta64(1, 'h'), 1.5),
             (datetime64(2015, 1, 7, 13, 58), numpy.timedelta64(1, 'm'), 1.0),
             (datetime64(2015, 1, 7, 13, 59), numpy.timedelta64(1, 'm'), 2.0)
-        ], measures)
+        ]}, measures)
 
     def test_gauge(self):
         self._test_gauge_or_ms("g")
@@ -132,12 +132,12 @@ class TestStatsd(tests_base.TestCase):
             self.stats.indexer, self.stats.incoming,
             [str(metric.id)], sync=True)
 
-        measures = self.storage.get_measures(metric, self.granularities)
-        self.assertEqual([
+        measures = self.storage.get_measures(metric, self.aggregations)
+        self.assertEqual({"mean": [
             (datetime64(2015, 1, 7), numpy.timedelta64(1, 'D'), 1.0),
             (datetime64(2015, 1, 7, 13), numpy.timedelta64(1, 'h'), 1.0),
             (datetime64(2015, 1, 7, 13, 58), numpy.timedelta64(1, 'm'), 1.0)
-        ], measures)
+        ]}, measures)
 
         utcnow.return_value = utils.datetime_utc(2015, 1, 7, 13, 59, 37)
         self.server.datagram_received(
@@ -152,13 +152,13 @@ class TestStatsd(tests_base.TestCase):
             self.stats.indexer, self.stats.incoming,
             [str(metric.id)], sync=True)
 
-        measures = self.storage.get_measures(metric, self.granularities)
-        self.assertEqual([
+        measures = self.storage.get_measures(metric, self.aggregations)
+        self.assertEqual({"mean": [
             (datetime64(2015, 1, 7), numpy.timedelta64(1, 'D'), 28),
             (datetime64(2015, 1, 7, 13), numpy.timedelta64(1, 'h'), 28),
             (datetime64(2015, 1, 7, 13, 58), numpy.timedelta64(1, 'm'), 1.0),
             (datetime64(2015, 1, 7, 13, 59), numpy.timedelta64(1, 'm'), 55.0)
-        ], measures)
+        ]}, measures)
 
 
 class TestStatsdArchivePolicyRule(TestStatsd):

--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -20,6 +20,7 @@ import mock
 import numpy
 import six.moves
 
+from gnocchi import aggregation as gaggregation
 from gnocchi import archive_policy
 from gnocchi import carbonara
 from gnocchi import incoming
@@ -81,13 +82,10 @@ class TestStorageDriver(tests_base.TestCase):
                             side_effect=carbonara.InvalidData()):
                 self.trigger_processing()
 
-        granularities = [
-            numpy.timedelta64(1, 'D'),
-            numpy.timedelta64(1, 'h'),
-            numpy.timedelta64(5, 'm'),
-        ]
-
-        m = self.storage.get_measures(self.metric, granularities)
+        m = self.storage.get_measures(
+            self.metric,
+            self.metric.archive_policy.get_aggregations_for_method('mean'),
+        )['mean']
         self.assertIn((datetime64(2014, 1, 1),
                        numpy.timedelta64(1, 'D'), 1), m)
         self.assertIn((datetime64(2014, 1, 1, 13),
@@ -110,13 +108,11 @@ class TestStorageDriver(tests_base.TestCase):
             self.trigger_processing()
             self.assertFalse(LOG.error.called)
 
-        granularities = [
-            numpy.timedelta64(1, 'D'),
-            numpy.timedelta64(1, 'h'),
-            numpy.timedelta64(5, 'm'),
-        ]
+        aggregations = (
+            self.metric.archive_policy.get_aggregations_for_method("mean")
+        )
 
-        m = self.storage.get_measures(self.metric, granularities)
+        m = self.storage.get_measures(self.metric, aggregations)['mean']
         self.assertIn((datetime64(2014, 1, 1),
                        numpy.timedelta64(1, 'D'), 5.0), m)
         self.assertIn((datetime64(2014, 1, 1, 12),
@@ -143,11 +139,13 @@ class TestStorageDriver(tests_base.TestCase):
         self.trigger_processing()
         self.storage._delete_metric(self.metric)
         self.trigger_processing()
-        self.assertEqual([], self.storage.get_measures(self.metric, [
-            numpy.timedelta64(1, 'D'),
-            numpy.timedelta64(1, 'h'),
-            numpy.timedelta64(5, 'm'),
-        ]))
+
+        aggregations = (
+            self.metric.archive_policy.get_aggregations_for_method("mean")
+        )
+
+        self.assertEqual({"mean": []}, self.storage.get_measures(
+            self.metric, aggregations))
         self.assertRaises(storage.MetricDoesNotExist,
                           self.storage._get_unaggregated_timeserie,
                           self.metric)
@@ -216,11 +214,12 @@ class TestStorageDriver(tests_base.TestCase):
             for i in six.moves.range(0, 60) for j in six.moves.range(0, 60)])
         self.trigger_processing([str(m.id)])
 
-        self.assertEqual(3661, len(self.storage.get_measures(m, [
-            numpy.timedelta64(1, 'h'),
-            numpy.timedelta64(1, 'm'),
-            numpy.timedelta64(1, 's'),
-        ])))
+        aggregations = (
+            m.archive_policy.get_aggregations_for_method("mean")
+        )
+
+        self.assertEqual(3661, len(
+            self.storage.get_measures(m, aggregations)['mean']))
 
     @mock.patch('gnocchi.carbonara.SplitKey.POINTS_PER_SPLIT', 48)
     def test_add_measures_update_subset_split(self):
@@ -276,19 +275,17 @@ class TestStorageDriver(tests_base.TestCase):
         ])
         self.trigger_processing()
 
-        granularities = [
-            numpy.timedelta64(1, 'D'),
-            numpy.timedelta64(1, 'h'),
-            numpy.timedelta64(5, 'm'),
-        ]
+        aggregations = (
+            self.metric.archive_policy.get_aggregations_for_method("mean")
+        )
 
-        self.assertEqual([
+        self.assertEqual({"mean": [
             (datetime64(2014, 1, 1), numpy.timedelta64(1, 'D'), 39.75),
             (datetime64(2014, 1, 1, 12), numpy.timedelta64(1, 'h'), 39.75),
             (datetime64(2014, 1, 1, 12), numpy.timedelta64(5, 'm'), 69.0),
             (datetime64(2014, 1, 1, 12, 5), numpy.timedelta64(5, 'm'), 23.0),
             (datetime64(2014, 1, 1, 12, 10), numpy.timedelta64(5, 'm'), 44.0),
-        ], self.storage.get_measures(self.metric, granularities))
+        ]}, self.storage.get_measures(self.metric, aggregations))
 
         # One year later…
         self.incoming.add_measures(self.metric.id, [
@@ -296,11 +293,11 @@ class TestStorageDriver(tests_base.TestCase):
         ])
         self.trigger_processing()
 
-        self.assertEqual([
+        self.assertEqual({"mean": [
             (datetime64(2015, 1, 1), numpy.timedelta64(1, 'D'), 69),
             (datetime64(2015, 1, 1, 12), numpy.timedelta64(1, 'h'), 69),
             (datetime64(2015, 1, 1, 12), numpy.timedelta64(5, 'm'), 69),
-        ], self.storage.get_measures(self.metric, granularities))
+        ]}, self.storage.get_measures(self.metric, aggregations))
 
         self.assertEqual({
             carbonara.SplitKey(numpy.datetime64(1244160000, 's'),
@@ -372,14 +369,15 @@ class TestStorageDriver(tests_base.TestCase):
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
-        self.assertEqual([
+        aggregation = self.metric.archive_policy.get_aggregation(
+            "mean", numpy.timedelta64(1, 'm'))
+
+        self.assertEqual({"mean": [
             (datetime64(2016, 1, 1, 12), numpy.timedelta64(1, 'm'), 69),
             (datetime64(2016, 1, 2, 13, 7), numpy.timedelta64(1, 'm'), 42),
             (datetime64(2016, 1, 4, 14, 9), numpy.timedelta64(1, 'm'), 4),
             (datetime64(2016, 1, 6, 15, 12), numpy.timedelta64(1, 'm'), 44),
-        ], self.storage.get_measures(
-            self.metric,
-            granularities=[numpy.timedelta64(1, 'm')]))
+        ]}, self.storage.get_measures(self.metric, [aggregation]))
 
         # Now store brand new points that should force a rewrite of one of the
         # split (keep in mind the back window size in one hour here). We move
@@ -429,16 +427,14 @@ class TestStorageDriver(tests_base.TestCase):
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
-        self.assertEqual([
+        self.assertEqual({"mean": [
             (datetime64(2016, 1, 1, 12), numpy.timedelta64(1, 'm'), 69),
             (datetime64(2016, 1, 2, 13, 7), numpy.timedelta64(1, 'm'), 42),
             (datetime64(2016, 1, 4, 14, 9), numpy.timedelta64(1, 'm'), 4),
             (datetime64(2016, 1, 6, 15, 12), numpy.timedelta64(1, 'm'), 44),
             (datetime64(2016, 1, 10, 16, 18), numpy.timedelta64(1, 'm'), 45),
             (datetime64(2016, 1, 10, 17, 12), numpy.timedelta64(1, 'm'), 46),
-        ], self.storage.get_measures(
-            self.metric,
-            granularities=[numpy.timedelta64(1, 'm')]))
+        ]}, self.storage.get_measures(self.metric, [aggregation]))
 
     def test_rewrite_measures_oldest_mutable_timestamp_eq_next_key(self):
         """See LP#1655422"""
@@ -495,14 +491,15 @@ class TestStorageDriver(tests_base.TestCase):
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
-        self.assertEqual([
+        aggregation = self.metric.archive_policy.get_aggregation(
+            "mean", numpy.timedelta64(1, 'm'))
+
+        self.assertEqual({"mean": [
             (datetime64(2016, 1, 1, 12), numpy.timedelta64(1, 'm'), 69),
             (datetime64(2016, 1, 2, 13, 7), numpy.timedelta64(1, 'm'), 42),
             (datetime64(2016, 1, 4, 14, 9), numpy.timedelta64(1, 'm'), 4),
             (datetime64(2016, 1, 6, 15, 12), numpy.timedelta64(1, 'm'), 44),
-        ], self.storage.get_measures(
-            self.metric,
-            granularities=[numpy.timedelta64(60, 's')]))
+        ]}, self.storage.get_measures(self.metric, [aggregation]))
 
         # Now store brand new points that should force a rewrite of one of the
         # split (keep in mind the back window size in one hour here). We move
@@ -554,15 +551,13 @@ class TestStorageDriver(tests_base.TestCase):
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
-        self.assertEqual([
+        self.assertEqual({"mean": [
             (datetime64(2016, 1, 1, 12), numpy.timedelta64(1, 'm'), 69),
             (datetime64(2016, 1, 2, 13, 7), numpy.timedelta64(1, 'm'), 42),
             (datetime64(2016, 1, 4, 14, 9), numpy.timedelta64(1, 'm'), 4),
             (datetime64(2016, 1, 6, 15, 12), numpy.timedelta64(1, 'm'), 44),
             (datetime64(2016, 1, 10, 0, 12), numpy.timedelta64(1, 'm'), 45),
-        ], self.storage.get_measures(
-            self.metric,
-            granularities=[numpy.timedelta64(60, 's')]))
+        ]}, self.storage.get_measures(self.metric, [aggregation]))
 
     def test_rewrite_measures_corruption_missing_file(self):
         # Create an archive policy that spans on several splits. Each split
@@ -619,7 +614,10 @@ class TestStorageDriver(tests_base.TestCase):
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
-        self.assertEqual([
+        aggregation = self.metric.archive_policy.get_aggregation(
+            "mean", numpy.timedelta64(1, 'm'))
+
+        self.assertEqual({"mean": [
             (datetime64(2016, 1, 1, 12),
              numpy.timedelta64(1, 'm'), 69),
             (datetime64(2016, 1, 2, 13, 7),
@@ -628,9 +626,7 @@ class TestStorageDriver(tests_base.TestCase):
              numpy.timedelta64(1, 'm'), 4),
             (datetime64(2016, 1, 6, 15, 12),
              numpy.timedelta64(1, 'm'), 44),
-        ], self.storage.get_measures(
-            self.metric,
-            granularities=[numpy.timedelta64(60, 's')]))
+        ]}, self.storage.get_measures(self.metric, [aggregation]))
 
         # Test what happens if we delete the latest split and then need to
         # compress it!
@@ -704,14 +700,15 @@ class TestStorageDriver(tests_base.TestCase):
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
-        self.assertEqual([
+        aggregation = self.metric.archive_policy.get_aggregation(
+            "mean", numpy.timedelta64(1, 'm'))
+
+        self.assertEqual({"mean": [
             (datetime64(2016, 1, 1, 12), numpy.timedelta64(1, 'm'), 69),
             (datetime64(2016, 1, 2, 13, 7), numpy.timedelta64(1, 'm'), 42),
             (datetime64(2016, 1, 4, 14, 9), numpy.timedelta64(1, 'm'), 4),
             (datetime64(2016, 1, 6, 15, 12), numpy.timedelta64(1, 'm'), 44),
-        ], self.storage.get_measures(
-            self.metric,
-            granularities=[numpy.timedelta64(1, 'm')]))
+        ]}, self.storage.get_measures(self.metric, [aggregation]))
 
         # Test what happens if we write garbage
         self.storage._store_metric_measures(
@@ -738,18 +735,16 @@ class TestStorageDriver(tests_base.TestCase):
         ])
         self.trigger_processing()
 
-        granularities = [
-            numpy.timedelta64(1, 'D'),
-            numpy.timedelta64(1, 'h'),
-            numpy.timedelta64(5, 'm'),
-        ]
+        aggregations = (
+            self.metric.archive_policy.get_aggregations_for_method("mean")
+        )
 
-        self.assertEqual([
+        self.assertEqual({"mean": [
             (datetime64(2014, 1, 1), numpy.timedelta64(1, 'D'), 55.5),
             (datetime64(2014, 1, 1, 12), numpy.timedelta64(1, 'h'), 55.5),
             (datetime64(2014, 1, 1, 12), numpy.timedelta64(5, 'm'), 69),
             (datetime64(2014, 1, 1, 12, 5), numpy.timedelta64(5, 'm'), 42.0),
-        ], self.storage.get_measures(self.metric, granularities))
+        ]}, self.storage.get_measures(self.metric, aggregations))
 
         self.incoming.add_measures(self.metric.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 9, 31), 4),
@@ -757,31 +752,37 @@ class TestStorageDriver(tests_base.TestCase):
         ])
         self.trigger_processing()
 
-        self.assertEqual([
+        self.assertEqual({"mean": [
             (datetime64(2014, 1, 1), numpy.timedelta64(1, 'D'), 39.75),
             (datetime64(2014, 1, 1, 12), numpy.timedelta64(1, 'h'), 39.75),
             (datetime64(2014, 1, 1, 12), numpy.timedelta64(5, 'm'), 69.0),
             (datetime64(2014, 1, 1, 12, 5), numpy.timedelta64(5, 'm'), 23.0),
             (datetime64(2014, 1, 1, 12, 10), numpy.timedelta64(5, 'm'), 44.0),
-        ], self.storage.get_measures(self.metric, granularities))
+        ]}, self.storage.get_measures(self.metric, aggregations))
 
-        self.assertEqual([
+        aggregations = (
+            self.metric.archive_policy.get_aggregations_for_method("max")
+        )
+
+        self.assertEqual({"max": [
             (datetime64(2014, 1, 1), numpy.timedelta64(1, 'D'), 69),
             (datetime64(2014, 1, 1, 12), numpy.timedelta64(1, 'h'), 69.0),
             (datetime64(2014, 1, 1, 12), numpy.timedelta64(5, 'm'), 69.0),
             (datetime64(2014, 1, 1, 12, 5), numpy.timedelta64(5, 'm'), 42.0),
             (datetime64(2014, 1, 1, 12, 10), numpy.timedelta64(5, 'm'), 44.0),
-        ], self.storage.get_measures(self.metric,
-                                     granularities, aggregation='max'))
+        ]}, self.storage.get_measures(self.metric, aggregations))
 
-        self.assertEqual([
+        aggregations = (
+            self.metric.archive_policy.get_aggregations_for_method("min")
+        )
+
+        self.assertEqual({"min": [
             (datetime64(2014, 1, 1), numpy.timedelta64(1, 'D'), 4),
             (datetime64(2014, 1, 1, 12), numpy.timedelta64(1, 'h'), 4),
             (datetime64(2014, 1, 1, 12), numpy.timedelta64(5, 'm'), 69.0),
             (datetime64(2014, 1, 1, 12, 5), numpy.timedelta64(5, 'm'), 4.0),
             (datetime64(2014, 1, 1, 12, 10), numpy.timedelta64(5, 'm'), 44.0),
-        ], self.storage.get_measures(self.metric,
-                                     granularities, aggregation='min'))
+        ]}, self.storage.get_measures(self.metric, aggregations))
 
     def test_add_and_get_measures(self):
         self.incoming.add_measures(self.metric.id, [
@@ -792,89 +793,91 @@ class TestStorageDriver(tests_base.TestCase):
         ])
         self.trigger_processing()
 
-        granularities = [
-            numpy.timedelta64(1, 'D'),
-            numpy.timedelta64(1, 'h'),
-            numpy.timedelta64(5, 'm'),
-        ]
+        aggregations = (
+            self.metric.archive_policy.get_aggregations_for_method("mean")
+        )
 
-        self.assertEqual([
+        self.assertEqual({"mean": [
             (datetime64(2014, 1, 1), numpy.timedelta64(1, 'D'), 39.75),
             (datetime64(2014, 1, 1, 12), numpy.timedelta64(1, 'h'), 39.75),
             (datetime64(2014, 1, 1, 12), numpy.timedelta64(5, 'm'), 69.0),
             (datetime64(2014, 1, 1, 12, 5), numpy.timedelta64(5, 'm'), 23.0),
             (datetime64(2014, 1, 1, 12, 10), numpy.timedelta64(5, 'm'), 44.0),
-        ], self.storage.get_measures(self.metric, granularities))
+        ]}, self.storage.get_measures(self.metric, aggregations))
 
-        self.assertEqual([
+        self.assertEqual({"mean": [
             (datetime64(2014, 1, 1), numpy.timedelta64(1, 'D'), 39.75),
             (datetime64(2014, 1, 1, 12), numpy.timedelta64(1, 'h'), 39.75),
             (datetime64(2014, 1, 1, 12, 10), numpy.timedelta64(5, 'm'), 44.0),
-        ], self.storage.get_measures(
-            self.metric,
-            granularities,
+        ]}, self.storage.get_measures(
+            self.metric, aggregations,
             from_timestamp=datetime64(2014, 1, 1, 12, 10, 0)))
 
-        self.assertEqual([
+        self.assertEqual({"mean": [
             (datetime64(2014, 1, 1), numpy.timedelta64(1, 'D'), 39.75),
             (datetime64(2014, 1, 1, 12), numpy.timedelta64(1, 'h'), 39.75),
             (datetime64(2014, 1, 1, 12), numpy.timedelta64(5, 'm'), 69.0),
             (datetime64(2014, 1, 1, 12, 5), numpy.timedelta64(5, 'm'), 23.0),
-        ], self.storage.get_measures(
-            self.metric,
-            granularities,
+        ]}, self.storage.get_measures(
+            self.metric, aggregations,
             to_timestamp=datetime64(2014, 1, 1, 12, 6, 0)))
 
-        self.assertEqual([
+        self.assertEqual({"mean": [
             (datetime64(2014, 1, 1), numpy.timedelta64(1, 'D'), 39.75),
             (datetime64(2014, 1, 1, 12), numpy.timedelta64(1, 'h'), 39.75),
             (datetime64(2014, 1, 1, 12, 10), numpy.timedelta64(5, 'm'), 44.0),
-        ], self.storage.get_measures(
-            self.metric,
-            granularities,
+        ]}, self.storage.get_measures(
+            self.metric, aggregations,
             to_timestamp=datetime64(2014, 1, 1, 12, 10, 10),
             from_timestamp=datetime64(2014, 1, 1, 12, 10, 10)))
 
-        self.assertEqual([
+        self.assertEqual({"mean": [
             (datetime64(2014, 1, 1), numpy.timedelta64(1, 'D'), 39.75),
             (datetime64(2014, 1, 1, 12), numpy.timedelta64(1, 'h'), 39.75),
             (datetime64(2014, 1, 1, 12), numpy.timedelta64(5, 'm'), 69.0),
-        ], self.storage.get_measures(
-            self.metric,
-            granularities,
+        ]}, self.storage.get_measures(
+            self.metric, aggregations,
             from_timestamp=datetime64(2014, 1, 1, 12, 0, 0),
             to_timestamp=datetime64(2014, 1, 1, 12, 0, 2)))
 
-        self.assertEqual([
+        self.assertEqual({"mean": [
             (datetime64(2014, 1, 1), numpy.timedelta64(1, 'D'), 39.75),
             (datetime64(2014, 1, 1, 12), numpy.timedelta64(1, 'h'), 39.75),
             (datetime64(2014, 1, 1, 12), numpy.timedelta64(5, 'm'), 69.0),
-        ], self.storage.get_measures(
-            self.metric,
-            granularities,
+        ]}, self.storage.get_measures(
+            self.metric, aggregations,
             from_timestamp=datetime64(2014, 1, 1, 12),
             to_timestamp=datetime64(2014, 1, 1, 12, 0, 2)))
 
-        self.assertEqual([
+        aggregation_1h = (
+            self.metric.archive_policy.get_aggregation(
+                "mean", numpy.timedelta64(1, 'h'))
+        )
+
+        self.assertEqual({"mean": [
             (datetime64(2014, 1, 1, 12), numpy.timedelta64(1, 'h'), 39.75),
-        ], self.storage.get_measures(
-            self.metric,
+        ]}, self.storage.get_measures(
+            self.metric, [aggregation_1h],
             from_timestamp=datetime64(2014, 1, 1, 12, 0, 0),
-            to_timestamp=datetime64(2014, 1, 1, 12, 0, 2),
-            granularities=[numpy.timedelta64(1, 'h')]))
+            to_timestamp=datetime64(2014, 1, 1, 12, 0, 2)))
 
-        self.assertEqual([
+        aggregation_5m = (
+            self.metric.archive_policy.get_aggregation(
+                "mean", numpy.timedelta64(5, 'm'))
+        )
+
+        self.assertEqual({"mean": [
             (datetime64(2014, 1, 1, 12), numpy.timedelta64(5, 'm'), 69.0),
-        ], self.storage.get_measures(
-            self.metric,
+        ]}, self.storage.get_measures(
+            self.metric, [aggregation_5m],
             from_timestamp=datetime64(2014, 1, 1, 12, 0, 0),
-            to_timestamp=datetime64(2014, 1, 1, 12, 0, 2),
-            granularities=[numpy.timedelta64(5, 'm')]))
+            to_timestamp=datetime64(2014, 1, 1, 12, 0, 2)))
 
-        self.assertRaises(storage.AggregationDoesNotExist,
-                          self.storage.get_measures,
-                          self.metric,
-                          granularities=[numpy.timedelta64(42, 's')])
+        self.assertEqual({"mean": []},
+                         self.storage.get_measures(
+                             self.metric,
+                             [gaggregation.Aggregation(
+                                 "mean", numpy.timedelta64(42, 's'), None)]))
 
     def test_get_measure_unknown_aggregation(self):
         self.incoming.add_measures(self.metric.id, [
@@ -883,14 +886,13 @@ class TestStorageDriver(tests_base.TestCase):
             incoming.Measure(datetime64(2014, 1, 1, 12, 9, 31), 4),
             incoming.Measure(datetime64(2014, 1, 1, 12, 12, 45), 44),
         ])
-        granularities = [
-            numpy.timedelta64(1, 'D'),
-            numpy.timedelta64(1, 'h'),
-            numpy.timedelta64(5, 'm'),
-        ]
+
+        aggregations = (
+            self.metric.archive_policy.get_aggregations_for_method("last")
+        )
+
         self.assertEqual(
-            [], self.storage.get_measures(
-                self.metric, granularities, aggregation='last'))
+            {"last": []}, self.storage.get_measures(self.metric, aggregations))
 
     def test_find_measures(self):
         metric2, __ = self._create_metric()
@@ -964,11 +966,15 @@ class TestStorageDriver(tests_base.TestCase):
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 10), 1),
         ])
         self.trigger_processing([str(m.id)])
-        self.assertEqual([
+
+        aggregation = m.archive_policy.get_aggregation(
+            "mean", numpy.timedelta64(5, 's'))
+
+        self.assertEqual({"mean": [
             (datetime64(2014, 1, 1, 12, 0, 0), numpy.timedelta64(5, 's'), 1),
             (datetime64(2014, 1, 1, 12, 0, 5), numpy.timedelta64(5, 's'), 1),
             (datetime64(2014, 1, 1, 12, 0, 10), numpy.timedelta64(5, 's'), 1),
-        ], self.storage.get_measures(m, [numpy.timedelta64(5, 's')]))
+        ]}, self.storage.get_measures(m, [aggregation]))
         # expand to more points
         self.index.update_archive_policy(
             name, [archive_policy.ArchivePolicyItem(granularity=5, points=6)])
@@ -977,27 +983,30 @@ class TestStorageDriver(tests_base.TestCase):
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 15), 1),
         ])
         self.trigger_processing([str(m.id)])
-        self.assertEqual([
-            (datetime64(2014, 1, 1, 12, 0, 0), numpy.timedelta64(5, 's'), 1),
+        self.assertEqual({"mean": [
             (datetime64(2014, 1, 1, 12, 0, 5), numpy.timedelta64(5, 's'), 1),
             (datetime64(2014, 1, 1, 12, 0, 10), numpy.timedelta64(5, 's'), 1),
             (datetime64(2014, 1, 1, 12, 0, 15), numpy.timedelta64(5, 's'), 1),
-        ], self.storage.get_measures(m, [numpy.timedelta64(5, 's')]))
+        ]}, self.storage.get_measures(m, [aggregation]))
         # shrink timespan
         self.index.update_archive_policy(
             name, [archive_policy.ArchivePolicyItem(granularity=5, points=2)])
         m = self.index.list_metrics(attribute_filter={"=": {"id": m.id}})[0]
-        self.assertEqual([
+        aggregation = m.archive_policy.get_aggregation(
+            "mean", numpy.timedelta64(5, 's'))
+        self.assertEqual({"mean": [
             (datetime64(2014, 1, 1, 12, 0, 10), numpy.timedelta64(5, 's'), 1),
             (datetime64(2014, 1, 1, 12, 0, 15), numpy.timedelta64(5, 's'), 1),
-        ], self.storage.get_measures(m, [numpy.timedelta64(5, 's')]))
+        ]}, self.storage.get_measures(m, [aggregation]))
 
     def test_resample_no_metric(self):
         """https://github.com/gnocchixyz/gnocchi/issues/69"""
-        self.assertEqual([],
+        aggregation = self.metric.archive_policy.get_aggregation(
+            "mean", numpy.timedelta64(300, 's'))
+        self.assertEqual({"mean": []},
                          self.storage.get_measures(
                              self.metric,
-                             [numpy.timedelta64(300, 's')],
+                             [aggregation],
                              datetime64(2014, 1, 1),
                              datetime64(2015, 1, 1),
                              resample=numpy.timedelta64(1, 'h')))


### PR DESCRIPTION
This frees a bit more the storage engine from the archive policy system.