### PR TITLE
api: simplify archive policy validation

### DIFF
--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -487,12 +487,6 @@ class MetricController(rest.RestController):
                      granularity=None, resample=None, refresh=False,
                      **param):
         self.enforce_metric("get measures")
-        if (aggregation not in
-           archive_policy.ArchivePolicy.VALID_AGGREGATION_METHODS):
-            msg = "Invalid aggregation value %(agg)s, must be one of %(std)s"
-            abort(400, msg % dict(
-                agg=aggregation,
-                std=archive_policy.ArchivePolicy.VALID_AGGREGATION_METHODS))
 
         if resample:
             if not granularity:
@@ -1833,14 +1827,6 @@ class AggregationController(rest.RestController):
                                             refresh=False, resample=None):
         start, stop, granularity, needed_overlap, fill = validate_qs(
             start, stop, granularity, needed_overlap, fill)
-
-        if (aggregation
-           not in archive_policy.ArchivePolicy.VALID_AGGREGATION_METHODS):
-            abort(
-                400,
-                'Invalid aggregation value %s, must be one of %s'
-                % (aggregation,
-                   archive_policy.ArchivePolicy.VALID_AGGREGATION_METHODS))
 
         if reaggregation is None:
             reaggregation = aggregation

--- a/gnocchi/tests/functional/gabbits/aggregation.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregation.yaml
@@ -113,6 +113,14 @@ tests:
           - ['2015-03-06T14:30:00+00:00', 300.0, 15.05]
           - ['2015-03-06T14:33:57+00:00', 1.0, 23.1]
 
+    - name: get measure aggregates with invalid aggregation method
+      GET: /v1/aggregation/metric?metric=$HISTORY['get metric list'].$RESPONSE['$[0].id']&metric=$HISTORY['get metric list'].$RESPONSE['$[1].id']&aggregation=wtf
+      request_headers:
+        accept: application/json
+      status: 404
+      response_json_paths:
+        $.description: Aggregation method 'wtf' at granularity '1.0' for metric $HISTORY['get metric list'].$RESPONSE['$[0].id'] does not exist
+
     - name: get measure aggregates and reaggregate
       GET: /v1/aggregation/metric?metric=$HISTORY['get metric list'].$RESPONSE['$[0].id']&metric=$HISTORY['get metric list'].$RESPONSE['$[1].id']&reaggregation=min
       poll:

--- a/gnocchi/tests/functional/gabbits/metric.yaml
+++ b/gnocchi/tests/functional/gabbits/metric.yaml
@@ -178,9 +178,13 @@ tests:
 
     - name: get measurements invalid agg method
       GET: /v1/metric/$HISTORY['list valid metrics'].$RESPONSE['$[0].id']/measures?aggregation=wtf
-      status: 400
-      response_strings:
-        - Invalid aggregation value
+      request_headers:
+        accept: application/json
+      status: 404
+      response_json_paths:
+        $.description.cause: Aggregation method does not exist for this metric
+        $.description.detail.metric: $HISTORY['list valid metrics'].$RESPONSE['$[0].id']
+        $.description.detail.aggregation_method: wtf
 
     - name: get measurements by start
       GET: /v1/metric/$HISTORY['list valid metrics'].$RESPONSE['$[0].id']/measures?refresh=true&start=2015-03-06T14:34


### PR DESCRIPTION
The current validation code validates measure aggregates retrieval against the
whole list of valid aggregation methods. That serves little purpose as it is
again validated just after against the actual list of existing aggregation
method defined in the archive policy attached to this/these metric(s).

This patch removes that validation and adds a missing test for the aggregation
endpoint.