### PR TITLE
storage: fix corruption scenario

### DIFF
--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -273,8 +273,8 @@ class StorageDriver(object):
                           "aggregated `%s' timeserie, granularity `%s' "
                           "around time `%s', ignoring.",
                           metric.id, aggregation.method, key.sampling, key)
-            else:
-                results.append(ts)
+                ts = carbonara.AggregatedTimeSerie(aggregation)
+            results.append(ts)
         return results
 
     def _get_measures_timeserie(self, metric, aggregation, keys,

--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -65,6 +65,31 @@ class TestStorageDriver(tests_base.TestCase):
         driver = storage.get_driver(self.conf)
         self.assertIsInstance(driver, storage.StorageDriver)
 
+    def test_corrupted_split(self):
+        self.incoming.add_measures(self.metric.id, [
+            incoming.Measure(datetime64(2014, 1, 1, 12, 0, 1), 69),
+        ])
+        self.trigger_processing()
+
+        aggregation = self.metric.archive_policy.get_aggregation(
+            "mean", numpy.timedelta64(5, 'm'))
+
+        with mock.patch('gnocchi.carbonara.AggregatedTimeSerie.unserialize',
+                        side_effect=carbonara.InvalidData()):
+            results = self.storage._get_splits_and_unserialize(
+                self.metric,
+                [
+                    (carbonara.SplitKey(
+                        numpy.datetime64(1387800000, 's'),
+                        numpy.timedelta64(5, 'm')),
+                     aggregation)
+                ])
+            self.assertEqual(1, len(results))
+            self.assertIsInstance(results[0], carbonara.AggregatedTimeSerie)
+            # Assert it's an empty one since corrupted
+            self.assertEqual(0, len(results[0]))
+            self.assertEqual(results[0].aggregation, aggregation)
+
     def test_corrupted_data(self):
         self.incoming.add_measures(self.metric.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 1), 69),


### PR DESCRIPTION
If data corruption occurs, the _get_splits_and_unserialize() method might not
return the same number of arguments that it received. It's not a big deal when
concatenating the splits to retrieve the data for reading. However, when
requesting a bunch of splits for rewrite, that's a problem because the list is
zipped with other data on iteration, possibly corrupting the results.