### PR TITLE
chef: import process_new_measures and refresh_metric

### DIFF
--- a/gnocchi/cli/metricd.py
+++ b/gnocchi/cli/metricd.py
@@ -241,8 +241,7 @@ class MetricProcessor(MetricProcessBase):
             try:
                 metrics = self.incoming.list_metric_with_measures_to_process(s)
                 m_count += len(metrics)
-                self.store.process_new_measures(
-                    self.index, self.incoming, metrics)
+                self.chef.process_new_measures(metrics)
                 s_count += 1
                 self.incoming.finish_sack_processing(s)
                 self.sacks_with_measures_to_process.discard(s)
@@ -310,8 +309,8 @@ def metricd_tester(conf):
         metrics.update(inc.list_metric_with_measures_to_process(i))
         if len(metrics) >= conf.stop_after_processing_metrics:
             break
-    s.process_new_measures(
-        index, inc,
+    c = chef.Chef(None, inc, index, s)
+    c.process_new_measures(
         list(metrics)[:conf.stop_after_processing_metrics], True)
 
 

--- a/gnocchi/rest/app.py
+++ b/gnocchi/rest/app.py
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 #
+# Copyright © 2018 Red Hat
 # Copyright © 2014-2016 eNovance
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -28,6 +29,7 @@ from pecan import templating
 from stevedore import driver
 import webob.exc
 
+from gnocchi import chef
 from gnocchi.cli import metricd
 from gnocchi import exceptions
 from gnocchi import incoming as gnocchi_incoming
@@ -58,6 +60,12 @@ class GnocchiHook(pecan.hooks.PecanHook):
         state.request.storage = self._lazy_load('storage')
         state.request.indexer = self._lazy_load('indexer')
         state.request.incoming = self._lazy_load('incoming')
+        state.request.chef = chef.Chef(
+            state.request.coordinator,
+            state.request.incoming,
+            state.request.indexer,
+            state.request.storage,
+        )
         state.request.conf = self.conf
         state.request.policy_enforcer = self.policy_enforcer
         state.request.auth_helper = self.auth_helper

--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 #
-# Copyright © 2016-2017 Red Hat, Inc.
+# Copyright © 2016-2018 Red Hat, Inc.
 # Copyright © 2014-2015 eNovance
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -95,10 +95,6 @@ class CorruptionError(ValueError, StorageError):
 
     def __init__(self, message):
         super(CorruptionError, self).__init__(message)
-
-
-class SackLockTimeoutError(StorageError):
-    pass
 
 
 @utils.retry_on_exception_and_log("Unable to initialize storage driver")
@@ -409,47 +405,7 @@ class StorageDriver(object):
                                 aggregation, granularity, version=3):
         raise NotImplementedError
 
-    def refresh_metric(self, coord, indexer, incoming, metric, timeout):
-        s = incoming.sack_for_metric(metric.id)
-        lock = incoming.get_sack_lock(coord, s)
-        if not lock.acquire(blocking=timeout):
-            raise SackLockTimeoutError(
-                'Unable to refresh metric: %s. Metric is locked. '
-                'Please try again.' % metric.id)
-        try:
-            self.process_new_measures(indexer, incoming,
-                                      [six.text_type(metric.id)])
-        finally:
-            lock.release()
-
-    def process_new_measures(self, indexer, incoming, metrics_to_process,
-                             sync=False):
-        """Process added measures in background.
-
-        Some drivers might need to have a background task running that process
-        the measures sent to metrics. This is used for that.
-        """
-        # process only active metrics. deleted metrics with unprocessed
-        # measures will be skipped until cleaned by janitor.
-        metrics = indexer.list_metrics(
-            attribute_filter={"in": {"id": metrics_to_process}})
-        metrics_by_id = {m.id: m for m in metrics}
-        # NOTE(gordc): must lock at sack level
-        try:
-            LOG.debug("Processing measures for %s", metrics)
-            with incoming.process_measure_for_metrics([m.id for m in metrics]) \
-                    as metrics_and_measures:
-                for metric, measures in six.iteritems(metrics_and_measures):
-                    self._compute_and_store_timeseries(
-                        metrics_by_id[metric], measures
-                    )
-                    LOG.debug("Measures for metric %s processed", metrics)
-        except Exception:
-            if sync:
-                raise
-            LOG.error("Error processing new measures", exc_info=True)
-
-    def _compute_and_store_timeseries(self, metric, measures):
+    def compute_and_store_timeseries(self, metric, measures):
         # NOTE(mnaser): The metric could have been handled by
         #               another worker, ignore if no measures.
         if len(measures) == 0:

