### PR TITLE
carbonara: make SplitKey carry aggregation method

### DIFF
--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -182,7 +182,9 @@ class StorageDriver(object):
     def _list_split_keys_for_metric(self, metric, aggregation, granularity,
                                     version=3):
         return set(map(
-            functools.partial(carbonara.SplitKey, sampling=granularity),
+            functools.partial(carbonara.SplitKey,
+                              sampling=granularity,
+                              aggregation_method=aggregation),
             (numpy.array(
                 list(self._list_split_keys(
                     metric, aggregation, granularity, version)),
@@ -258,11 +260,11 @@ class StorageDriver(object):
 
         if from_timestamp:
             from_timestamp = carbonara.SplitKey.from_timestamp_and_sampling(
-                from_timestamp, aggregation.granularity)
+                from_timestamp, aggregation.granularity, aggregation.method)
 
         if to_timestamp:
             to_timestamp = carbonara.SplitKey.from_timestamp_and_sampling(
-                to_timestamp, aggregation.granularity)
+                to_timestamp, aggregation.granularity, aggregation.method)
 
         keys = [key for key in sorted(all_keys)
                 if ((not from_timestamp or key >= from_timestamp)

--- a/gnocchi/tests/test_carbonara.py
+++ b/gnocchi/tests/test_carbonara.py
@@ -16,6 +16,7 @@
 import datetime
 import functools
 import math
+import operator
 
 import fixtures
 import iso8601
@@ -808,16 +809,19 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
             numpy.datetime64("2014-10-07"),
             carbonara.SplitKey.from_timestamp_and_sampling(
                 numpy.datetime64("2015-01-01T15:03"),
-                numpy.timedelta64(3600, 's')))
+                numpy.timedelta64(3600, 's'),
+                "mean"))
         self.assertEqual(
             numpy.datetime64("2014-12-31 18:00"),
             carbonara.SplitKey.from_timestamp_and_sampling(
                 numpy.datetime64("2015-01-01 15:03:58"),
-                numpy.timedelta64(58, 's')))
+                numpy.timedelta64(58, 's'),
+                "mean"))
 
         key = carbonara.SplitKey.from_timestamp_and_sampling(
             numpy.datetime64("2015-01-01 15:03"),
-            numpy.timedelta64(3600, 's'))
+            numpy.timedelta64(3600, 's'),
+            "mean")
 
         self.assertGreater(key, numpy.datetime64("1970"))
 
@@ -830,28 +834,33 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
         td = numpy.timedelta64(60, 's')
 
         self.assertEqual(
-            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td),
-            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td))
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td, "mean"),
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td, "mean"))
         self.assertEqual(
-            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td),
-            carbonara.SplitKey.from_timestamp_and_sampling(dt1_1, td))
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td, "mean"),
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1_1, td, "mean"))
         self.assertNotEqual(
-            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td),
-            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td))
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td, "mean"),
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td, "mean"))
+        self.assertRaises(
+            TypeError,
+            operator.le,
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td, "max"),
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1_1, td, "mean"))
 
         self.assertLess(
-            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td),
-            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td))
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td, "mean"),
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td, "mean"))
         self.assertLessEqual(
-            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td),
-            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td))
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td, "mean"),
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td, "mean"))
 
         self.assertGreater(
-            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td),
-            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td))
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td, "mean"),
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td, "mean"))
         self.assertGreaterEqual(
-            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td),
-            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td))
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td, "mean"),
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td, "mean"))
 
     def test_split_key_cmp_negative(self):
         dt1 = numpy.datetime64("2015-01-01T15:03")
@@ -860,40 +869,42 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
         td = numpy.timedelta64(60, 's')
 
         self.assertFalse(
-            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td) !=
-            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td))
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td, "mean") !=
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td, "mean"))
         self.assertFalse(
-            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td) !=
-            carbonara.SplitKey.from_timestamp_and_sampling(dt1_1, td))
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td, "mean") !=
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1_1, td, "mean"))
         self.assertFalse(
-            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td) ==
-            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td))
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td, "mean") ==
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td, "mean"))
 
         self.assertFalse(
-            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td) >=
-            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td))
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td, "mean") >=
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td, "mean"))
         self.assertFalse(
-            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td) >
-            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td))
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td, "mean") >
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td, "mean"))
 
         self.assertFalse(
-            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td) <=
-            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td))
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td, "mean") <=
+            carbonara.SplitKey.from_timestamp_and_sampling(dt1, td, "mean"))
         self.assertFalse(
-            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td) <
-            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td))
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td, "mean") <
+            carbonara.SplitKey.from_timestamp_and_sampling(dt2, td, "mean"))
 
     def test_split_key_next(self):
         self.assertEqual(
             numpy.datetime64("2015-03-06"),
             next(carbonara.SplitKey.from_timestamp_and_sampling(
                 numpy.datetime64("2015-01-01 15:03"),
-                numpy.timedelta64(3600, 's'))))
+                numpy.timedelta64(3600, 's'),
+                "mean")))
         self.assertEqual(
             numpy.datetime64("2015-08-03"),
             next(next(carbonara.SplitKey.from_timestamp_and_sampling(
                 numpy.datetime64("2015-01-01T15:03"),
-                numpy.timedelta64(3600, 's')))))
+                numpy.timedelta64(3600, 's'),
+                "mean"))))
 
     def test_split(self):
         sampling = numpy.timedelta64(5, 's')
