### PR TITLE
indexer: fix not operator

### DIFF
--- a/gnocchi/indexer/sqlalchemy.py
+++ b/gnocchi/indexer/sqlalchemy.py
@@ -1221,6 +1221,6 @@ class QueryTransformer(object):
                     op = cls.unary_operators[operator]
                 except KeyError:
                     raise indexer.QueryInvalidOperator(operator)
-                return cls._handle_unary_op(engine, op, nodes)
+                return cls._handle_unary_op(engine, table, op, nodes)
             return cls._handle_binary_op(engine, table, op, nodes)
         return cls._handle_multiple_op(engine, table, op, nodes)


### PR DESCRIPTION
The not operator was buggy. This change fix it.

Closes: #649
(cherry picked from commit 246dd263e91e240cdbf74d253e09f834233ef21d)