### PR TITLE
redis: hmget requires at least one args

### DIFF
--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -230,6 +230,8 @@ class StorageDriver(object):
                                       for ts in agg_timeseries]))
 
     def _get_measures_and_unserialize(self, metric, keys, aggregation):
+        if not keys:
+            return []
         raw_measures = self._get_measures(metric, keys, aggregation)
         results = []
         for key, raw in six.moves.zip(keys, raw_measures):

--- a/gnocchi/storage/redis.py
+++ b/gnocchi/storage/redis.py
@@ -93,6 +93,8 @@ class RedisStorage(storage.StorageDriver):
         self._client.delete(self._metric_key(metric))
 
     def _get_measures(self, metric, keys, aggregation, version=3):
+        if not keys:
+            return []
         redis_key = self._metric_key(metric)
         fields = [
             self._aggregated_field_for_split(aggregation, key, version)


### PR DESCRIPTION
If no keys have to be retrieved, we can skip the backend code and just
return an empty list.

This is specially needed by redis that need at least one key for
using hmget.