### PR TITLE
storage: replace _store_unaggregated_timeserie by _store_unaggregated_timeseries

### DIFF
--- a/gnocchi/storage/ceph.py
+++ b/gnocchi/storage/ceph.py
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 #
+# Copyright © 2018 Red Hat
 # Copyright © 2014-2015 eNovance
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -196,7 +197,8 @@ class CephStorage(storage.StorageDriver):
             # emptiness instead.
             return contents or None
 
-    def _store_unaggregated_timeserie(self, metric, data, version=3):
+    def _store_unaggregated_timeseries_unbatched(
+            self, metric, data, version=3):
         self.ioctx.write_full(
             self._build_unaggregated_timeserie_path(metric, version), data)
 

--- a/gnocchi/storage/file.py
+++ b/gnocchi/storage/file.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 #
 # Copyright © 2014 Objectif Libre
-# Copyright © 2015 Red Hat
+# Copyright © 2015-2018 Red Hat
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -96,7 +96,8 @@ class FileStorage(storage.StorageDriver):
                 if e.errno != errno.EEXIST:
                     raise
 
-    def _store_unaggregated_timeserie(self, metric, data, version=3):
+    def _store_unaggregated_timeseries_unbatched(
+            self, metric, data, version=3):
         dest = self._build_unaggregated_timeserie_path(metric, version)
         with open(dest, "wb") as f:
             f.write(data)

--- a/gnocchi/storage/redis.py
+++ b/gnocchi/storage/redis.py
@@ -87,9 +87,12 @@ return {0, final}
             str(utils.timespan_total_seconds(granularity or key.sampling))])
         return path + '_v%s' % version if version else path
 
-    def _store_unaggregated_timeserie(self, metric, data, version=3):
-        self._client.hset(self._metric_key(metric),
-                          self._unaggregated_field(version), data)
+    def _store_unaggregated_timeseries(self, metrics_and_data, version=3):
+        pipe = self._client.pipeline(transaction=False)
+        unagg_key = self._unaggregated_field(version)
+        for metric, data in metrics_and_data:
+            pipe.hset(self._metric_key(metric), unagg_key, data)
+        pipe.execute()
 
     def _get_or_create_unaggregated_timeseries(self, metrics, version=3):
         pipe = self._client.pipeline(transaction=False)

--- a/gnocchi/storage/s3.py
+++ b/gnocchi/storage/s3.py
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 #
-# Copyright © 2016-2017 Red Hat, Inc.
+# Copyright © 2016-2018 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -226,7 +226,8 @@ class S3Storage(storage.StorageDriver):
         else:
             return response['Body'].read()
 
-    def _store_unaggregated_timeserie(self, metric, data, version=3):
+    def _store_unaggregated_timeseries_unbatched(
+            self, metric, data, version=3):
         self._put_object_safe(
             Bucket=self._bucket_name,
             Key=self._build_unaggregated_timeserie_path(metric, version),

--- a/gnocchi/storage/swift.py
+++ b/gnocchi/storage/swift.py
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 #
+# Copyright © 2018 Red Hat
 # Copyright © 2014-2015 eNovance
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -203,7 +204,9 @@ class SwiftStorage(storage.StorageDriver):
         else:
             return contents
 
-    def _store_unaggregated_timeserie(self, metric, data, version=3):
-        self.swift.put_object(self._container_name(metric),
-                              self._build_unaggregated_timeserie_path(version),
-                              data)
+    def _store_unaggregated_timeseries_unbatched(
+            self, metric, data, version=3):
+        self.swift.put_object(
+            self._container_name(metric),
+            self._build_unaggregated_timeserie_path(version),
+            data)

--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -97,7 +97,7 @@ class TestStorageDriver(tests_base.TestCase):
         self.incoming.add_measures(self.metric.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 1), 5),
         ])
-        with mock.patch.object(self.storage, '_store_unaggregated_timeserie',
+        with mock.patch.object(self.storage, '_store_unaggregated_timeseries',
                                side_effect=Exception):
             try:
                 self.trigger_processing()


### PR DESCRIPTION
This allows to store several unaggregated timeseries at the same time.