### PR TITLE
travis: remove docs-gnocchi.xyz from stable/4.2 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ cache:
 env:
   - TARGET: pep8
   - TARGET: docs
-  - TARGET: docs-gnocchi.xyz
 
   - TARGET: py27-mysql-ceph-upgrade-from-3.1
   - TARGET: py35-postgresql-file-upgrade-from-3.1


### PR DESCRIPTION
We don't need to test this on stable branches.