### PR TITLE
rest: stop using set to validate archive policies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,13 @@ env:
   - TARGET: py35-postgresql
 
 before_script:
-  # Travis We need to fetch all tags/branches for documentation target
+  # NOTE(sileht): We need to fetch all tags/branches for documentation.
+  # For the multiversioning, we change all remotes refs to point to
+  # the pull request checkout. So the "master" branch will be the PR sha and not
+  # real "master" branch. This ensures the doc build use the PR code for initial
+  # doc setup.
   - if \[ "$TRAVIS_PULL_REQUEST" != "false" -o  -n "$TRAVIS_TAG" \]; then
+      set -x;
       case $TARGET in
         docs*)
           git config --get-all remote.origin.fetch;
@@ -36,6 +41,16 @@ before_script:
           git fetch --unshallow --tags;
           ;;
       esac ;
+      case $TARGET in
+        docs-gnocchi.xyz)
+          git branch -a | sed -n "/\/HEAD /d; /\/master$/d; s,remotes/origin/,,p;" | xargs -i git branch {} origin/{} ;
+          git branch -D master;
+          git checkout -b master;
+          git remote set-url origin file:///home/tester/src;
+          git ls-remote --heads --tags | grep heads;
+          ;;
+      esac ;
+      set +x;
     fi
 install:
   - if \[ "$TRAVIS_PULL_REQUEST" != "false" -o  -n "$TRAVIS_TAG" \]; then

--- a/gnocchi/archive_policy.py
+++ b/gnocchi/archive_policy.py
@@ -88,7 +88,7 @@ class ArchivePolicy(object):
         if aggregation_methods is None:
             self.aggregation_methods = self.DEFAULT_AGGREGATION_METHODS
         else:
-            self.aggregation_methods = aggregation_methods
+            self.aggregation_methods = set(aggregation_methods)
 
     def get_aggregation(self, method, granularity):
         # Find the timespan

--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -222,10 +222,10 @@ def strtobool(varname, v):
         abort(400, "Unable to parse `%s': %s" % (varname, six.text_type(e)))
 
 
-RESOURCE_DEFAULT_PAGINATION = ['revision_start:asc',
-                               'started_at:asc']
+RESOURCE_DEFAULT_PAGINATION = [u'revision_start:asc',
+                               u'started_at:asc']
 
-METRIC_DEFAULT_PAGINATION = ['id:asc']
+METRIC_DEFAULT_PAGINATION = [u'id:asc']
 
 
 def get_pagination_options(params, default):
@@ -324,7 +324,7 @@ class ArchivePoliciesController(rest.RestController):
         enforce("create archive policy", {})
         # NOTE(jd): Initialize this one at run-time because we rely on conf
         conf = pecan.request.conf
-        valid_agg_methods = (
+        valid_agg_methods = list(
             archive_policy.ArchivePolicy.VALID_AGGREGATION_METHODS_VALUES
         )
         ArchivePolicySchema = voluptuous.Schema({
@@ -335,8 +335,8 @@ class ArchivePoliciesController(rest.RestController):
             ),
             voluptuous.Required(
                 "aggregation_methods",
-                default=set(conf.archive_policy.default_aggregation_methods)):
-            voluptuous.All(list(valid_agg_methods), voluptuous.Coerce(set)),
+                default=list(conf.archive_policy.default_aggregation_methods)):
+            valid_agg_methods,
             voluptuous.Required("definition"): ArchivePolicyDefinitionSchema,
         })
 


### PR DESCRIPTION
voluptuous does not know how to use set and now wants to check that the default
value validates against the validators.