### PR TITLE
storage: truncate the whole AggregatedTimeSerie, not every split

### DIFF
--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -580,16 +580,17 @@ class AggregatedTimeSerie(TimeSerie):
 
         :param oldest_point: Oldest point to keep from, this excluded.
         :type oldest_point: numpy.datetime64 or numpy.timedelta64
+        :return: The oldest point that could have been kept.
         """
         last = self.last
         if last is None:
-            # There's nothing to truncate
             return
         if isinstance(oldest_point, numpy.timedelta64):
             oldest_point = last - oldest_point
         index = numpy.searchsorted(self.ts['timestamps'], oldest_point,
                                    side='right')
         self.ts = self.ts[index:]
+        return oldest_point
 
     def split(self):
         # NOTE(sileht): We previously use groupby with
@@ -694,12 +695,14 @@ class AggregatedTimeSerie(TimeSerie):
     def get_split_key(self, timestamp=None):
         """Return the split key for a particular timestamp.
 
-        :param timestamp: If None, the first timestamp of the timeserie
+        :param timestamp: If None, the first timestamp of the timeseries
                           is used.
-        :return: A SplitKey object.
+        :return: A SplitKey object or None if the timeseries is empty.
         """
         if timestamp is None:
             timestamp = self.first
+            if timestamp is None:
+                return
         return SplitKey.from_timestamp_and_sampling(
             timestamp, self.sampling)
 

--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -291,8 +291,7 @@ class StorageDriver(object):
         return ts
 
     def _store_timeserie_splits(self, metric, keys_and_splits,
-                                aggregation, oldest_mutable_timestamp,
-                                oldest_point_to_keep):
+                                aggregation, oldest_mutable_timestamp):
         keys_to_rewrite = []
         splits_to_rewrite = []
         for key, split in six.iteritems(keys_and_splits):
@@ -338,9 +337,6 @@ class StorageDriver(object):
                             aggregation, key)
                 continue
 
-            if oldest_point_to_keep is not None:
-                split.truncate(oldest_point_to_keep)
-
             offset, data = split.serialize(
                 key, compressed=key in keys_to_rewrite)
             key_data_offset.append((key, data, offset))
@@ -365,11 +361,11 @@ class StorageDriver(object):
         )
 
         if aggregation.timespan:
-            oldest_point_to_keep = ts.last - aggregation.timespan
-            oldest_key_to_keep = ts.get_split_key(oldest_point_to_keep)
+            oldest_point_to_keep = ts.truncate(aggregation.timespan)
         else:
             oldest_point_to_keep = None
-            oldest_key_to_keep = None
+
+        oldest_key_to_keep = ts.get_split_key(oldest_point_to_keep)
 
         keys_and_split_to_store = {}
 
@@ -419,7 +415,7 @@ class StorageDriver(object):
                             keys_and_split_to_store[key] = None
 
         for key, split in ts.split():
-            if oldest_key_to_keep is None or key >= oldest_key_to_keep:
+            if key >= oldest_key_to_keep:
                 LOG.debug(
                     "Storing split %s (%s) for metric %s",
                     key, aggregation.method, metric)
@@ -427,7 +423,7 @@ class StorageDriver(object):
 
         self._store_timeserie_splits(
             metric, keys_and_split_to_store, aggregation.method,
-            oldest_mutable_timestamp, oldest_point_to_keep)
+            oldest_mutable_timestamp)
 
     @staticmethod
     def _delete_metric(metric):


### PR DESCRIPTION
There's no reason to truncate each split if we truncate the AggregatedTimeSerie
once and for all before splitting it.