### PR TITLE
indexer: detach metric from resource when marked as 'deleted'

### DIFF
--- a/gnocchi/indexer/sqlalchemy.py
+++ b/gnocchi/indexer/sqlalchemy.py
@@ -1092,7 +1092,7 @@ class SQLAlchemyIndexer(indexer.IndexerDriver):
         with self.facade.writer() as session:
             if session.query(Metric).filter(
                 Metric.id == id, Metric.status == 'active').update(
-                    {"status": "delete"}) == 0:
+                    {"status": "delete", "resource_id": None}) == 0:
                 raise indexer.NoSuchMetric(id)
 
     @staticmethod


### PR DESCRIPTION
This allows to re associate another metric using the same name as used
previously, even if the metric is not expunged yet.

Closes: #702
(cherry picked from commit d3a93519e55fa10bb1de3eac8821e26b2c6581e3)