### PR TITLE
storage: allow to pass different aggregations to measures retrieval functions

### DIFF
--- a/gnocchi/storage/ceph.py
+++ b/gnocchi/storage/ceph.py
@@ -85,7 +85,8 @@ class CephStorage(storage.StorageDriver):
                              aggregation, version=3):
         with rados.WriteOpCtx() as op:
             for key, data, offset in keys_and_data_and_offset:
-                name = self._get_object_name(metric, key, aggregation, version)
+                name = self._get_object_name(
+                    metric, key, aggregation.method, version)
                 if offset is None:
                     self.ioctx.write_full(name, data)
                 else:
@@ -146,13 +147,14 @@ class CephStorage(storage.StorageDriver):
 
     def _get_measures_unbatched(self, metric, key, aggregation, version=3):
         try:
-            name = self._get_object_name(metric, key, aggregation, version)
+            name = self._get_object_name(
+                metric, key, aggregation.method, version)
             return self._get_object_content(name)
         except rados.ObjectNotFound:
             if self._object_exists(
                     self._build_unaggregated_timeserie_path(metric, 3)):
                 raise storage.AggregationDoesNotExist(
-                    metric, aggregation, key.sampling)
+                    metric, aggregation.method, key.sampling)
             else:
                 raise storage.MetricDoesNotExist(metric)
 

--- a/gnocchi/storage/file.py
+++ b/gnocchi/storage/file.py
@@ -168,7 +168,7 @@ class FileStorage(storage.StorageDriver):
         for key, data, offset in keys_and_data_and_offset:
             self._atomic_file_store(
                 self._build_metric_path_for_split(
-                    metric, aggregation, key, version),
+                    metric, aggregation.method, key, version),
                 data)
 
     def _delete_metric(self, metric):
@@ -183,7 +183,7 @@ class FileStorage(storage.StorageDriver):
 
     def _get_measures_unbatched(self, metric, key, aggregation, version=3):
         path = self._build_metric_path_for_split(
-            metric, aggregation, key, version)
+            metric, aggregation.method, key, version)
         try:
             with open(path, 'rb') as aggregation_file:
                 return aggregation_file.read()

--- a/gnocchi/storage/s3.py
+++ b/gnocchi/storage/s3.py
@@ -126,7 +126,7 @@ class S3Storage(storage.StorageDriver):
             self._put_object_safe(
                 Bucket=self._bucket_name,
                 Key=self._prefix(metric) + self._object_name(
-                    key, aggregation, version),
+                    key, aggregation.method, version),
                 Body=data)
 
     def _delete_metric_splits_unbatched(self, metric, key, aggregation,
@@ -162,12 +162,12 @@ class S3Storage(storage.StorageDriver):
             response = self.s3.get_object(
                 Bucket=self._bucket_name,
                 Key=self._prefix(metric) + self._object_name(
-                    key, aggregation, version))
+                    key, aggregation.method, version))
         except botocore.exceptions.ClientError as e:
             if e.response['Error'].get('Code') == 'NoSuchKey':
                 if self._metric_exists_p(metric, version):
                     raise storage.AggregationDoesNotExist(
-                        metric, aggregation, key.sampling)
+                        metric, aggregation.method, key.sampling)
                 raise storage.MetricDoesNotExist(metric)
             raise
         return response['Body'].read()

--- a/gnocchi/storage/swift.py
+++ b/gnocchi/storage/swift.py
@@ -121,7 +121,7 @@ class SwiftStorage(storage.StorageDriver):
         for key, data, offset in keys_and_data_and_offset:
             self.swift.put_object(
                 self._container_name(metric),
-                self._object_name(key, aggregation, version),
+                self._object_name(key, aggregation.method, version),
                 data)
 
     def _delete_metric_splits_unbatched(
@@ -152,7 +152,7 @@ class SwiftStorage(storage.StorageDriver):
         try:
             headers, contents = self.swift.get_object(
                 self._container_name(metric), self._object_name(
-                    key, aggregation, version))
+                    key, aggregation.method, version))
         except swclient.ClientException as e:
             if e.http_status == 404:
                 try:
