### PR TITLE
doc: don't build sdist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 minversion = 2.4
 envlist = py{35,27}-{postgresql,mysql}{,-file,-swift,-ceph,-s3},pep8
+skipsdist = True
 
 [testenv]
 skip_install = True


### PR DESCRIPTION
By default tox built a sdist with the python OS packages. We already
skip install/develop phase and manually use "pip install -e"
The sdist is useless and removing it allow to run tox on old OS
that doesn't have a recent setuptools.