### PR TITLE
storage: change _delete_metric_measures to _delete_metric_splits

### DIFF
--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -371,6 +371,7 @@ class StorageDriver(object):
 
                 # First, check for old splits to delete
                 if ap_def.timespan:
+                    deleted_keys = set()
                     for key in list(existing_keys):
                         # NOTE(jd) Only delete if the key is strictly inferior
                         # the timestamp; we don't delete any timeserie split
@@ -378,8 +379,10 @@ class StorageDriver(object):
                         # bit more than deleting too much
                         if key >= oldest_key_to_keep:
                             break
-                        self._delete_metric_measures(metric, key, aggregation)
+                        deleted_keys.add(key)
                         existing_keys.remove(key)
+                    self._delete_metric_splits(
+                        metric, deleted_keys, aggregation)
 
                 # Rewrite all read-only splits just for fun (and compression).
                 # This only happens if `previous_oldest_mutable_timestamp'
@@ -414,9 +417,13 @@ class StorageDriver(object):
         raise NotImplementedError
 
     @staticmethod
-    def _delete_metric_measures(metric, timestamp_key,
-                                aggregation, granularity, version=3):
+    def _delete_metric_splits_unbatched(metric, keys, aggregation, version=3):
         raise NotImplementedError
+
+    def _delete_metric_splits(self, metric, keys, aggregation, version=3):
+        utils.parallel_map(
+            utils.return_none_on_failure(self._delete_metric_splits_unbatched),
+            ((metric, key, aggregation) for key in keys))
 
     def compute_and_store_timeseries(self, metric, measures):
         # NOTE(mnaser): The metric could have been handled by

--- a/gnocchi/storage/file.py
+++ b/gnocchi/storage/file.py
@@ -133,7 +133,8 @@ class FileStorage(storage.StorageDriver):
                 keys.add(meta[0])
         return keys
 
-    def _delete_metric_measures(self, metric, key, aggregation, version=3):
+    def _delete_metric_splits_unbatched(
+            self, metric, key, aggregation, version=3):
         os.unlink(self._build_metric_path_for_split(
             metric, aggregation, key, version))
 

--- a/gnocchi/storage/redis.py
+++ b/gnocchi/storage/redis.py
@@ -120,9 +120,13 @@ return {0, final}
             raise storage.MetricDoesNotExist(metric)
         return set(split_keys)
 
-    def _delete_metric_measures(self, metric, key, aggregation, version=3):
-        field = self._aggregated_field_for_split(aggregation, key, version)
-        self._client.hdel(self._metric_key(metric), field)
+    def _delete_metric_splits(self, metric, keys, aggregation, version=3):
+        metric_key = self._metric_key(metric)
+        pipe = self._client.pipeline(transaction=False)
+        for key in keys:
+            pipe.hdel(metric_key, self._aggregated_field_for_split(
+                aggregation, key, version))
+        pipe.execute()
 
     def _store_metric_splits(self, metric, keys_and_data_and_offset,
                              aggregation, version=3):

--- a/gnocchi/storage/s3.py
+++ b/gnocchi/storage/s3.py
@@ -128,8 +128,8 @@ class S3Storage(storage.StorageDriver):
                     key, aggregation, version),
                 Body=data)
 
-    def _delete_metric_measures(self, metric, key, aggregation,
-                                version=3):
+    def _delete_metric_splits_unbatched(self, metric, key, aggregation,
+                                        version=3):
         self.s3.delete_object(
             Bucket=self._bucket_name,
             Key=self._prefix(metric) + self._object_name(

--- a/gnocchi/storage/swift.py
+++ b/gnocchi/storage/swift.py
@@ -121,7 +121,8 @@ class SwiftStorage(storage.StorageDriver):
                 self._object_name(key, aggregation, version),
                 data)
 
-    def _delete_metric_measures(self, metric, key, aggregation, version=3):
+    def _delete_metric_splits_unbatched(
+            self, metric, key, aggregation, version=3):
         self.swift.delete_object(
             self._container_name(metric),
             self._object_name(key, aggregation, version))

--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -608,11 +608,11 @@ class TestStorageDriver(tests_base.TestCase):
 
         # Test what happens if we delete the latest split and then need to
         # compress it!
-        self.storage._delete_metric_measures(
-            self.metric, carbonara.SplitKey(
+        self.storage._delete_metric_splits(
+            self.metric, [carbonara.SplitKey(
                 numpy.datetime64(1451952000, 's'),
                 numpy.timedelta64(1, 'm'),
-            ), 'mean')
+            )], 'mean')
 
         # Now store brand new points that should force a rewrite of one of the
         # split (keep in mind the back window size in one hour here). We move


### PR DESCRIPTION
This new method allows to delete a bunch of splits at the same time for a
single metric, batching delete.