@@ -911,7 +922,8 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
                       / carbonara.SplitKey.POINTS_PER_SPLIT),
             len(grouped_points))
         self.assertEqual("0.0",
-                         str(carbonara.SplitKey(grouped_points[0][0], 0)))
+                         str(carbonara.SplitKey(
+                             grouped_points[0][0], 0, "mean")))
         # 3600 × 5s = 5 hours
         self.assertEqual(datetime64(1970, 1, 1, 5),
                          grouped_points[1][0])

--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -279,17 +279,20 @@ class TestStorageDriver(tests_base.TestCase):
 
         self.assertEqual({
             carbonara.SplitKey(numpy.datetime64(1244160000, 's'),
-                               numpy.timedelta64(1, 'D')),
+                               numpy.timedelta64(1, 'D'),
+                               "mean"),
         }, self.storage._list_split_keys_for_metric(
             self.metric, "mean", numpy.timedelta64(1, 'D')))
         self.assertEqual({
             carbonara.SplitKey(numpy.datetime64(1412640000, 's'),
-                               numpy.timedelta64(1, 'h')),
+                               numpy.timedelta64(1, 'h'),
+                               "mean"),
         }, self.storage._list_split_keys_for_metric(
             self.metric, "mean", numpy.timedelta64(1, 'h')))
         self.assertEqual({
             carbonara.SplitKey(numpy.datetime64(1419120000, 's'),
-                               numpy.timedelta64(5, 'm')),
+                               numpy.timedelta64(5, 'm'),
+                               "mean"),
         }, self.storage._list_split_keys_for_metric(
             self.metric, "mean", numpy.timedelta64(5, 'm')))
 
@@ -314,11 +317,14 @@ class TestStorageDriver(tests_base.TestCase):
 
         self.assertEqual({
             carbonara.SplitKey(numpy.datetime64(1451520000, 's'),
-                               numpy.timedelta64(1, 'm')),
+                               numpy.timedelta64(1, 'm'),
+                               "mean"),
             carbonara.SplitKey(numpy.datetime64(1451736000, 's'),
-                               numpy.timedelta64(1, 'm')),
+                               numpy.timedelta64(1, 'm'),
+                               "mean"),
             carbonara.SplitKey(numpy.datetime64(1451952000, 's'),
-                               numpy.timedelta64(1, 'm')),
+                               numpy.timedelta64(1, 'm'),
+                               "mean"),
         }, self.storage._list_split_keys_for_metric(
             self.metric, "mean", numpy.timedelta64(1, 'm')))
 
