### PR TITLE
storage: do not return empty data set on non-existing metric

### DIFF
--- a/gnocchi/rest/aggregates/processor.py
+++ b/gnocchi/rest/aggregates/processor.py
@@ -52,11 +52,16 @@ class MetricReference(object):
 
 
 def _get_measures_timeserie(storage, ref, granularity, *args, **kwargs):
-    return (ref, storage._get_measures_timeserie(
-        ref.metric,
-        ref.metric.archive_policy.get_aggregation(
-            ref.aggregation, granularity),
-        *args, **kwargs))
+    try:
+        data = storage._get_measures_timeserie(
+            ref.metric,
+            ref.metric.archive_policy.get_aggregation(
+                ref.aggregation, granularity),
+            *args, **kwargs)
+    except gnocchi_storage.MetricDoesNotExist:
+        data = carbonara.AggregatedTimeSerie(
+            carbonara.Aggregation(ref.aggregation, granularity, None))
+    return (ref, data)
 
 
 def get_measures(storage, references, operations,

--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -250,11 +250,7 @@ class StorageDriver(object):
 
     def _get_measures_timeserie(self, metric, aggregation,
                                 from_timestamp=None, to_timestamp=None):
-        try:
-            all_keys = self._list_split_keys(
-                metric, [aggregation])[aggregation]
-        except MetricDoesNotExist:
-            return carbonara.AggregatedTimeSerie(aggregation)
+        all_keys = self._list_split_keys(metric, [aggregation])[aggregation]
 
         if from_timestamp:
             from_timestamp = carbonara.SplitKey.from_timestamp_and_sampling(
@@ -534,8 +530,11 @@ class StorageDriver(object):
         if agg is None:
             raise AggregationDoesNotExist(metric, aggregation, granularity)
 
-        timeserie = self._get_measures_timeserie(
-            metric, agg, from_timestamp, to_timestamp)
+        try:
+            timeserie = self._get_measures_timeserie(
+                metric, agg, from_timestamp, to_timestamp)
+        except MetricDoesNotExist:
+            return []
         values = timeserie.fetch(from_timestamp, to_timestamp)
         return [(timestamp, granularity, value)
                 for timestamp, value in values

--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -143,8 +143,9 @@ class TestStorageDriver(tests_base.TestCase):
             self.metric.archive_policy.get_aggregations_for_method("mean")
         )
 
-        self.assertEqual({"mean": []}, self.storage.get_measures(
-            self.metric, aggregations))
+        self.assertRaises(storage.MetricDoesNotExist,
+                          self.storage.get_measures,
+                          self.metric, aggregations)
         self.assertEqual(
             {self.metric: None},
             self.storage._get_or_create_unaggregated_timeseries([self.metric]))
@@ -897,8 +898,10 @@ class TestStorageDriver(tests_base.TestCase):
             self.metric.archive_policy.get_aggregations_for_method("last")
         )
 
-        self.assertEqual(
-            {"last": []}, self.storage.get_measures(self.metric, aggregations))
+        self.assertRaises(
+            storage.MetricDoesNotExist,
+            self.storage.get_measures,
+            self.metric, aggregations)
 
     def test_find_measures(self):
         metric2, __ = self._create_metric()
@@ -1009,13 +1012,13 @@ class TestStorageDriver(tests_base.TestCase):
         """https://github.com/gnocchixyz/gnocchi/issues/69"""
         aggregation = self.metric.archive_policy.get_aggregation(
             "mean", numpy.timedelta64(300, 's'))
-        self.assertEqual({"mean": []},
-                         self.storage.get_measures(
-                             self.metric,
-                             [aggregation],
-                             datetime64(2014, 1, 1),
-                             datetime64(2015, 1, 1),
-                             resample=numpy.timedelta64(1, 'h')))
+        self.assertRaises(storage.MetricDoesNotExist,
+                          self.storage.get_measures,
+                          self.metric,
+                          [aggregation],
+                          datetime64(2014, 1, 1),
+                          datetime64(2015, 1, 1),
+                          resample=numpy.timedelta64(1, 'h'))
 
 
 class TestMeasureQuery(tests_base.TestCase):


### PR DESCRIPTION
This decision is now available for the upper layer.