### PR TITLE
indexer: fix not operator

### DIFF
--- a/gnocchi/indexer/sqlalchemy.py
+++ b/gnocchi/indexer/sqlalchemy.py
@@ -1290,6 +1290,6 @@ class QueryTransformer(object):
                     op = cls.unary_operators[operator]
                 except KeyError:
                     raise indexer.QueryInvalidOperator(operator)
-                return cls._handle_unary_op(engine, op, nodes)
+                return cls._handle_unary_op(engine, table, op, nodes)
             return cls._handle_binary_op(engine, table, op, nodes)
         return cls._handle_multiple_op(engine, table, op, nodes)

--- a/gnocchi/tests/functional/gabbits/search.yaml
+++ b/gnocchi/tests/functional/gabbits/search.yaml
@@ -144,6 +144,11 @@ tests:
       response_json_paths:
         $.`len`: 2
 
+    - name: search not in_ query string
+      POST: /v1/search/resource/generic?filter=not%20id%20in%20%5Bfaef212f-0bf4-4030-a461-2186fef79be0%2C%20df7e5e75-6a1d-4ff7-85cb-38eb9d75da7e%5D
+      response_json_paths:
+        $.`len`: 0
+
     - name: search empty in_
       POST: /v1/search/resource/generic
       data:


### PR DESCRIPTION
The not operator was buggy. This change fix it.

Closes: #649
(cherry picked from commit 246dd263e91e240cdbf74d253e09f834233ef21d)