### PR TITLE
metricd: fix retry being too aggressive

### DIFF
--- a/gnocchi/cli.py
+++ b/gnocchi/cli.py
@@ -85,9 +85,12 @@ class MetricProcessBase(cotyledon.Service):
 
     @utils.retry
     def _configure(self):
-        self.store = storage.get_driver(self.conf)
-        self.index = indexer.get_driver(self.conf)
-        self.index.connect()
+        try:
+            self.store = storage.get_driver(self.conf)
+            self.index = indexer.get_driver(self.conf)
+            self.index.connect()
+        except Exception as e:
+            raise utils.Retry(e)
 
     def run(self):
         self._configure()


### PR DESCRIPTION
The patch in f5f2e3e9e8d0c36e23a5ad21ec3dc425cdc214cc was way too optimistic:
@utils.retry only retries if `utils.Retry` is raised. Here, a random exception
can be raised and then it crashes back to Cotyledon which restarts without
delay.

This patch transforms any `Exception` to `utils.Retry` so retrying is used and
wait before retrying, rather than having cotyledon restarting right away.

Closes: #681