### PR TITLE
tox: only run doc8 in docs target

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,6 @@ test =
     testresources>=0.2.4 # Apache-2.0/BSD
     testtools>=0.9.38
     WebTest>=2.0.16
-    doc8
     keystonemiddleware>=4.0.0,!=4.19.0
     wsgi_intercept>=1.4.1
 test-swift =

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,6 @@ deps = .[test,redis,prometheus,{env:GNOCCHI_STORAGE_DEPS:},{env:GNOCCHI_INDEXER_
    {env:GNOCCHI_TEST_TARBALLS:}
    cliff!=2.9.0
 commands =
-    doc8 doc/source
     {toxinidir}/run-tests.sh {posargs}
     {toxinidir}/run-func-tests.sh {posargs}
 
@@ -147,6 +146,7 @@ basepython = python3
 #        .[postgresql,doc]
 # setenv = GNOCCHI_STORAGE_DEPS=file
 deps = .[test,file,postgresql,doc]
+       doc8
 setenv = GNOCCHI_TEST_DEBUG=1
 commands = doc8 --ignore-path doc/source/rest.rst,doc/source/comparison-table.rst doc/source
            pifpaf -g GNOCCHI_INDEXER_URL run postgresql -- python setup.py build_sphinx -W


### PR DESCRIPTION
The docs target is run in Travis so we should be good. No need to run it here.