### PR TITLE
storage: replace _get_unaggregated_timeserie by _get_or_create_unaggregated_timeseries

### DIFF
--- a/gnocchi/storage/ceph.py
+++ b/gnocchi/storage/ceph.py
@@ -183,12 +183,17 @@ class CephStorage(storage.StorageDriver):
         return (('gnocchi_%s_none' % metric.id)
                 + ("_v%s" % version if version else ""))
 
-    def _get_unaggregated_timeserie(self, metric, version=3):
+    def _get_or_create_unaggregated_timeseries_unbatched(
+            self, metric, version=3):
         try:
-            return self._get_object_content(
+            contents = self._get_object_content(
                 self._build_unaggregated_timeserie_path(metric, version))
         except rados.ObjectNotFound:
-            raise storage.MetricDoesNotExist(metric)
+            self._create_metric(metric)
+        else:
+            # _create_metric writes "" so replace it by None to indicate
+            # emptiness instead.
+            return contents or None
 
     def _store_unaggregated_timeserie(self, metric, data, version=3):
         self.ioctx.write_full(

--- a/gnocchi/storage/file.py
+++ b/gnocchi/storage/file.py
@@ -31,6 +31,12 @@ OPTS = [
                help='Path used to store gnocchi data files.'),
 ]
 
+# Python 2 compatibility
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = None
+
 
 class FileStorage(storage.StorageDriver):
     WRITE_FULL = True
@@ -95,15 +101,21 @@ class FileStorage(storage.StorageDriver):
         with open(dest, "wb") as f:
             f.write(data)
 
-    def _get_unaggregated_timeserie(self, metric, version=3):
+    def _get_or_create_unaggregated_timeseries_unbatched(
+            self, metric, version=3):
         path = self._build_unaggregated_timeserie_path(metric, version)
         try:
             with open(path, 'rb') as f:
                 return f.read()
+        except FileNotFoundError:
+            pass
         except IOError as e:
-            if e.errno == errno.ENOENT:
-                raise storage.MetricDoesNotExist(metric)
-            raise
+            if e.errno != errno.ENOENT:
+                raise
+        try:
+            self._create_metric(metric)
+        except storage.MetricAlreadyExists:
+            pass
 
     def _list_split_keys(self, metric, aggregation, granularity, version=3):
         try:

--- a/gnocchi/storage/s3.py
+++ b/gnocchi/storage/s3.py
@@ -104,9 +104,6 @@ class S3Storage(storage.StorageDriver):
     def _prefix(metric):
         return str(metric.id) + '/'
 
-    def _create_metric(self, metric):
-        pass
-
     def _put_object_safe(self, Bucket, Key, Body):
         put = self.s3.put_object(Bucket=Bucket, Key=Key, Body=Body)
 
@@ -216,16 +213,17 @@ class S3Storage(storage.StorageDriver):
         return S3Storage._prefix(metric) + 'none' + ("_v%s" % version
                                                      if version else "")
 
-    def _get_unaggregated_timeserie(self, metric, version=3):
+    def _get_or_create_unaggregated_timeseries_unbatched(
+            self, metric, version=3):
+        key = self._build_unaggregated_timeserie_path(metric, version)
         try:
             response = self.s3.get_object(
-                Bucket=self._bucket_name,
-                Key=self._build_unaggregated_timeserie_path(metric, version))
+                Bucket=self._bucket_name, Key=key)
         except botocore.exceptions.ClientError as e:
-            if e.response['Error'].get('Code') == "NoSuchKey":
-                raise storage.MetricDoesNotExist(metric)
-            raise
-        return response['Body'].read()
+            if e.response['Error'].get('Code') != "NoSuchKey":
+                raise
+        else:
+            return response['Body'].read()
 
     def _store_unaggregated_timeserie(self, metric, data, version=3):
         self._put_object_safe(

--- a/gnocchi/storage/swift.py
+++ b/gnocchi/storage/swift.py
@@ -186,16 +186,21 @@ class SwiftStorage(storage.StorageDriver):
     def _build_unaggregated_timeserie_path(version):
         return 'none' + ("_v%s" % version if version else "")
 
-    def _get_unaggregated_timeserie(self, metric, version=3):
+    def _get_or_create_unaggregated_timeseries_unbatched(
+            self, metric, version=3):
         try:
             headers, contents = self.swift.get_object(
                 self._container_name(metric),
                 self._build_unaggregated_timeserie_path(version))
         except swclient.ClientException as e:
-            if e.http_status == 404:
-                raise storage.MetricDoesNotExist(metric)
-            raise
-        return contents
+            if e.http_status != 404:
+                raise
+            try:
+                self._create_metric(metric)
+            except storage.MetricAlreadyExists:
+                pass
+        else:
+            return contents
 
     def _store_unaggregated_timeserie(self, metric, data, version=3):
         self.swift.put_object(self._container_name(metric),

--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -146,9 +146,9 @@ class TestStorageDriver(tests_base.TestCase):
 
         self.assertEqual({"mean": []}, self.storage.get_measures(
             self.metric, aggregations))
-        self.assertRaises(storage.MetricDoesNotExist,
-                          self.storage._get_unaggregated_timeserie,
-                          self.metric)
+        self.assertEqual(
+            {self.metric: None},
+            self.storage._get_or_create_unaggregated_timeseries([self.metric]))
 
     def test_measures_reporting_format(self):
         report = self.incoming.measures_report(True)

--- a/gnocchi/tests/test_utils.py
+++ b/gnocchi/tests/test_utils.py
@@ -138,3 +138,13 @@ class ParallelMap(tests_base.TestCase):
                              utils.parallel_map(lambda x: x,
                                                 [[1], [2], [3]]))
             sm.assert_not_called()
+
+
+class ReturnNoneOnFailureTest(tests_base.TestCase):
+    def test_works(self):
+
+        @utils.return_none_on_failure
+        def foobar():
+            raise Exception("boom")
+
+        self.assertIsNone(foobar())

--- a/gnocchi/utils.py
+++ b/gnocchi/utils.py
@@ -314,6 +314,25 @@ def parallel_map(fn, list_of_args):
 
 parallel_map.MAX_WORKERS = get_default_workers()
 
+
+def return_none_on_failure(f):
+    try:
+        # Python 3
+        fname = f.__qualname__
+    except AttributeError:
+        fname = f.__name__
+
+    @six.wraps(f)
+    def _return_none_on_failure(*args, **kwargs):
+        try:
+            return f(*args, **kwargs)
+        except Exception as e:
+            LOG.critical("Unexpected error while calling %s: %s",
+                         fname, e, exc_info=True)
+
+    return _return_none_on_failure
+
+
 # Retry with exponential backoff for up to 1 minute
 wait_exponential = tenacity.wait_exponential(multiplier=0.5, max=60)
 


### PR DESCRIPTION
This replaces this method in each storage driver by a new one that can retrieve
several unaggregated timeseries at the same time. The storage engine does not
leverage it and only passes a list of one metric… for now.