### PR TITLE
storage: stop requiring a coordinator

### DIFF
--- a/gnocchi/cli/manage.py
+++ b/gnocchi/cli/manage.py
@@ -61,10 +61,7 @@ def upgrade():
         LOG.info("Upgrading indexer %s", index)
         index.upgrade()
     if not conf.skip_storage:
-        # FIXME(jd) Pass None as coordinator because it's not needed in this
-        # case. This will be removed when the storage will stop requiring a
-        # coordinator object.
-        s = storage.get_driver(conf, None)
+        s = storage.get_driver(conf)
         LOG.info("Upgrading storage %s", s)
         s.upgrade()
     if not conf.skip_incoming:

--- a/gnocchi/cli/metricd.py
+++ b/gnocchi/cli/metricd.py
@@ -68,7 +68,7 @@ class MetricProcessBase(cotyledon.Service):
                                   str(uuid.uuid4()))
         self.coord = get_coordinator_and_start(member_id,
                                                self.conf.coordination_url)
-        self.store = storage.get_driver(self.conf, self.coord)
+        self.store = storage.get_driver(self.conf)
         self.incoming = incoming.get_driver(self.conf)
         self.index = indexer.get_driver(self.conf)
 
@@ -266,7 +266,7 @@ class MetricJanitor(MetricProcessBase):
             worker_id, conf, conf.metricd.metric_cleanup_delay)
 
     def _run_job(self):
-        self.store.expunge_metrics(self.incoming, self.index)
+        self.store.expunge_metrics(self.coord, self.incoming, self.index)
         LOG.debug("Metrics marked for deletion removed from backend")
 
 

--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -549,6 +549,7 @@ class MetricController(rest.RestController):
                 pecan.request.incoming.has_unprocessed(self.metric.id)):
             try:
                 pecan.request.storage.refresh_metric(
+                    pecan.request.coordinator,
                     pecan.request.indexer, pecan.request.incoming, self.metric,
                     pecan.request.conf.api.operation_timeout)
             except storage.SackLockTimeoutError as e:
@@ -1928,6 +1929,7 @@ class AggregationController(rest.RestController):
                 for m in metrics_to_update:
                     try:
                         pecan.request.storage.refresh_metric(
+                            pecan.request.coordinator,
                             pecan.request.indexer, pecan.request.incoming, m,
                             pecan.request.conf.api.operation_timeout)
                     except storage.SackLockTimeoutError as e:

--- a/gnocchi/rest/app.py
+++ b/gnocchi/rest/app.py
@@ -97,9 +97,8 @@ class GnocchiHook(pecan.hooks.PecanHook):
                                 self.conf.coordination_url)
                         )
                     elif name == "storage":