@@ -331,18 +337,21 @@ class TestStorageDriver(tests_base.TestCase):
             self.metric, [carbonara.SplitKey(
                 numpy.datetime64(1451520000, 's'),
                 numpy.timedelta64(1, 'm'),
+                "mean",
             )], "mean")[0]
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
             self.metric, [carbonara.SplitKey(
                 numpy.datetime64(1451736000, 's'),
                 numpy.timedelta64(60, 's'),
+                "mean",
             )], "mean")[0]
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
             self.metric, [carbonara.SplitKey(
                 numpy.datetime64(1451952000, 's'),
                 numpy.timedelta64(60, 's'),
+                "mean",
             )], "mean")[0]
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
@@ -369,31 +378,38 @@ class TestStorageDriver(tests_base.TestCase):
 
         self.assertEqual({
             carbonara.SplitKey(numpy.datetime64(1452384000, 's'),
-                               numpy.timedelta64(1, 'm')),
+                               numpy.timedelta64(1, 'm'),
+                               "mean"),
             carbonara.SplitKey(numpy.datetime64(1451736000, 's'),
-                               numpy.timedelta64(1, 'm')),
+                               numpy.timedelta64(1, 'm'),
+                               "mean"),
             carbonara.SplitKey(numpy.datetime64(1451520000, 's'),
-                               numpy.timedelta64(1, 'm')),
+                               numpy.timedelta64(1, 'm'),
+                               "mean"),
             carbonara.SplitKey(numpy.datetime64(1451952000, 's'),
-                               numpy.timedelta64(1, 'm')),
+                               numpy.timedelta64(1, 'm'),
+                               "mean"),
         }, self.storage._list_split_keys_for_metric(
             self.metric, "mean", numpy.timedelta64(1, 'm')))
         data = self.storage._get_measures(
             self.metric, [carbonara.SplitKey(
                 numpy.datetime64(1451520000, 's'),
                 numpy.timedelta64(60, 's'),
+                "mean",
             )], "mean")[0]
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
             self.metric, [carbonara.SplitKey(
                 numpy.datetime64(1451736000, 's'),
                 numpy.timedelta64(60, 's'),
+                "mean",
             )], "mean")[0]
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
             self.metric, [carbonara.SplitKey(
                 numpy.datetime64(1451952000, 's'),
                 numpy.timedelta64(1, 'm'),
+                "mean",
             )], "mean")[0]
         # Now this one is compressed because it has been rewritten!
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
@@ -401,6 +417,7 @@ class TestStorageDriver(tests_base.TestCase):
             self.metric, [carbonara.SplitKey(
                 numpy.datetime64(1452384000, 's'),
                 numpy.timedelta64(60, 's'),
+                "mean",
             )], "mean")[0]
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
@@ -436,11 +453,14 @@ class TestStorageDriver(tests_base.TestCase):
 
         self.assertEqual({
             carbonara.SplitKey(numpy.datetime64(1451520000, 's'),
-                               numpy.timedelta64(1, 'm')),
+                               numpy.timedelta64(1, 'm'),
+                               "mean"),
             carbonara.SplitKey(numpy.datetime64(1451736000, 's'),
-                               numpy.timedelta64(1, 'm')),
+                               numpy.timedelta64(1, 'm'),
+                               "mean"),
             carbonara.SplitKey(numpy.datetime64(1451952000, 's'),
-                               numpy.timedelta64(1, 'm')),
+                               numpy.timedelta64(1, 'm'),
+                               "mean"),
         }, self.storage._list_split_keys_for_metric(
             self.metric, "mean", numpy.timedelta64(1, 'm')))
 
@@ -453,18 +473,21 @@ class TestStorageDriver(tests_base.TestCase):
             self.metric, [carbonara.SplitKey(
                 numpy.datetime64(1451520000, 's'),
                 numpy.timedelta64(1, 'm'),
+                "mean",
             )], "mean")[0]
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
             self.metric, [carbonara.SplitKey(
                 numpy.datetime64(1451736000, 's'),
                 numpy.timedelta64(1, 'm'),
+                "mean",
             )], "mean")[0]
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
             self.metric, [carbonara.SplitKey(
                 numpy.datetime64(1451952000, 's'),
-                numpy.timedelta64(1, 'm')
+                numpy.timedelta64(1, 'm'),
+                "mean",
             )], "mean")[0]
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
@@ -493,31 +516,38 @@ class TestStorageDriver(tests_base.TestCase):
 
         self.assertEqual({
             carbonara.SplitKey(numpy.datetime64('2016-01-10T00:00:00'),
-                               numpy.timedelta64(1, 'm')),
+                               numpy.timedelta64(1, 'm'),
+                               "mean"),
             carbonara.SplitKey(numpy.datetime64('2016-01-02T12:00:00'),
-                               numpy.timedelta64(1, 'm')),
+                               numpy.timedelta64(1, 'm'),
+                               "mean"),
             carbonara.SplitKey(numpy.datetime64('2015-12-31T00:00:00'),
-                               numpy.timedelta64(1, 'm')),
+                               numpy.timedelta64(1, 'm'),
+                               "mean"),
             carbonara.SplitKey(numpy.datetime64('2016-01-05T00:00:00'),
-                               numpy.timedelta64(1, 'm')),
+                               numpy.timedelta64(1, 'm'),
+                               "mean"),
         }, self.storage._list_split_keys_for_metric(
             self.metric, "mean", numpy.timedelta64(1, 'm')))
         data = self.storage._get_measures(
             self.metric, [carbonara.SplitKey(
                 numpy.datetime64(1451520000, 's'),
                 numpy.timedelta64(1, 'm'),
+                "mean",
             )], "mean")[0]
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
             self.metric, [carbonara.SplitKey(
                 numpy.datetime64(1451736000, 's'),
                 numpy.timedelta64(1, 'm'),
+                "mean",
             )], "mean")[0]
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
             self.metric, [carbonara.SplitKey(
                 numpy.datetime64(1451952000, 's'),
-                numpy.timedelta64(60, 's')
+                numpy.timedelta64(60, 's'),
+                "mean",
             )], "mean")[0]
         # Now this one is compressed because it has been rewritten!
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
@@ -525,6 +555,7 @@ class TestStorageDriver(tests_base.TestCase):
             self.metric, [carbonara.SplitKey(
                 numpy.datetime64(1452384000, 's'),
                 numpy.timedelta64(1, 'm'),
+                "mean",
             )], "mean")[0]
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
@@ -558,11 +589,14 @@ class TestStorageDriver(tests_base.TestCase):
 
         self.assertEqual({
             carbonara.SplitKey(numpy.datetime64('2015-12-31T00:00:00'),
-                               numpy.timedelta64(1, 'm')),
+                               numpy.timedelta64(1, 'm'),
+                               "mean"),
             carbonara.SplitKey(numpy.datetime64('2016-01-02T12:00:00'),
-                               numpy.timedelta64(1, 'm')),
+                               numpy.timedelta64(1, 'm'),
+                               "mean"),
             carbonara.SplitKey(numpy.datetime64('2016-01-05T00:00:00'),
-                               numpy.timedelta64(1, 'm')),
+                               numpy.timedelta64(1, 'm'),
+                               "mean"),
         }, self.storage._list_split_keys_for_metric(
             self.metric, "mean", numpy.timedelta64(1, 'm')))
 
