### PR TITLE
api: add some uwsgi flags

### DIFF
--- a/gnocchi/cli/api.py
+++ b/gnocchi/cli/api.py
@@ -87,6 +87,8 @@ def api():
                                     conf.port or conf.api.port),
         "--master",
         "--enable-threads",
+        "--thunder-lock", "true",
+        "--hook-master-start", "unix_signal:15 gracefully_kill_them_all",
         "--die-on-term",
         # NOTE(jd) See https://github.com/gnocchixyz/gnocchi/issues/156
         "--add-header", "Connection: close",


### PR DESCRIPTION
--thunder-lock is recommended when we mix threads and processes.
http://uwsgi-docs.readthedocs.io/en/latest/articles/SerializingAccept.html

"--hook-master-start", "unix_signal:15 gracefully_kill_them_all make
child receving sigterm instead of sigkill on exit. This should avoid having
some connections still in TIME-WAIT after the process stop.