### PR TITLE
storage: _add_measures can handle multiple aggregations at the same time

### DIFF
--- a/gnocchi/storage/file.py
+++ b/gnocchi/storage/file.py
@@ -161,11 +161,11 @@ class FileStorage(storage.StorageDriver):
     def _delete_metric_splits_unbatched(
             self, metric, key, aggregation, version=3):
         os.unlink(self._build_metric_path_for_split(
-            metric, aggregation, key, version))
+            metric, aggregation.method, key, version))
 
-    def _store_metric_splits(self, metric, keys_and_data_and_offset,
-                             aggregation, version=3):
-        for key, data, offset in keys_and_data_and_offset:
+    def _store_metric_splits(self, metric, keys_aggregations_data_offset,
+                             version=3):
+        for key, aggregation, data, offset in keys_aggregations_data_offset:
             self._atomic_file_store(
                 self._build_metric_path_for_split(
                     metric, aggregation.method, key, version),

--- a/gnocchi/storage/redis.py
+++ b/gnocchi/storage/redis.py
@@ -126,19 +126,19 @@ return ids
             }
         return keys
 
-    def _delete_metric_splits(self, metric, keys, aggregation, version=3):
+    def _delete_metric_splits(self, metric, keys_and_aggregations, version=3):
         metric_key = self._metric_key(metric)
         pipe = self._client.pipeline(transaction=False)
-        for key in keys:
+        for key, aggregation in keys_and_aggregations:
             pipe.hdel(metric_key, self._aggregated_field_for_split(
-                aggregation, key, version))
+                aggregation.method, key, version))
         pipe.execute()
 
-    def _store_metric_splits(self, metric, keys_and_data_and_offset,
-                             aggregation, version=3):
+    def _store_metric_splits(self, metric, keys_aggregations_data_offset,
+                             version=3):
         pipe = self._client.pipeline(transaction=False)
         metric_key = self._metric_key(metric)
-        for key, data, offset in keys_and_data_and_offset:
+        for key, aggregation, data, offset in keys_aggregations_data_offset:
             key = self._aggregated_field_for_split(
                 aggregation.method, key, version)
             pipe.hset(metric_key, key, data)

--- a/gnocchi/storage/s3.py
+++ b/gnocchi/storage/s3.py
@@ -120,9 +120,9 @@ class S3Storage(storage.StorageDriver):
                 wait=self._consistency_wait,
                 stop=self._consistency_stop)(_head)
 
-    def _store_metric_splits(self, metric, keys_and_data_and_offset,
-                             aggregation, version=3):
-        for key, data, offset in keys_and_data_and_offset:
+    def _store_metric_splits(self, metric, keys_aggregations_data_offset,
+                             version=3):
+        for key, aggregation, data, offset in keys_aggregations_data_offset:
             self._put_object_safe(
                 Bucket=self._bucket_name,
                 Key=self._prefix(metric) + self._object_name(
@@ -134,7 +134,7 @@ class S3Storage(storage.StorageDriver):
         self.s3.delete_object(
             Bucket=self._bucket_name,
             Key=self._prefix(metric) + self._object_name(
-                key, aggregation, version))
+                key, aggregation.method, version))
 
     def _delete_metric(self, metric):
         bucket = self._bucket_name

--- a/gnocchi/storage/swift.py
+++ b/gnocchi/storage/swift.py
@@ -116,9 +116,9 @@ class SwiftStorage(storage.StorageDriver):
         if resp['status'] == 204:
             raise storage.MetricAlreadyExists(metric)
 
-    def _store_metric_splits(self, metric, keys_and_data_and_offset,
-                             aggregation, version=3):
-        for key, data, offset in keys_and_data_and_offset:
+    def _store_metric_splits(self, metric, keys_aggregations_data_offset,
+                             version=3):
+        for key, aggregation, data, offset in keys_aggregations_data_offset:
             self.swift.put_object(
                 self._container_name(metric),
                 self._object_name(key, aggregation.method, version),
@@ -128,7 +128,7 @@ class SwiftStorage(storage.StorageDriver):
             self, metric, key, aggregation, version=3):
         self.swift.delete_object(
             self._container_name(metric),
-            self._object_name(key, aggregation, version))
+            self._object_name(key, aggregation.method, version))
 
     def _delete_metric(self, metric):
         container = self._container_name(metric)


### PR DESCRIPTION
This allows to batch storage and deletion of splits for a metric.