### PR TITLE
improve documentation on tuning the number of sacks

### DIFF
--- a/doc/source/operating.rst
+++ b/doc/source/operating.rst
@@ -227,62 +227,63 @@ metricd daemon on any number of servers.
 How to scale measure processing
 -------------------------------
 
-Measurement data pushed to Gnocchi is divided into sacks for better
-distribution. The number of partitions is controlled by the `sacks` option
-under the `[incoming]` section. This value should be set based on the
-number of active |metrics| the system will capture. Additionally, the number of
-`sacks`, should be higher than the total number of active metricd workers.
-distribution. Incoming |metrics| are pushed to specific sacks and each sack
-is assigned to one or more `gnocchi-metricd` daemons for processing.
+Measurement data pushed to Gnocchi is divided into "sacks" for better
+distribution.  Incoming |metrics| are pushed to specific sacks and
+each sack is assigned to one or more `gnocchi-metricd` daemons for
+processing.
 
-How many sacks do we need to create
------------------------------------
-
-This number of sacks enabled should be set based on the number of active
-|metrics| the system will capture. Additionally, the number of sacks, should
-be higher than the total number of active `gnocchi-metricd` workers.
+The number of sacks should be set based on the number of active
+|metrics| the system will capture. Additionally, the number of sacks
+should be higher than the total number of active `gnocchi-metricd`
+workers.
 
 In general, use the following equation to determine the appropriate `sacks`
 value to set::
 
    sacks value = number of **active** metrics / 300
 
-If the estimated number of |metrics| is the absolute maximum, divide the value
-by 500 instead. If the estimated number of active |metrics| is conservative and
-expected to grow, divide the value by 100 instead to accommodate growth.
+If the estimated number of |metrics| is the absolute maximum, divide
+the value by 500 instead. If the estimated number of active |metrics|
+is conservative and expected to grow, divide the value by 100 instead
+to accommodate growth.
 
 How do we change sack size
 --------------------------
 
-In the event your system grows to capture signficantly more |metrics| than
-originally anticipated, the number of sacks can be changed to maintain good
-distribution. To avoid any loss of data when modifying `sacks` option. The
-option should be changed in the following order::
+In the event your system grows to capture significantly more |metrics|
+than originally anticipated, the number of sacks can be changed to
+maintain good distribution. To avoid any loss of data when modifying
+the number of `sacks`, the value should be changed in the following
+order:
 
-  1. Stop all input services (api, statsd)
+1. Stop all input services (api, statsd).
 
-  2. Stop all metricd services once backlog is cleared
+2. Stop all metricd services once backlog is cleared.
 
-  3. Run gnocchi-change-sack-size <number of sacks> to set new sack size. Note
-     that sack value can only be changed if the backlog is empty.
+3. Run ``gnocchi-change-sack-size <number of sacks>`` to set new sack
+   size. Note that the sack value can only be changed if the backlog
+   is empty.
 
-  4. Restart all gnocchi services (api, statsd, metricd) with new configuration
+4. Restart all gnocchi services (api, statsd, metricd) with the new
+   configuration.
 
-Alternatively, to minimise API downtime::
+Alternatively, to minimize API downtime:
 
-  1. Run gnocchi-upgrade but use a new incoming storage target such as a new
-     ceph pool, file path, etc... Additionally, set |aggregate| storage to a
-     new target as well.
+1. Run gnocchi-upgrade but use a new incoming storage target such as a new
+   ceph pool, file path, etc. Additionally, set |aggregate| storage to a
+   new target as well.
 
-  2. Run gnocchi-change-sack-size <number of sacks> against new target
+2. Run ``gnocchi-change-sack-size <number of sacks>`` against the new
+   target.
 
-  3. Stop all input services (api, statsd)
+3. Stop all input services (api, statsd).
 
-  4. Restart all input services but target newly created incoming storage
+4. Restart all input services but target the newly created incoming
+   storage.
 
-  5. When done clearing backlog from original incoming storage, switch all
-     metricd datemons to target new incoming storage but maintain original
-     |aggregate| storage.
+5. When done clearing backlog from original incoming storage, switch
+   all metricd daemons to target the new incoming storage but maintain
+   original |aggregate| storage.
 
 How to monitor Gnocchi
 ======================


### PR DESCRIPTION
The documentation suggested that the number of sacks could be tuned
via a configuration option the in gnocchi.conf file.  This commit
corrects the docs to indicate that the value can be changed only with
the gnocchi-change-sack-size command.

This commit also corrects spelling, grammar, and formatting issues in
the same section.