### PR TITLE
redis: concatenate bytes before unserializing

### DIFF
--- a/gnocchi/incoming/redis.py
+++ b/gnocchi/incoming/redis.py
@@ -110,10 +110,8 @@ class RedisStorage(incoming.IncomingDriver):
         # lrange is inclusive on both ends, decrease to grab exactly n items
         item_len = item_len - 1 if item_len else item_len
 
-        yield self._array_concatenate([
-            self._unserialize_measures('%s-%s' % (metric_id, i), data)
-            for i, data in enumerate(self._client.lrange(key, 0, item_len))
-        ])
+        yield self._unserialize_measures(metric_id, b"".join(
+            self._client.lrange(key, 0, item_len)))
 
         # ltrim is inclusive, bump 1 to remove up to and including nth item
         self._client.ltrim(key, item_len + 1, -1)

--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -514,7 +514,7 @@ class StorageDriver(object):
             LOG.debug("Skipping %s (already processed)", metric)
             return
 
-        measures.sort(order='timestamps')
+        measures = numpy.sort(measures, order='timestamps')
 
         agg_methods = list(metric.archive_policy.aggregation_methods)
         block_size = metric.archive_policy.max_block_size


### PR DESCRIPTION
This is actually faster than concatenating numpy arrays.