### PR TITLE
Add filter format in aggregation

### DIFF
--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -1705,7 +1705,8 @@ class AggregationResourceController(rest.RestController):
     @pecan.expose('json')
     def post(self, start=None, stop=None, aggregation='mean',
              reaggregation=None, granularity=None, needed_overlap=100.0,
-             groupby=None, fill=None, refresh=False, resample=None):
+             groupby=None, fill=None, refresh=False, resample=None,
+             **kwargs):
         # First, set groupby in the right format: a sorted list of unique
         # strings.
         groupby = sorted(set(arg_to_list(groupby)))
@@ -1714,7 +1715,8 @@ class AggregationResourceController(rest.RestController):
         # groups when using itertools.groupby later.
         try:
             resources = SearchResourceTypeController(
-                self.resource_type)._search(sort=groupby)
+                self.resource_type)._search(sort=groupby,
+                                            filter=kwargs.get("filter"))
         except indexer.InvalidPagination:
             abort(400, "Invalid groupby attribute")
         except indexer.IndexerException as e:
@@ -1747,7 +1749,6 @@ class AggregationResourceController(rest.RestController):
             })
 
         return results
-
 
 FillSchema = voluptuous.Schema(
     voluptuous.Any(voluptuous.Coerce(float), "null", "dropna",

--- a/gnocchi/tests/functional/gabbits/resource-aggregation.yaml
+++ b/gnocchi/tests/functional/gabbits/resource-aggregation.yaml
@@ -97,6 +97,26 @@ tests:
           value: 45.41
       status: 202
 
+    - name: aggregate metric with groupby on project_id with filter
+      POST: /v1/aggregation/resource/generic/metric/cpu.util?groupby=project_id&filter=user_id%3D%276c865dd0-7945-4e08-8b27-d0d7f1c2b667%27
+      poll:
+        count: 10
+        delay: 1
+      response_json_paths:
+        $:
+          - measures:
+            - ["2015-03-06T14:30:00+00:00", 300.0, 21.525]
+            - ["2015-03-06T14:33:57+00:00", 1.0, 33.05]
+            - ["2015-03-06T14:34:12+00:00", 1.0, 10.0]
+            group:
+              project_id: c7f32f1f-c5ef-427a-8ecd-915b219c66e8
+          - measures:
+            - ["2015-03-06T14:30:00+00:00", 300.0, 137.70499999999998]
+            - ["2015-03-06T14:33:57+00:00", 1.0, 230.0]
+            - ["2015-03-06T14:34:12+00:00", 1.0, 45.41]
+            group:
+              project_id: ee4cfc41-1cdc-4d2f-9a08-f94111d80171
+
     - name: aggregate metric with groupby on project_id
       POST: /v1/aggregation/resource/generic/metric/cpu.util?groupby=project_id
       data:

--- a/releasenotes/notes/filter-param-for-aggregation-f68c47c59ca81dc0.yaml
+++ b/releasenotes/notes/filter-param-for-aggregation-f68c47c59ca81dc0.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    /v1/aggregation/resources endpoint can now take the STRING format in
+    `filter` parameter instead of the JSON format into the request payload.


### PR DESCRIPTION
The filter= argument is missing from the aggregation API.

This change adds it.