### PR TITLE
further work to make resource create docs match reality

### DIFF
--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -387,15 +387,18 @@ To create a generic |resource|:
 
 {{ scenarios['create-resource-generic']['doc'] }}
 
-The *user_id* and *project_id* attributes must be UUIDs. The timestamp
-describing the lifespan of the |resource| are optional, and *started_at* is by
-default set to the current timestamp.
+The *user_id* and *project_id* attributes may be any arbitrary string. The
+:ref:`timestamps<timestamp-format>` describing the lifespan of the
+|resource| are optional, and *started_at* is by default set to the current
+timestamp.
 
 The *id* attribute may be a UUID or some other arbitrary string.  If it is
-not a UUID, the original value will be stored in the *original_resource_id*
-attribute and Gnocchi will generate a new UUID that is unique for the user.
-That is, if two users create resources with the same non-UUID *id* field,
-the resources will have different UUIDs.
+a UUID, Gnocchi will use it verbatim. If it is not a UUID, the original
+value will be stored in the *original_resource_id* attribute and Gnocchi
+will generate a new UUID that is unique for the user.  That is, if two
+users submit create requests with the same non-UUID *id* attribute, the
+resulting resources will have different UUID values in their respective
+*id* attributes.
 
 You may use either of the *id* or the *original_resource_id* attributes to
 refer to the |resource|.  The value returned by the create operation
@@ -985,6 +988,8 @@ reporting values such as the number of new |measures| to process for each
 |metric|:
 
 {{ scenarios['get-status']['doc'] }}
+
+.. _timestamp-format:
 
 Timestamp format
 ================


### PR DESCRIPTION
- Change documentation of user and project attributes based on comments
  in #698.
- Link to timestamp format description when mentioning timestamps.
- Minor rephrasing in the paragraph regaring the id attribute

Please feel free to request changes before merging! :)