### PR TITLE
rest: stop using set to validate archive policies

### DIFF
--- a/gnocchi/archive_policy.py
+++ b/gnocchi/archive_policy.py
@@ -84,7 +84,7 @@ class ArchivePolicy(object):
         if aggregation_methods is None:
             self.aggregation_methods = self.DEFAULT_AGGREGATION_METHODS
         else:
-            self.aggregation_methods = aggregation_methods
+            self.aggregation_methods = set(aggregation_methods)
 
     @property
     def aggregation_methods(self):

--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -199,10 +199,10 @@ def strtobool(varname, v):
         abort(400, "Unable to parse `%s': %s" % (varname, six.text_type(e)))
 
 
-RESOURCE_DEFAULT_PAGINATION = ['revision_start:asc',
-                               'started_at:asc']
+RESOURCE_DEFAULT_PAGINATION = [u'revision_start:asc',
+                               u'started_at:asc']
 
-METRIC_DEFAULT_PAGINATION = ['id:asc']
+METRIC_DEFAULT_PAGINATION = [u'id:asc']
 
 
 def get_pagination_options(params, default):
@@ -302,7 +302,7 @@ class ArchivePoliciesController(rest.RestController):
             voluptuous.Required("back_window", default=0): PositiveOrNullInt,
             voluptuous.Required(
                 "aggregation_methods",
-                default=set(conf.archive_policy.default_aggregation_methods)):
+                default=list(conf.archive_policy.default_aggregation_methods)):
             [ValidAggMethod],
             voluptuous.Required("definition"):
             voluptuous.All([{


### PR DESCRIPTION
voluptuous does not know how to use set and now wants to check that the default
value validates against the validators.