### PR TITLE
use concatenate consistently

### DIFF
--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -96,7 +96,7 @@ def combine_timeseries(ts1, ts2):
     :param ts: The timeseries to combine.
     :return: A new timeseries.
     """
-    ts = numpy.append(ts1, ts2)
+    ts = numpy.concatenate((ts1, ts2))
     _, index = numpy.unique(ts['timestamps'], return_index=True)
     return ts[index]
 

--- a/gnocchi/incoming/ceph.py
+++ b/gnocchi/incoming/ceph.py
@@ -214,7 +214,8 @@ class CephStorage(incoming.IncomingDriver):
 
         measures = self._make_measures_array()
         for k, v in omaps:
-            measures = numpy.append(measures, self._unserialize_measures(k, v))
+            measures = numpy.concatenate(
+                (measures, self._unserialize_measures(k, v)))
             processed_keys.append(k)
 
         yield measures

--- a/gnocchi/incoming/file.py
+++ b/gnocchi/incoming/file.py
@@ -169,8 +169,8 @@ class FileStorage(incoming.IncomingDriver):
         for f in files:
             abspath = self._build_measure_path(metric_id, f)
             with open(abspath, "rb") as e:
-                measures = numpy.append(
-                    measures, self._unserialize_measures(f, e.read()))
+                measures = numpy.concatenate((
+                    measures, self._unserialize_measures(f, e.read())))
 
         yield measures
 

--- a/gnocchi/incoming/s3.py
+++ b/gnocchi/incoming/s3.py
@@ -167,10 +167,10 @@ class S3Storage(incoming.IncomingDriver):
             response = self.s3.get_object(
                 Bucket=self._bucket_name_measures,
                 Key=f)
-            measures = numpy.append(
+            measures = numpy.concatenate((
                 measures,
                 self._unserialize_measures(f, response['Body'].read())
-            )
+            ))
 
         yield measures
 

--- a/gnocchi/rest/aggregates/operations.py
+++ b/gnocchi/rest/aggregates/operations.py
@@ -191,7 +191,7 @@ def handle_resample(agg, granularity, timestamps, values, is_aggregated,
         if new_values is None:
             new_values = numpy.array([ts["values"]])
         else:
-            new_values = numpy.append(new_values, [ts["values"]], axis=0)
+            new_values = numpy.concatenate((new_values, [ts["values"]]))
     return sampling, result_timestamps, new_values.T, is_aggregated
 
 


### PR DESCRIPTION
it just does some validation we don't need then calls concatenate[1].
just call concatenate so we use it consistently everywhere.

[1] https://github.com/numpy/numpy/blob/99019107cbde06294a356fd7fc859f9b31f87410/numpy/lib/function_base.py#L4326