### PR TITLE
docs: grammar fixes for statsd.rst

### DIFF
--- a/doc/source/statsd.rst
+++ b/doc/source/statsd.rst
@@ -12,8 +12,8 @@ listen to |metrics| sent over the network, named `gnocchi-statsd`.
 
 .. _`Statsd`: https://github.com/etsy/statsd/
 
-How It Works?
-=============
+How Does It Work?
+=================
 In order to enable statsd support in Gnocchi, you need to configure the
 `[statsd]` option group in the configuration file. You need to provide a
 |resource| ID that will be used as the main generic |resource| where all the
@@ -25,14 +25,14 @@ All the |metrics| will be created dynamically as the |metrics| are sent to
 `gnocchi-statsd`, and attached with the provided name to the |resource| ID you
 configured.
 
-The `gnocchi-statsd` may be scaled, but trade-offs have to been made due to the
+The `gnocchi-statsd` may be scaled, but trade-offs have been made due to the
 nature of the statsd protocol. That means that if you use |metrics| of type
 `counter`_ or sampling (`c` in the protocol), you should always send those
 |metrics| to the same daemon – or not use them at all. The other supported
-types (`timing`_ and `gauges`_) does not suffer this limitation, but be aware
-that you might have more |measures| that expected if you send the same |metric|
-to different `gnocchi-statsd` server, as their cache nor their flush delay are
-synchronized.
+types (`timing`_ and `gauges`_) do not suffer this limitation, but be aware
+that you might have more |measures| than expected if you send the same |metric|
+to different `gnocchi-statsd` servers, as neither their cache nor their flush
+delay are synchronized.
 
 .. _`counter`: https://github.com/etsy/statsd/blob/master/docs/metric_types.md#counting
 .. _`timing`: https://github.com/etsy/statsd/blob/master/docs/metric_types.md#timing


### PR DESCRIPTION
this commit fixes some minor grammatic issues with
the statsd daemon documentation.