### PR TITLE
indexer: detach metric from resource when marked as 'deleted'

### DIFF
--- a/gnocchi/indexer/sqlalchemy.py
+++ b/gnocchi/indexer/sqlalchemy.py
@@ -1067,7 +1067,7 @@ class SQLAlchemyIndexer(indexer.IndexerDriver):
         with self.facade.writer() as session:
             if session.query(Metric).filter(
                 Metric.id == id, Metric.status == 'active').update(
-                    {"status": "delete"}) == 0:
+                    {"status": "delete", "resource_id": None}) == 0:
                 raise indexer.NoSuchMetric(id)
 
     @staticmethod

--- a/gnocchi/tests/test_indexer.py
+++ b/gnocchi/tests/test_indexer.py
@@ -426,6 +426,33 @@ class TestIndexerDriver(tests_base.TestCase):
         self.assertIn('foo', metric_names)
         self.assertIn('bar', metric_names)
 
+    def test_update_resource_metrics_append_after_delete(self):
+        r1 = uuid.uuid4()
+        m1 = uuid.uuid4()
+        m2 = uuid.uuid4()
+        m3 = uuid.uuid4()
+        user = str(uuid.uuid4())
+        project = str(uuid.uuid4())
+        self.index.create_metric(m1, user, project,
+                                 archive_policy_name="low")
+        self.index.create_metric(m2, user, project,
+                                 archive_policy_name="low")
+        self.index.create_metric(m3, user, project,
+                                 archive_policy_name="low")
+        self.index.create_resource('generic', r1, user, project,
+                                   metrics={'foo': m1})
+        rc = self.index.update_resource('generic', r1, metrics={'bar': m2},
+                                        append_metrics=True)
+        self.index.delete_metric(m1)
+        rc = self.index.update_resource('generic', r1, metrics={'foo': m3},
+                                        append_metrics=True)
+        r = self.index.get_resource('generic', r1, with_metrics=True)
+        self.assertEqual(rc, r)
+        metric_names = [m.name for m in rc.metrics]
+        self.assertEqual(2, len(metric_names))
+        self.assertIn('foo', metric_names)
+        self.assertIn('bar', metric_names)
+
     def test_update_resource_metrics_append_fail(self):
         r1 = uuid.uuid4()
         e1 = uuid.uuid4()


### PR DESCRIPTION
This allows to re associate another metric using the same name as used
previously, even if the metric is not expunged yet.

Closes: #702
(cherry picked from commit d3a93519e55fa10bb1de3eac8821e26b2c6581e3)