@@ -162,7 +162,7 @@ class SwiftStorage(storage.StorageDriver):
                         raise storage.MetricDoesNotExist(metric)
                     raise
                 raise storage.AggregationDoesNotExist(
-                    metric, aggregation, key.sampling)
+                    metric, aggregation.method, key.sampling)
             raise
         return contents
 

--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -225,7 +225,7 @@ class TestStorageDriver(tests_base.TestCase):
             # policy is 60 points and split is 48. should only update 2nd half
             args = call[1]
             if (args[0] == m_sql
-               and args[2] == 'mean'
+               and args[2].method == 'mean'
                and args[1][0][0].sampling == numpy.timedelta64(1, 'm')):
                 count += 1
         self.assertEqual(1, count)
@@ -343,28 +343,28 @@ class TestStorageDriver(tests_base.TestCase):
         else:
             assertCompressedIfWriteFull = self.assertFalse
 
-        data = self.storage._get_measures(
-            self.metric, [carbonara.SplitKey(
-                numpy.datetime64(1451520000, 's'),
-                numpy.timedelta64(1, 'm'),
-            )], "mean")[0]
-        self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
-        data = self.storage._get_measures(
-            self.metric, [carbonara.SplitKey(
-                numpy.datetime64(1451736000, 's'),
-                numpy.timedelta64(60, 's'),
-            )], "mean")[0]
-        self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
-        data = self.storage._get_measures(
-            self.metric, [carbonara.SplitKey(
-                numpy.datetime64(1451952000, 's'),
-                numpy.timedelta64(60, 's'),
-            )], "mean")[0]
-        assertCompressedIfWriteFull(
-            carbonara.AggregatedTimeSerie.is_compressed(data))
-
         aggregation = self.metric.archive_policy.get_aggregation(
             "mean", numpy.timedelta64(1, 'm'))
+
+        data = self.storage._get_measures(
+            self.metric, [(carbonara.SplitKey(
+                numpy.datetime64(1451520000, 's'),
+                numpy.timedelta64(1, 'm'),
+            ), aggregation)])[0]
+        self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
+        data = self.storage._get_measures(
+            self.metric, [(carbonara.SplitKey(
+                numpy.datetime64(1451736000, 's'),
+                numpy.timedelta64(60, 's'),
+            ), aggregation)])[0]
+        self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
+        data = self.storage._get_measures(
+            self.metric, [(carbonara.SplitKey(
+                numpy.datetime64(1451952000, 's'),
+                numpy.timedelta64(60, 's'),
+            ), aggregation)])[0]
+        assertCompressedIfWriteFull(
+            carbonara.AggregatedTimeSerie.is_compressed(data))
 
         self.assertEqual({"mean": [
             (datetime64(2016, 1, 1, 12), numpy.timedelta64(1, 'm'), 69),
@@ -398,29 +398,29 @@ class TestStorageDriver(tests_base.TestCase):
             },
         }, self.storage._list_split_keys(self.metric, [agg]))
         data = self.storage._get_measures(
-            self.metric, [carbonara.SplitKey(
+            self.metric, [(carbonara.SplitKey(
                 numpy.datetime64(1451520000, 's'),
                 numpy.timedelta64(60, 's'),
-            )], "mean")[0]
+            ), aggregation)])[0]
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, [carbonara.SplitKey(
+            self.metric, [(carbonara.SplitKey(
                 numpy.datetime64(1451736000, 's'),
                 numpy.timedelta64(60, 's'),
-            )], "mean")[0]
+            ), aggregation)])[0]
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, [carbonara.SplitKey(
+            self.metric, [(carbonara.SplitKey(
                 numpy.datetime64(1451952000, 's'),
                 numpy.timedelta64(1, 'm'),
-            )], "mean")[0]
+            ), aggregation)])[0]
         # Now this one is compressed because it has been rewritten!
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, [carbonara.SplitKey(
+            self.metric, [(carbonara.SplitKey(
                 numpy.datetime64(1452384000, 's'),
                 numpy.timedelta64(60, 's'),
-            )], "mean")[0]
+            ), aggregation)])[0]
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
@@ -471,28 +471,28 @@ class TestStorageDriver(tests_base.TestCase):
         else:
             assertCompressedIfWriteFull = self.assertFalse
 
