### PR TITLE
tox: don't install gnocchi twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: python
+language: generic
 sudo: required
 
 services:

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ minversion = 2.4
 envlist = py{35,27}-{postgresql,mysql}{,-file,-swift,-ceph,-s3},pep8
 
 [testenv]
-usedevelop = True
+skip_install = True
 sitepackages = False
 passenv = LANG GNOCCHI_TEST_* AWS_*
 setenv =
@@ -40,7 +40,9 @@ setenv =
 # NOTE(jd) Install redis as a test dependency since it is used as a
 # coordination driver in functional tests (--coordination-driver is passed to
 # pifpaf)
-deps = .[test,redis,prometheus,{env:GNOCCHI_STORAGE_DEPS:},{env:GNOCCHI_INDEXER_DEPS:}]
+deps =
+   -e
+   .[test,redis,prometheus,{env:GNOCCHI_STORAGE_DEPS:},{env:GNOCCHI_INDEXER_DEPS:}]
    {env:GNOCCHI_TEST_TARBALLS:}
    cliff!=2.9.0
 commands =
@@ -51,8 +53,6 @@ commands =
 # We should always recreate since the script upgrade
 # Gnocchi we can't reuse the virtualenv
 recreate = True
-skip_install = True
-usedevelop = False
 setenv = GNOCCHI_VARIANT=test,postgresql,file
 deps = gnocchi[{env:GNOCCHI_VARIANT}]>=3.1,<3.2
   pifpaf[gnocchi]>=0.13
@@ -63,8 +63,6 @@ commands = pifpaf --env-prefix INDEXER run postgresql {toxinidir}/run-upgrade-te
 # We should always recreate since the script upgrade
 # Gnocchi we can't reuse the virtualenv
 recreate = True
-skip_install = True
-usedevelop = False
 setenv = GNOCCHI_VARIANT=test,mysql,ceph,ceph_recommended_lib
 deps = gnocchi[{env:GNOCCHI_VARIANT}]>=3.1,<3.2
   gnocchiclient>=2.8.0
@@ -75,8 +73,6 @@ commands = pifpaf --env-prefix INDEXER run mysql -- pifpaf --env-prefix STORAGE 
 # We should always recreate since the script upgrade
 # Gnocchi we can't reuse the virtualenv
 recreate = True
-skip_install = True
-usedevelop = False
 setenv = GNOCCHI_VARIANT=test,postgresql,file
 deps = gnocchi[{env:GNOCCHI_VARIANT}]>=4.0,<4.1
   pifpaf[gnocchi]>=0.13
@@ -87,8 +83,6 @@ commands = pifpaf --env-prefix INDEXER run postgresql {toxinidir}/run-upgrade-te
 # We should always recreate since the script upgrade
 # Gnocchi we can't reuse the virtualenv
 recreate = True
-skip_install = True
-usedevelop = False
 setenv = GNOCCHI_VARIANT=test,mysql,ceph,ceph_recommended_lib
 deps = gnocchi[{env:GNOCCHI_VARIANT}]>=4.0,<4.1
   gnocchiclient>=2.8.0
@@ -99,8 +93,6 @@ commands = pifpaf --env-prefix INDEXER run mysql -- pifpaf --env-prefix STORAGE 
 # We should always recreate since the script upgrade
 # Gnocchi we can't reuse the virtualenv
 recreate = True
-skip_install = True
-usedevelop = False
 setenv = GNOCCHI_VARIANT=test,postgresql,file
 deps = gnocchi[{env:GNOCCHI_VARIANT}]>=4.1,<4.2
   pifpaf[gnocchi]>=0.13
@@ -111,8 +103,6 @@ commands = pifpaf --env-prefix INDEXER run postgresql {toxinidir}/run-upgrade-te
 # We should always recreate since the script upgrade
 # Gnocchi we can't reuse the virtualenv
 recreate = True
-skip_install = True
-usedevelop = False
 setenv = GNOCCHI_VARIANT=test,mysql,ceph,ceph_recommended_lib
 deps = gnocchi[{env:GNOCCHI_VARIANT}]>=4.1,<4.2
   gnocchiclient>=2.8.0


### PR DESCRIPTION
We current install Gnocchi twice, once with no extra and develop mode,
and a second time with extra but without develop mode.

This change install gnocchi only once with extra and develop mode.