### PR TITLE
carbonara: handle timeseries derivation for rate aggregations

### DIFF
--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -610,7 +610,12 @@ class AggregatedTimeSerie(TimeSerie):
 
     @classmethod
     def from_grouped_serie(cls, grouped_serie, sampling, aggregation_method):
-        agg_name, q = cls._get_agg_method(aggregation_method)
+        if aggregation_method.startswith("rate:"):
+            grouped_serie = grouped_serie.derived()
+            aggregation_method_name = aggregation_method[5:]
+        else:
+            aggregation_method_name = aggregation_method
+        agg_name, q = cls._get_agg_method(aggregation_method_name)
         return cls(sampling, aggregation_method,
                    ts=cls._resample_grouped(grouped_serie, agg_name,
                                             q))

--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -348,15 +348,8 @@ class StorageDriver(object):
     def _add_measures(self, metric, aggregation, grouped_serie,
                       previous_oldest_mutable_timestamp,
                       oldest_mutable_timestamp):
-
-        if aggregation.method.startswith("rate:"):
-            grouped_serie = grouped_serie.derived()
-            aggregation_to_compute = aggregation.method[5:]
-        else:
-            aggregation_to_compute = aggregation.method
-
         ts = carbonara.AggregatedTimeSerie.from_grouped_serie(
-            grouped_serie, aggregation.granularity, aggregation_to_compute)
+            grouped_serie, aggregation.granularity, aggregation.method)
 
         # Don't do anything if the timeserie is empty
         if not ts:


### PR DESCRIPTION
This moves the handling into Carbonara itself so the storage engine does not
have to handle that.