### PR TITLE
Use list as default aggregation_methods

### DIFF
--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -330,7 +330,7 @@ class ArchivePoliciesController(rest.RestController):
             ),
             voluptuous.Required(
                 "aggregation_methods",
-                default=conf.archive_policy.default_aggregation_methods):
+                default=list(conf.archive_policy.default_aggregation_methods)):
             voluptuous.All(list(valid_agg_methods)),
             voluptuous.Required("definition"): ArchivePolicyDefinitionSchema,
         })


### PR DESCRIPTION
voluptuous expects a list, the list-like oslo.config doesn't work well
on py27. So this change casts it a real list.