### PR TITLE
redis: use regular keys and not hash to store metrics and splits

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -25,7 +25,7 @@ The list of variants available is:
 * `s3` – provides Amazon S3 storage support
 * `ceph` – provides Ceph (>= 0.80) storage support
 * `ceph_alternative` – provides Ceph (>= 12.2.0) storage support
-* `redis` – provides Redis storage support
+* `redis` – provides Redis storage support (requires Redis >= 3.2)
 * `prometheus` – provides Prometheus Remote Write support
 * `doc` – documentation building support
 * `test` – unit and functional tests support

--- a/gnocchi/common/redis.py
+++ b/gnocchi/common/redis.py
@@ -30,7 +30,8 @@ except ImportError:
 from gnocchi import utils
 
 
-SEP = b':'
+SEP = ':'
+SEP_B = b':'
 
 CLIENT_ARGS = frozenset([
     'db',

--- a/gnocchi/incoming/redis.py
+++ b/gnocchi/incoming/redis.py
@@ -52,7 +52,7 @@ return {llen, table.concat(redis.call("LRANGE", KEYS[1], 0, llen), "")}
         pass
 
     def _build_measure_path_with_sack(self, metric_id, sack_name):
-        return redis.SEP.join([sack_name.encode(), str(metric_id).encode()])
+        return redis.SEP.join([sack_name, str(metric_id)])
 
     def _build_measure_path(self, metric_id):
         return self._build_measure_path_with_sack(
@@ -80,7 +80,7 @@ return {llen, table.concat(redis.call("LRANGE", KEYS[1], 0, llen), "")}
                 report_vars['metric_details'].update(
                     dict(six.moves.zip(m_list, results)))
 
-        match = redis.SEP.join([self.get_sack_name("*").encode(), b"*"])
+        match = redis.SEP.join([self.get_sack_name("*"), "*"])
         metrics = 0
         m_list = []
         pipe = self._client.pipeline()
@@ -88,7 +88,7 @@ return {llen, table.concat(redis.call("LRANGE", KEYS[1], 0, llen), "")}
             metrics += 1
             pipe.llen(key)
             if details:
-                m_list.append(key.split(redis.SEP)[1].decode("utf8"))
+                m_list.append(key.split(redis.SEP_B)[1].decode("utf8"))
             # group 100 commands/call
             if metrics % 100 == 0:
                 results = pipe.execute()
@@ -102,9 +102,9 @@ return {llen, table.concat(redis.call("LRANGE", KEYS[1], 0, llen), "")}
                 report_vars['metric_details'] if details else None)
 
     def list_metric_with_measures_to_process(self, sack):
-        match = redis.SEP.join([self.get_sack_name(sack).encode(), b"*"])
+        match = redis.SEP.join([self.get_sack_name(sack), "*"])
         keys = self._client.scan_iter(match=match, count=1000)
-        return set([k.split(redis.SEP)[1].decode("utf8") for k in keys])
+        return set([k.split(redis.SEP_B)[1].decode("utf8") for k in keys])
 
     def delete_unprocessed_measures_for_metric(self, metric_id):
         self._client.delete(self._build_measure_path(metric_id))

--- a/gnocchi/tests/base.py
+++ b/gnocchi/tests/base.py
@@ -357,7 +357,7 @@ class TestCase(BaseTestCase):
 
         if self.conf.storage.driver == 'redis':
             # Create one prefix per test
-            self.storage.STORAGE_PREFIX = str(uuid.uuid4()).encode()
+            self.storage.STORAGE_PREFIX = str(uuid.uuid4())
 
         if self.conf.incoming.driver == 'redis':
             self.incoming.SACK_PREFIX = str(uuid.uuid4())

--- a/releasenotes/notes/redis-aggregate-storage-change-da53fe35fd9745f1.yaml
+++ b/releasenotes/notes/redis-aggregate-storage-change-da53fe35fd9745f1.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    The Redis storage driver for aggregates have been rewritten and uses a
+    different storage layout. This version is not compatible with Gnocchi 4 and
+    before.


### PR DESCRIPTION
This changes the storage format so it's possible to use SETRANGE in a future
patch.