### PR TITLE
Set minimal setuptools version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,5 @@
 import setuptools
 
 setuptools.setup(
-    setup_requires=['pbr'],
+    setup_requires=['pbr', 'setuptools>=20.6.8'],
     pbr=True)

--- a/tox.ini
+++ b/tox.ini
@@ -143,9 +143,7 @@ basepython = python2.7
 whitelist_externals = bash rm
 setenv = GNOCCHI_STORAGE_DEPS=file
          GNOCCHI_TEST_DEBUG=1
-deps = -U
-       setuptools>=22.0
-       {[testenv:docs]deps}
+deps = {[testenv:docs]deps}
        sphinxcontrib-versioning
 # for <= 4.2 doc
        scipy


### PR DESCRIPTION
We use environment marker in requirement so we need at least
setuptools 20.6.8.

This must be a setup_requires because pbr use setuptools to read the
requirement.