### PR TITLE
tests: fix tempest tests.

### DIFF
--- a/devstack/gate/post_test_hook.sh
+++ b/devstack/gate/post_test_hook.sh
@@ -40,6 +40,7 @@ openstack catalog list
 
 export GNOCCHI_SERVICE_TOKEN=$(openstack token issue -c id -f value)
 export GNOCCHI_SERVICE_URL=$(openstack catalog show metric -c endpoints -f value | awk '/public/{print $2}')
+export GNOCCHI_AUTHORIZATION=""  # Temporary set to transition to the new functional testing
 
 curl -X GET ${GNOCCHI_SERVICE_URL}/v1/archive_policy -H "Content-Type: application/json"
 

--- a/gnocchi/tempest/scenario/__init__.py
+++ b/gnocchi/tempest/scenario/__init__.py
@@ -62,6 +62,7 @@ class GnocchiGabbiTest(tempest.test.BaseTestCase):
             require_ssl=require_ssl)
 
         os.environ["GNOCCHI_SERVICE_TOKEN"] = token
+        os.environ["GNOCCHI_AUTHORIZATION"] = "not used"
 
     @classmethod
     def clear_credentials(cls):

--- a/gnocchi/tests/gabbi/gabbits-live/live.yaml
+++ b/gnocchi/tests/gabbi/gabbits-live/live.yaml
@@ -6,6 +6,7 @@
 defaults:
     request_headers:
         x-auth-token: $ENVIRON['GNOCCHI_SERVICE_TOKEN']
+        authorization: $ENVIRON['GNOCCHI_AUTHORIZATION']
 
 tests:
     - name: check /
@@ -37,6 +38,7 @@ tests:
       request_headers:
           content-type: application/json
           x-auth-token: 'hello'
+          authorization: 'basic hello:'
       data:
           name: medium
           definition:
@@ -154,8 +156,8 @@ tests:
           $.definition[2].granularity: "0:01:00"
           $.definition[2].points: 5
           $.definition[2].timespan: "0:05:00"
-      response_strings:
-          - '"aggregation_methods": ["max", "min", "mean"]'
+      response_json_paths:
+          $.aggregation_methods.`sorted`: ["max", "mean", "min"]
 
     - name: get wrong accept
       desc: invalid 'accept' header
@@ -322,6 +324,7 @@ tests:
       request_headers:
           content-type: application/json
           x-auth-token: 'hello'
+          authorization: 'basic hello:'
       data:
         name: test_rule
         metric_pattern: "disk.foo.*"
@@ -353,8 +356,10 @@ tests:
     - name: get all archive policy rules
       url: /v1/archive_policy_rule
       status: 200
-      response_strings:
-          - '"metric_pattern": "live.*", "archive_policy_name": "gabbilive", "name": "gabbilive_rule"'
+      response_json_paths:
+          $[\name][0].name: "gabbilive_rule"
+          $[\name][0].metric_pattern: "live.*"
+          $[\name][0].archive_policy_name: "gabbilive"
 
     - name: get unknown archive policy rule
       url: /v1/archive_policy_rule/foo


### PR DESCRIPTION
Some tempest tests fail because their hardcode list order, while
Gnocchi can return an order order.

To fix them, this is a partial cherry-pick of
aa0716be945352e2d9ac65a8861916b9e634d1f0

Change-Id: I7d609a778c7c8592a3c7847e62b832d3805a71f4