### PR TITLE
doc: document filter parameter

### DIFF
--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -601,30 +601,48 @@ Gnocchi's search API supports to the ability to execute a query across
 |resources| or |metrics|. This API provides a language to construct more
 complex matching contraints beyond basic filtering.
 
-Usage
------
+Usage and format
+----------------
 
 You can specify a time range to look for by specifying the `start` and/or
 `stop` query parameter, and the |aggregation method| to use by specifying the
 `aggregation` query parameter.
 
+Query can be expressed in two formats: `JSON` or `STRING`.
+
 The supported operators are: equal to (`=`, `==` or `eq`), lesser than (`<` or
 `lt`), greater than (`>` or `gt`), less than or equal to (`<=`, `le` or `≤`)
 greater than or equal to (`>=`, `ge` or `≥`) not equal to (`!=`, `ne` or `≠`),
 addition (`+` or `add`), substraction (`-` or `sub`), multiplication (`*`,
-`mul` or `×`), division (`/`, `div` or `÷`). These operations take either one
-argument, and in this case the second argument passed is the value, or it.
+`mul` or `×`), division (`/`, `div` or `÷`). In JSON format, these operations
+take only one argument, the second argument being automatically set to the
+field value. In STRING format, this is just `<first argument> <operator>
+<second argument>`
 
 The operators or (`or` or `∨`), and (`and` or `∧`) and `not` are also
-supported, and take a list of arguments as parameters.
+supported. In JSON format, it takes a list of arguments as parameters. Using
+STRING, the format is `<left group> and/or <right group>` or `not <right
+group>`. With the STRING format, parenthesis can be used to create group.
+
+An example of the JSON format::
+
+    ["and",
+      ["=", ["host", "example1"]],
+      ["like", ["owner", "admin-%"]],
+    ]
+
+And its STRING format equivalent::
+
+    host = "example1" or owner like "admin-%"
 
 .. _search-resource:
 
 Resource
 --------
 
-It's possible to search for |resources| using a query mechanism, using the
-`POST` method and uploading a JSON formatted query.
+It's possible to search for |resources| using a query mechanism by using the
+`POST` method and uploading a JSON formatted query or by passing a
+STRING a formatted query URL-encoded in the ``filter`` parameter.
 
 Single filter
 ~~~~~~~~~~~~~
@@ -638,12 +656,23 @@ Or even:
 
 {{ scenarios['search-resource-for-host-like']['doc'] }}
 
+For the ``filter`` parameter version, the value is the URL-encoded version of
+``{{ scenarios['search-resource-for-host-like-filter']['filter'] }}``
+
+{{ scenarios['search-resource-for-host-like-filter']['doc'] }}
+
 Multiple filters
 ~~~~~~~~~~~~~~~~
 
 Complex operators such as `and` and `or` are also available:
 
 {{ scenarios['search-resource-for-user-after-timestamp']['doc'] }}
+
+``filter`` version is
+``{{ scenarios['search-resource-for-user-after-timestamp-filter']['filter'] }}``
+URL-encoded.
+
+{{ scenarios['search-resource-for-user-after-timestamp-filter']['doc'] }}
 
 With details
 ~~~~~~~~~~~~
@@ -677,6 +706,14 @@ Time range
 The timerange of the history can be set, too:
 
 {{ scenarios['search-resource-history-partial']['doc'] }}
+
+This can be done with the ``filter`` parameter too:
+
+``{{ scenarios['search-resource-history-partial-filter']['filter'] }}``
+
+
+{{ scenarios['search-resource-history-partial-filter']['doc'] }}
+
 
 Magic
 ~~~~~
@@ -931,6 +968,12 @@ In order to select these |resources|, the following endpoint accepts a query
 such as the one described in the :ref:`resource search API <search-resource>`.
 
 {{ scenarios['get-across-metrics-measures-by-attributes-lookup']['doc'] }}