--- a/gnocchi/tests/base.py
+++ b/gnocchi/tests/base.py
@@ -33,6 +33,7 @@ except ImportError:
 from testtools import testcase
 
 from gnocchi import archive_policy
+from gnocchi import chef
 from gnocchi.cli import metricd
 from gnocchi import exceptions
 from gnocchi import incoming
@@ -364,6 +365,8 @@ class TestCase(BaseTestCase):
 
         self.storage.upgrade()
         self.incoming.upgrade(128)
+        self.chef = chef.Chef(
+            self.coord, self.incoming, self.index, self.storage)
 
     def tearDown(self):
         self.index.disconnect()
@@ -385,5 +388,4 @@ class TestCase(BaseTestCase):
     def trigger_processing(self, metrics=None):
         if metrics is None:
             metrics = [str(self.metric.id)]
-        self.storage.process_new_measures(
-            self.index, self.incoming, metrics, sync=True)
+        self.chef.process_new_measures(metrics, sync=True)

--- a/gnocchi/tests/test_rest.py
+++ b/gnocchi/tests/test_rest.py
@@ -61,9 +61,7 @@ class TestingApp(webtest.TestApp):
 
     def __init__(self, *args, **kwargs):
         self.auth_mode = kwargs.pop('auth_mode')
-        self.storage = kwargs.pop('storage')
-        self.indexer = kwargs.pop('indexer')
-        self.incoming = kwargs.pop('incoming')
+        self.chef = kwargs.pop('chef')
         super(TestingApp, self).__init__(*args, **kwargs)
         # Setup Keystone auth_token fake cache
         self.token = self.VALID_TOKEN
@@ -129,9 +127,8 @@ class TestingApp(webtest.TestApp):
         elif self.auth_mode == "remoteuser":
             req.remote_user = self.user
         response = super(TestingApp, self).do_request(req, *args, **kwargs)
-        metrics = tests_utils.list_all_incoming_metrics(self.incoming)
-        self.storage.process_new_measures(
-            self.indexer, self.incoming, metrics, sync=True)
+        metrics = tests_utils.list_all_incoming_metrics(self.chef.incoming)
+        self.chef.process_new_measures(metrics, sync=True)
         return response
 
 
@@ -178,9 +175,7 @@ class RestTest(tests_base.TestCase, testscenarios.TestWithScenarios):
 
         self.app = TestingApp(app.load_app(conf=self.conf,
                                            not_implemented_middleware=False),
-                              storage=self.storage,
-                              indexer=self.index,
-                              incoming=self.incoming,
+                              chef=self.chef,
                               auth_mode=self.auth_mode)
 
     def _fake_lazy_load(self, name):

--- a/gnocchi/tests/test_statsd.py
+++ b/gnocchi/tests/test_statsd.py
@@ -73,9 +73,7 @@ class TestStatsd(tests_base.TestCase):
 
         metric = r.get_metric(metric_key)
 
-        self.storage.process_new_measures(
-            self.stats.indexer, self.stats.incoming,
-            [str(metric.id)], sync=True)
+        self.chef.process_new_measures([str(metric.id)], sync=True)
 
         measures = self.storage.get_measures(metric, self.aggregations)
         self.assertEqual({"mean": [
@@ -94,9 +92,7 @@ class TestStatsd(tests_base.TestCase):
             ("127.0.0.1", 12345))
         self.stats.flush()
 
-        self.storage.process_new_measures(
-            self.stats.indexer, self.stats.incoming,
-            [str(metric.id)], sync=True)
+        self.chef.process_new_measures([str(metric.id)], sync=True)
 
         measures = self.storage.get_measures(metric, self.aggregations)
         self.assertEqual({"mean": [
@@ -128,9 +124,7 @@ class TestStatsd(tests_base.TestCase):
         metric = r.get_metric(metric_key)
         self.assertIsNotNone(metric)
 
-        self.storage.process_new_measures(
-            self.stats.indexer, self.stats.incoming,
-            [str(metric.id)], sync=True)
+        self.chef.process_new_measures([str(metric.id)], sync=True)
 
         measures = self.storage.get_measures(metric, self.aggregations)
         self.assertEqual({"mean": [
@@ -148,9 +142,7 @@ class TestStatsd(tests_base.TestCase):
             ("127.0.0.1", 12345))
         self.stats.flush()
 
-        self.storage.process_new_measures(
-            self.stats.indexer, self.stats.incoming,
-            [str(metric.id)], sync=True)
+        self.chef.process_new_measures([str(metric.id)], sync=True)
 
         measures = self.storage.get_measures(metric, self.aggregations)
         self.assertEqual({"mean": [


### PR DESCRIPTION
This moves those methods out of storage and where they belong: in the Chef!