### PR TITLE
ceph: fix unprocessed measures deletion

### DIFF
--- a/gnocchi/storage/incoming/ceph.py
+++ b/gnocchi/storage/incoming/ceph.py
@@ -149,7 +149,7 @@ class CephStorage(_carbonara.CarbonaraBasedStorage):
 
     def delete_unprocessed_measures_for_metric_id(self, metric_id):
         object_prefix = self.MEASURE_PREFIX + "_" + str(metric_id)
-        object_names = self._list_object_names_to_process(object_prefix)
+        object_names = list(self._list_object_names_to_process(object_prefix))
         # Now clean objects and omap
         with rados.WriteOpCtx() as op:
             # NOTE(sileht): come on Ceph, no return code


### PR DESCRIPTION
`object_names` is an iterator that is iterated twice, therefore it's empty the
second time and no objects are removed. This patches fixes that.

Source: https://bugzilla.redhat.com/show_bug.cgi?id=1549922