-        data = self.storage._get_measures(
-            self.metric, [carbonara.SplitKey(
-                numpy.datetime64(1451520000, 's'),
-                numpy.timedelta64(1, 'm'),
-            )], "mean")[0]
-        self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
-        data = self.storage._get_measures(
-            self.metric, [carbonara.SplitKey(
-                numpy.datetime64(1451736000, 's'),
-                numpy.timedelta64(1, 'm'),
-            )], "mean")[0]
-        self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
-        data = self.storage._get_measures(
-            self.metric, [carbonara.SplitKey(
-                numpy.datetime64(1451952000, 's'),
-                numpy.timedelta64(1, 'm')
-            )], "mean")[0]
-        assertCompressedIfWriteFull(
-            carbonara.AggregatedTimeSerie.is_compressed(data))
-
         aggregation = self.metric.archive_policy.get_aggregation(
             "mean", numpy.timedelta64(1, 'm'))
+
+        data = self.storage._get_measures(
+            self.metric, [(carbonara.SplitKey(
+                numpy.datetime64(1451520000, 's'),
+                numpy.timedelta64(1, 'm'),
+            ), aggregation)])[0]
+        self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
+        data = self.storage._get_measures(
+            self.metric, [(carbonara.SplitKey(
+                numpy.datetime64(1451736000, 's'),
+                numpy.timedelta64(1, 'm'),
+            ), aggregation)])[0]
+        self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
+        data = self.storage._get_measures(
+            self.metric, [(carbonara.SplitKey(
+                numpy.datetime64(1451952000, 's'),
+                numpy.timedelta64(1, 'm')
+            ), aggregation)])[0]
+        assertCompressedIfWriteFull(
+            carbonara.AggregatedTimeSerie.is_compressed(data))
 
         self.assertEqual({"mean": [
             (datetime64(2016, 1, 1, 12), numpy.timedelta64(1, 'm'), 69),
@@ -528,29 +528,29 @@ class TestStorageDriver(tests_base.TestCase):
             }
         }, self.storage._list_split_keys(self.metric, [agg]))
         data = self.storage._get_measures(
-            self.metric, [carbonara.SplitKey(
+            self.metric, [(carbonara.SplitKey(
                 numpy.datetime64(1451520000, 's'),
                 numpy.timedelta64(1, 'm'),
-            )], "mean")[0]
+            ), agg)])[0]
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, [carbonara.SplitKey(
+            self.metric, [(carbonara.SplitKey(
                 numpy.datetime64(1451736000, 's'),
                 numpy.timedelta64(1, 'm'),
-            )], "mean")[0]
+            ), agg)])[0]
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, [carbonara.SplitKey(
+            self.metric, [(carbonara.SplitKey(
                 numpy.datetime64(1451952000, 's'),
                 numpy.timedelta64(60, 's')
-            )], "mean")[0]
+            ), agg)])[0]
         # Now this one is compressed because it has been rewritten!
         self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
         data = self.storage._get_measures(
-            self.metric, [carbonara.SplitKey(
+            self.metric, [(carbonara.SplitKey(
                 numpy.datetime64(1452384000, 's'),
                 numpy.timedelta64(1, 'm'),
-            )], "mean")[0]
+            ), agg)])[0]
         assertCompressedIfWriteFull(
             carbonara.AggregatedTimeSerie.is_compressed(data))
 
@@ -601,29 +601,29 @@ class TestStorageDriver(tests_base.TestCase):
         else:
             assertCompressedIfWriteFull = self.assertFalse
 
