### PR TITLE
storage: stop raising AggregationDoesNotExist on measures retrieval

### DIFF
--- a/gnocchi/storage/ceph.py
+++ b/gnocchi/storage/ceph.py
@@ -153,10 +153,8 @@ class CephStorage(storage.StorageDriver):
         except rados.ObjectNotFound:
             if self._object_exists(
                     self._build_unaggregated_timeserie_path(metric, 3)):
-                raise storage.AggregationDoesNotExist(
-                    metric, aggregation.method, key.sampling)
-            else:
-                raise storage.MetricDoesNotExist(metric)
+                return
+            raise storage.MetricDoesNotExist(metric)
 
     def _list_split_keys(self, metric, aggregations, version=3):
         with rados.ReadOpCtx() as op:

--- a/gnocchi/storage/file.py
+++ b/gnocchi/storage/file.py
@@ -190,7 +190,6 @@ class FileStorage(storage.StorageDriver):
         except IOError as e:
             if e.errno == errno.ENOENT:
                 if os.path.exists(self._build_metric_dir(metric)):
-                    raise storage.AggregationDoesNotExist(
-                        metric, aggregation, key.sampling)
+                    return
                 raise storage.MetricDoesNotExist(metric)
             raise

--- a/gnocchi/storage/s3.py
+++ b/gnocchi/storage/s3.py
@@ -166,8 +166,7 @@ class S3Storage(storage.StorageDriver):
         except botocore.exceptions.ClientError as e:
             if e.response['Error'].get('Code') == 'NoSuchKey':
                 if self._metric_exists_p(metric, version):
-                    raise storage.AggregationDoesNotExist(
-                        metric, aggregation.method, key.sampling)
+                    return
                 raise storage.MetricDoesNotExist(metric)
             raise
         return response['Body'].read()

--- a/gnocchi/storage/swift.py
+++ b/gnocchi/storage/swift.py
@@ -161,8 +161,7 @@ class SwiftStorage(storage.StorageDriver):
                     if e.http_status == 404:
                         raise storage.MetricDoesNotExist(metric)
                     raise
-                raise storage.AggregationDoesNotExist(
-                    metric, aggregation.method, key.sampling)
+                return
             raise
         return contents
 


### PR DESCRIPTION
Raising an exception at this point is damageable as when multiple SplitKeys are
being fetched at the same time, only one being absent will cancel the call. The
caller is already solid and know show to handle None as a return value so just
use None to indicate the split is non-existing.