### PR TITLE
rest: stop using set to validate archive policies

### DIFF
--- a/gnocchi/archive_policy.py
+++ b/gnocchi/archive_policy.py
@@ -88,7 +88,7 @@ class ArchivePolicy(object):
         if aggregation_methods is None:
             self.aggregation_methods = self.DEFAULT_AGGREGATION_METHODS
         else:
-            self.aggregation_methods = aggregation_methods
+            self.aggregation_methods = set(aggregation_methods)
 
     def get_aggregation(self, method, granularity):
         # Find the timespan

--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -222,10 +222,10 @@ def strtobool(varname, v):
         abort(400, "Unable to parse `%s': %s" % (varname, six.text_type(e)))
 
 
-RESOURCE_DEFAULT_PAGINATION = ['revision_start:asc',
-                               'started_at:asc']
+RESOURCE_DEFAULT_PAGINATION = [u'revision_start:asc',
+                               u'started_at:asc']
 
-METRIC_DEFAULT_PAGINATION = ['id:asc']
+METRIC_DEFAULT_PAGINATION = [u'id:asc']
 
 
 def get_pagination_options(params, default):
@@ -324,7 +324,7 @@ class ArchivePoliciesController(rest.RestController):
         enforce("create archive policy", {})
         # NOTE(jd): Initialize this one at run-time because we rely on conf
         conf = pecan.request.conf
-        valid_agg_methods = (
+        valid_agg_methods = list(
             archive_policy.ArchivePolicy.VALID_AGGREGATION_METHODS_VALUES
         )
         ArchivePolicySchema = voluptuous.Schema({
@@ -333,10 +333,10 @@ class ArchivePoliciesController(rest.RestController):
                 voluptuous.Coerce(int),
                 voluptuous.Range(min=0),
             ),
-            voluptuous.Required(
+            voluptuous.Optional(
                 "aggregation_methods",
-                default=set(conf.archive_policy.default_aggregation_methods)):
-            voluptuous.All(list(valid_agg_methods), voluptuous.Coerce(set)),
+                default=conf.archive_policy.default_aggregation_methods):
+            valid_agg_methods,
             voluptuous.Required("definition"): ArchivePolicyDefinitionSchema,
         })
 


### PR DESCRIPTION
voluptuous does not know how to use set and now wants to check that the default
value validates against the validators.