-                        coord = self._lazy_load("coordinator")
                         self.backends[name] = (
-                            gnocchi_storage.get_driver(self.conf, coord)
+                            gnocchi_storage.get_driver(self.conf)
                         )
                     elif name == "incoming":
                         self.backends[name] = (

--- a/gnocchi/storage/ceph.py
+++ b/gnocchi/storage/ceph.py
@@ -43,8 +43,8 @@ rados = ceph.rados
 class CephStorage(storage.StorageDriver):
     WRITE_FULL = False
 
-    def __init__(self, conf, coord=None):
-        super(CephStorage, self).__init__(conf, coord)
+    def __init__(self, conf):
+        super(CephStorage, self).__init__(conf)
         self.rados, self.ioctx = ceph.create_rados_connection(conf)
 
     def __str__(self):

--- a/gnocchi/storage/file.py
+++ b/gnocchi/storage/file.py
@@ -35,8 +35,8 @@ OPTS = [
 class FileStorage(storage.StorageDriver):
     WRITE_FULL = True
 
-    def __init__(self, conf, coord=None):
-        super(FileStorage, self).__init__(conf, coord)
+    def __init__(self, conf):
+        super(FileStorage, self).__init__(conf)
         self.basepath = conf.file_basepath
         self.basepath_tmp = os.path.join(self.basepath, 'tmp')
 

--- a/gnocchi/storage/redis.py
+++ b/gnocchi/storage/redis.py
@@ -27,8 +27,8 @@ class RedisStorage(storage.StorageDriver):
     STORAGE_PREFIX = b"timeseries"
     FIELD_SEP = '_'
 
-    def __init__(self, conf, coord=None):
-        super(RedisStorage, self).__init__(conf, coord)
+    def __init__(self, conf):
+        super(RedisStorage, self).__init__(conf)
         self._client = redis.get_client(conf)
 
     def __str__(self):

--- a/gnocchi/storage/s3.py
+++ b/gnocchi/storage/s3.py
@@ -68,8 +68,8 @@ class S3Storage(storage.StorageDriver):
 
     _consistency_wait = tenacity.wait_exponential(multiplier=0.1)
 
-    def __init__(self, conf, coord=None):
-        super(S3Storage, self).__init__(conf, coord)
+    def __init__(self, conf):
+        super(S3Storage, self).__init__(conf)
         self.s3, self._region_name, self._bucket_prefix = (
             s3.get_connection(conf)
         )

--- a/gnocchi/storage/swift.py
+++ b/gnocchi/storage/swift.py
@@ -83,8 +83,8 @@ class SwiftStorage(storage.StorageDriver):
 
     WRITE_FULL = True
 
-    def __init__(self, conf, coord=None):
-        super(SwiftStorage, self).__init__(conf, coord)
+    def __init__(self, conf):
+        super(SwiftStorage, self).__init__(conf)
         self.swift = swift.get_connection(conf)
         self._container_prefix = conf.swift_container_prefix
 

--- a/gnocchi/tests/base.py
+++ b/gnocchi/tests/base.py
@@ -352,7 +352,7 @@ class TestCase(BaseTestCase):
         self.conf.set_override("s3_bucket_prefix", str(uuid.uuid4())[:26],
                                "storage")
 
-        self.storage = storage.get_driver(self.conf, self.coord)
+        self.storage = storage.get_driver(self.conf)
         self.incoming = incoming.get_driver(self.conf)
 
         if self.conf.storage.driver == 'redis':

--- a/gnocchi/tests/functional/fixtures.py
+++ b/gnocchi/tests/functional/fixtures.py
@@ -146,7 +146,7 @@ class ConfigFixture(fixture.GabbiFixture):
 
         self.coord = metricd.get_coordinator_and_start(str(uuid.uuid4()),
                                                        conf.coordination_url)
-        s = storage.get_driver(conf, self.coord)
+        s = storage.get_driver(conf)
         s.upgrade()
         i = incoming.get_driver(conf)
         i.upgrade(128)
@@ -170,7 +170,7 @@ class ConfigFixture(fixture.GabbiFixture):
         }
 
         # start up a thread to async process measures
-        self.metricd_thread = MetricdThread(index, s, i)
+        self.metricd_thread = MetricdThread(self.coord, index, s, i)
         self.metricd_thread.start()
 
     def stop_fixture(self):
@@ -208,8 +208,9 @@ class ConfigFixture(fixture.GabbiFixture):
 class MetricdThread(threading.Thread):
     """Run metricd in a naive thread to process measures."""
 
-    def __init__(self, index, storer, incoming, name='metricd'):
+    def __init__(self, coord, index, storer, incoming, name='metricd'):
         super(MetricdThread, self).__init__(name=name)
+        self.coord = coord
         self.index = index
         self.storage = storer
         self.incoming = incoming
@@ -221,7 +222,8 @@ class MetricdThread(threading.Thread):
             metrics = self.index.list_metrics(
                 attribute_filter={"in": {"id": metrics}})
             for metric in metrics:
-                self.storage.refresh_metric(self.index,
+                self.storage.refresh_metric(self.coord,
+                                            self.index,
                                             self.incoming,
                                             metric,
                                             timeout=None)

--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -46,7 +46,7 @@ class TestStorageDriver(tests_base.TestCase):
         self.metric, __ = self._create_metric()
 
     def test_driver_str(self):
-        driver = storage.get_driver(self.conf, None)
+        driver = storage.get_driver(self.conf)
 
         if isinstance(driver, file.FileStorage):
             s = driver.basepath
@@ -63,7 +63,7 @@ class TestStorageDriver(tests_base.TestCase):
                          driver.__class__.__name__, s))
 
     def test_get_driver(self):
-        driver = storage.get_driver(self.conf, None)
+        driver = storage.get_driver(self.conf)
         self.assertIsInstance(driver, storage.StorageDriver)
 
     def test_corrupted_data(self):
@@ -158,7 +158,8 @@ class TestStorageDriver(tests_base.TestCase):
         self.trigger_processing()
         __, __, details = self.incoming._build_report(True)
         self.assertIn(str(self.metric.id), details)
-        self.storage.expunge_metrics(self.incoming, self.index, sync=True)
+        self.storage.expunge_metrics(self.coord,
+                                     self.incoming, self.index, sync=True)
         __, __, details = self.incoming._build_report(True)
         self.assertNotIn(str(self.metric.id), details)
 
@@ -168,7 +169,8 @@ class TestStorageDriver(tests_base.TestCase):
         ])
         self.trigger_processing()
         self.index.delete_metric(self.metric.id)
-        self.storage.expunge_metrics(self.incoming, self.index, sync=True)
+        self.storage.expunge_metrics(self.coord,
+                                     self.incoming, self.index, sync=True)
         self.assertRaises(indexer.NoSuchMetric, self.index.delete_metric,
                           self.metric.id)
 


### PR DESCRIPTION
The storage engine does not need a coordinator, except for locking sacks.
However sacks do not belong to the storage driver itself, so it makes no sense
to requires one.