@@ -576,18 +610,21 @@ class TestStorageDriver(tests_base.TestCase):
             [carbonara.SplitKey(
                 numpy.datetime64(1451520000, 's'),
                 numpy.timedelta64(1, 'm'),
+                "mean",
             )], "mean")[0]
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
             self.metric, [carbonara.SplitKey(
                 numpy.datetime64(1451736000, 's'),
-                numpy.timedelta64(1, 'm')
+                numpy.timedelta64(1, 'm'),
+                "mean",
             )], "mean")[0]
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
             self.metric, [carbonara.SplitKey(
                 numpy.datetime64(1451952000, 's'),
                 numpy.timedelta64(1, 'm'),
+                "mean",
             )], "mean")[0]
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
@@ -612,6 +649,7 @@ class TestStorageDriver(tests_base.TestCase):
             self.metric, [carbonara.SplitKey(
                 numpy.datetime64(1451952000, 's'),
                 numpy.timedelta64(1, 'm'),
+                "mean",
             )], 'mean')
 
         # Now store brand new points that should force a rewrite of one of the
@@ -645,11 +683,14 @@ class TestStorageDriver(tests_base.TestCase):
 
         self.assertEqual({
             carbonara.SplitKey(numpy.datetime64(1451520000, 's'),
-                               numpy.timedelta64(1, 'm')),
+                               numpy.timedelta64(1, 'm'),
+                               "mean"),
             carbonara.SplitKey(numpy.datetime64(1451736000, 's'),
-                               numpy.timedelta64(1, 'm')),
+                               numpy.timedelta64(1, 'm'),
+                               "mean"),
             carbonara.SplitKey(numpy.datetime64(1451952000, 's'),
-                               numpy.timedelta64(1, 'm')),
+                               numpy.timedelta64(1, 'm'),
+                               "mean"),
         }, self.storage._list_split_keys_for_metric(
             self.metric, "mean", numpy.timedelta64(1, 'm')))
 
@@ -662,18 +703,21 @@ class TestStorageDriver(tests_base.TestCase):
             self.metric, [carbonara.SplitKey(
                 numpy.datetime64(1451520000, 's'),
                 numpy.timedelta64(60, 's'),
+                "mean",
             )], "mean")[0]
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
             self.metric, [carbonara.SplitKey(
                 numpy.datetime64(1451736000, 's'),
                 numpy.timedelta64(1, 'm'),
+                "mean",
             )], "mean")[0]
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
             self.metric, [carbonara.SplitKey(
                 numpy.datetime64(1451952000, 's'),
                 numpy.timedelta64(1, 'm'),
+                "mean",
             )], "mean")[0]
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
@@ -693,7 +737,8 @@ class TestStorageDriver(tests_base.TestCase):
             self.metric, [
                 (carbonara.SplitKey(
                     numpy.datetime64(1451952000, 's'),
-                    numpy.timedelta64(1, 'm')),
+                    numpy.timedelta64(1, 'm'),
+                    "mean"),
                  b"oh really?", None)
             ], "mean")
 


### PR DESCRIPTION
Why not strictly used by the SplitKey, it actually makes sense as
AggregatedTimeSerie splits key are not really compatible with different
aggregation method. This will come handy to pass less arguments in the future.