-        data = self.storage._get_measures(
-            self.metric,
-            [carbonara.SplitKey(
-                numpy.datetime64(1451520000, 's'),
-                numpy.timedelta64(1, 'm'),
-            )], "mean")[0]
-        self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
-        data = self.storage._get_measures(
-            self.metric, [carbonara.SplitKey(
-                numpy.datetime64(1451736000, 's'),
-                numpy.timedelta64(1, 'm')
-            )], "mean")[0]
-        self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
-        data = self.storage._get_measures(
-            self.metric, [carbonara.SplitKey(
-                numpy.datetime64(1451952000, 's'),
-                numpy.timedelta64(1, 'm'),
-            )], "mean")[0]
-        assertCompressedIfWriteFull(
-            carbonara.AggregatedTimeSerie.is_compressed(data))
-
         aggregation = self.metric.archive_policy.get_aggregation(
             "mean", numpy.timedelta64(1, 'm'))
+
+        data = self.storage._get_measures(
+            self.metric,
+            [(carbonara.SplitKey(
+                numpy.datetime64(1451520000, 's'),
+                numpy.timedelta64(1, 'm'),
+            ), aggregation)])[0]
+        self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
+        data = self.storage._get_measures(
+            self.metric, [(carbonara.SplitKey(
+                numpy.datetime64(1451736000, 's'),
+                numpy.timedelta64(1, 'm')
+            ), aggregation)])[0]
+        self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
+        data = self.storage._get_measures(
+            self.metric, [(carbonara.SplitKey(
+                numpy.datetime64(1451952000, 's'),
+                numpy.timedelta64(1, 'm'),
+            ), aggregation)])[0]
+        assertCompressedIfWriteFull(
+            carbonara.AggregatedTimeSerie.is_compressed(data))
 
         self.assertEqual({"mean": [
             (datetime64(2016, 1, 1, 12),
@@ -691,28 +691,28 @@ class TestStorageDriver(tests_base.TestCase):
         else:
             assertCompressedIfWriteFull = self.assertFalse
 
-        data = self.storage._get_measures(
-            self.metric, [carbonara.SplitKey(
-                numpy.datetime64(1451520000, 's'),
-                numpy.timedelta64(60, 's'),
-            )], "mean")[0]
-        self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
-        data = self.storage._get_measures(
-            self.metric, [carbonara.SplitKey(
-                numpy.datetime64(1451736000, 's'),
-                numpy.timedelta64(1, 'm'),
-            )], "mean")[0]
-        self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
-        data = self.storage._get_measures(
-            self.metric, [carbonara.SplitKey(
-                numpy.datetime64(1451952000, 's'),
-                numpy.timedelta64(1, 'm'),
-            )], "mean")[0]
-        assertCompressedIfWriteFull(
-            carbonara.AggregatedTimeSerie.is_compressed(data))
-
         aggregation = self.metric.archive_policy.get_aggregation(
             "mean", numpy.timedelta64(1, 'm'))
+
+        data = self.storage._get_measures(
+            self.metric, [(carbonara.SplitKey(
+                numpy.datetime64(1451520000, 's'),
+                numpy.timedelta64(60, 's'),
+            ), aggregation)])[0]
+        self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
+        data = self.storage._get_measures(
+            self.metric, [(carbonara.SplitKey(
+                numpy.datetime64(1451736000, 's'),
+                numpy.timedelta64(1, 'm'),
+            ), aggregation)])[0]
+        self.assertTrue(carbonara.AggregatedTimeSerie.is_compressed(data))
+        data = self.storage._get_measures(
+            self.metric, [(carbonara.SplitKey(
+                numpy.datetime64(1451952000, 's'),
+                numpy.timedelta64(1, 'm'),
+            ), aggregation)])[0]
+        assertCompressedIfWriteFull(
+            carbonara.AggregatedTimeSerie.is_compressed(data))
 
         self.assertEqual({"mean": [
             (datetime64(2016, 1, 1, 12), numpy.timedelta64(1, 'm'), 69),
@@ -728,7 +728,7 @@ class TestStorageDriver(tests_base.TestCase):
                     numpy.datetime64(1451952000, 's'),
                     numpy.timedelta64(1, 'm')),
                  b"oh really?", None)
-            ], "mean")
+            ], aggregation)
 
         # Now store brand new points that should force a rewrite of one of the
         # split (keep in mind the back window size in one hour here). We move


### PR DESCRIPTION
The list of keys passed as argument now embeds also its companion Aggregation
object so it'll be possible to retrieve splits from different aggregations in
one single call.