+
+Like for searching resource, the query
+``{{ scenarios['get-across-metrics-measures-by-attributes-lookup-filter']['filter'] }}``
+can be passed in ``filter`` parameter
+
+{{ scenarios['get-across-metrics-measures-by-attributes-lookup-filter']['doc'] }}
 
 It is possible to group the |resource| search results by any attribute of the
 requested |resource| type, and then compute the aggregation:

--- a/doc/source/rest.yaml
+++ b/doc/source/rest.yaml
@@ -387,6 +387,12 @@
 
     {"like": {"host": "compute%"}}
 
+- name: search-resource-for-host-like-filter
+  filter: host like "compute%"
+  request: |
+    POST /v1/search/resource/instance?filter={{ scenarios['search-resource-for-host-like-filter']['filter'] | urlencode }} HTTP/1.1
+    Content-Type: application/json
+
 - name: search-resource-for-user-details
   request: |
     POST /v1/search/resource/generic?details=true HTTP/1.1
@@ -410,6 +416,12 @@
       {"=": {"user_id": "{{ scenarios['create-resource-instance']['response'].json['user_id'] }}"}},
       {">=": {"started_at": "2010-01-01"}}
     ]}
+
+- name: search-resource-for-user-after-timestamp-filter
+  filter: user_id = "{{ scenarios['create-resource-instance']['response'].json['user_id'] }}" and started_at >= "2010-01-01"
+  request: |
+    POST /v1/search/resource/instance?filter={{ scenarios['search-resource-for-user-after-timestamp-filter']['filter'] | urlencode }} HTTP/1.1
+    Content-Type: application/json
 
 - name: search-resource-lifespan
   request: |
@@ -533,6 +545,20 @@
 - name: search-resource-history-partial
   request: |
     POST /v1/search/resource/instance HTTP/1.1
+    Content-Type: application/json
+    Accept: application/json; history=true
+
+    {"and": [
+        {"=": {"host": "compute1"}},
+        {">=": {"revision_start": "{{ scenarios['get-instance']['response'].json['revision_start'] }}"}},
+        {"or": [{"<=": {"revision_end": "{{ scenarios['get-patched-instance']['response'].json['revision_start'] }}"}},
+            {"=": {"revision_end": null}}]}
+    ]}
+
+- name: search-resource-history-partial-filter
+  filter: host = 'compute1' and revision_start >= "{{ scenarios['get-instance']['response'].json['revision_start'] }}" and (revision_end <= "{{ scenarios['get-patched-instance']['response'].json['revision_start'] }}" or revision_end == null)
+  request: |
+    POST /v1/search/resource/instance?filter={{ scenarios['search-resource-history-partial-filter']['filter'] | urlencode }} HTTP/1.1
     Content-Type: application/json
     Accept: application/json; history=true
 
@@ -760,6 +786,12 @@
     Content-Type: application/json
 
     {"=": {"server_group": "my_autoscaling_group"}}
+
+- name: get-across-metrics-measures-by-attributes-lookup-filter
+  filter: server_group = "my_autoscaling_group"
+  request: |
+    POST /v1/aggregation/resource/instance/metric/cpu.util?start=2014-10-06T14:34&aggregation=mean&filter={{ scenarios['get-across-metrics-measures-by-attributes-lookup-filter']['filter'] | urlencode }} HTTP/1.1
+    Content-Type: application/json
 
 - name: get-across-metrics-measures-by-attributes-lookup-groupby
   request: |

--- a/gnocchi/gendoc.py
+++ b/gnocchi/gendoc.py
@@ -200,6 +200,10 @@ def setup(app):
 
     try:
         for entry in scenarios:
+            if 'filter' in entry:
+                entry['filter'] = jinja2.Template(entry['filter']).render(
+                    scenarios=scenarios)
+
             template = jinja2.Template(entry['request'])
             fake_file = six.moves.cStringIO()
             content = template.render(scenarios=scenarios)


### PR DESCRIPTION
All resource search payload can also be passed in the filter parameter
into other format. This is missing from the documentation while Grafana
have to use this format. So documents it