### PR TITLE
storage: remove metric existence check when retrieving splits

### DIFF
--- a/gnocchi/storage/ceph.py
+++ b/gnocchi/storage/ceph.py
@@ -151,10 +151,7 @@ class CephStorage(storage.StorageDriver):
                 metric, key, aggregation.method, version)
             return self._get_object_content(name)
         except rados.ObjectNotFound:
-            if self._object_exists(
-                    self._build_unaggregated_timeserie_path(metric, 3)):
-                return
-            raise storage.MetricDoesNotExist(metric)
+            return
 
     def _list_split_keys(self, metric, aggregations, version=3):
         with rados.ReadOpCtx() as op:

--- a/gnocchi/storage/file.py
+++ b/gnocchi/storage/file.py
@@ -189,7 +189,5 @@ class FileStorage(storage.StorageDriver):
                 return aggregation_file.read()
         except IOError as e:
             if e.errno == errno.ENOENT:
-                if os.path.exists(self._build_metric_dir(metric)):
-                    return
-                raise storage.MetricDoesNotExist(metric)
+                return
             raise

--- a/gnocchi/storage/s3.py
+++ b/gnocchi/storage/s3.py
@@ -165,9 +165,7 @@ class S3Storage(storage.StorageDriver):
                     key, aggregation.method, version))
         except botocore.exceptions.ClientError as e:
             if e.response['Error'].get('Code') == 'NoSuchKey':
-                if self._metric_exists_p(metric, version):
-                    return
-                raise storage.MetricDoesNotExist(metric)
+                return
             raise
         return response['Body'].read()
 

--- a/gnocchi/storage/swift.py
+++ b/gnocchi/storage/swift.py
@@ -155,12 +155,6 @@ class SwiftStorage(storage.StorageDriver):
                     key, aggregation.method, version))
         except swclient.ClientException as e:
             if e.http_status == 404:
-                try:
-                    self.swift.head_container(self._container_name(metric))
-                except swclient.ClientException as e:
-                    if e.http_status == 404:
-                        raise storage.MetricDoesNotExist(metric)
-                    raise
                 return
             raise
         return contents

--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -306,6 +306,79 @@ class TestStorageDriver(tests_base.TestCase):
             self.metric, [agg],
         ))
 
+    def test_get_measures_return(self):
+        self.incoming.add_measures(self.metric.id, [
+            incoming.Measure(datetime64(2016, 1, 1, 12, 0, 1), 69),
+            incoming.Measure(datetime64(2016, 1, 2, 13, 7, 31), 42),
+            incoming.Measure(datetime64(2016, 1, 4, 14, 9, 31), 4),
+            incoming.Measure(datetime64(2016, 1, 6, 15, 12, 45), 44),
+        ])
+        self.trigger_processing()
+
+        aggregation = self.metric.archive_policy.get_aggregation(
+            "mean", numpy.timedelta64(5, 'm'))
+
+        data = self.storage._get_measures(
+            self.metric, [(carbonara.SplitKey(
+                numpy.datetime64(1451520000, 's'),
+                numpy.timedelta64(5, 'm'),
+            ), aggregation)])
+        self.assertEqual(1, len(data))
+        self.assertIsInstance(data[0], bytes)
+        self.assertGreater(len(data[0]), 0)
+        existing = data[0]
+
+        # Now retrieve an existing and a non-existing key
+        data = self.storage._get_measures(
+            self.metric, [
+                (carbonara.SplitKey(
+                    numpy.datetime64(1451520000, 's'),
+                    numpy.timedelta64(5, 'm'),
+                ), aggregation),
+                (carbonara.SplitKey(
+                    numpy.datetime64(1451520010, 's'),
+                    numpy.timedelta64(5, 'm'),
+                ), aggregation),
+            ])
+        self.assertEqual(2, len(data))
+        self.assertIsInstance(data[0], bytes)
+        self.assertGreater(len(data[0]), 0)
+        self.assertEqual(existing, data[0])
+        self.assertIsNone(data[1])
+
+        # Now retrieve a non-existing and an existing key
+        data = self.storage._get_measures(
+            self.metric, [
+                (carbonara.SplitKey(
+                    numpy.datetime64(155152000, 's'),
+                    numpy.timedelta64(5, 'm'),
+                ), aggregation),
+                (carbonara.SplitKey(
+                    numpy.datetime64(1451520000, 's'),
+                    numpy.timedelta64(5, 'm'),
+                ), aggregation),
+            ])
+        self.assertEqual(2, len(data))
+        self.assertIsInstance(data[1], bytes)
+        self.assertGreater(len(data[1]), 0)
+        self.assertEqual(existing, data[1])
+        self.assertIsNone(data[0])
+
+        m2, _ = self._create_metric()
+        # Now retrieve a non-existing (= no aggregated measures) metric
+        data = self.storage._get_measures(
+            m2, [
+                (carbonara.SplitKey(
+                    numpy.datetime64(1451520010, 's'),
+                    numpy.timedelta64(5, 'm'),
+                ), aggregation),
+                (carbonara.SplitKey(
+                    numpy.datetime64(1451520000, 's'),
+                    numpy.timedelta64(5, 'm'),
+                ), aggregation),
+            ])
+        self.assertEqual([None, None], data)
+
     def test_rewrite_measures(self):
         # Create an archive policy that spans on several splits. Each split
         # being 3600 points, let's go for 36k points so we have 10 splits.


### PR DESCRIPTION
Splits are either retrieve for reading from:

- the REST API, where the splits are actually listed before being retrieved, we
  don't care about the metric existence or not, None is enough.

- on rewriting the split (WRITE_FULL) and in that case we know the metric
  exists