### PR TITLE
incoming: introduce process_measures_for_sack

### DIFF
--- a/gnocchi/cli/metricd.py
+++ b/gnocchi/cli/metricd.py
@@ -237,9 +237,7 @@ class MetricProcessor(MetricProcessBase):
                 continue
 
             try:
-                metrics = self.incoming.list_metric_with_measures_to_process(s)
-                m_count += len(metrics)
-                self.chef.process_new_measures(metrics)
+                m_count += self.chef.process_new_measures_for_sack(s)
                 s_count += 1
                 self.incoming.finish_sack_processing(s)
                 self.sacks_with_measures_to_process.discard(s)

--- a/gnocchi/common/redis.py
+++ b/gnocchi/common/redis.py
@@ -30,6 +30,7 @@ except ImportError:
 from gnocchi import utils
 
 
+SEP_S = ':'
 SEP = b':'
 
 CLIENT_ARGS = frozenset([

--- a/gnocchi/incoming/__init__.py
+++ b/gnocchi/incoming/__init__.py
@@ -212,6 +212,10 @@ class IncomingDriver(object):
         raise exceptions.NotImplementedError
 
     @staticmethod
+    def process_measures_for_sack(sack):
+        raise exceptions.NotImplementedError
+
+    @staticmethod
     def has_unprocessed(metric_id):
         raise exceptions.NotImplementedError
 

--- a/gnocchi/incoming/ceph.py
+++ b/gnocchi/incoming/ceph.py
@@ -13,6 +13,7 @@
 # under the License.
 from collections import defaultdict
 import contextlib
+import daiquiri
 import datetime
 import json
 import uuid
@@ -24,6 +25,8 @@ from gnocchi.common import ceph
 from gnocchi import incoming
 
 rados = ceph.rados
+
+LOG = daiquiri.getLogger(__name__)
 
 
 class CephStorage(incoming.IncomingDriver):
@@ -212,5 +215,33 @@ class CephStorage(incoming.IncomingDriver):
                 # NOTE(sileht): come on Ceph, no return code
                 # for this operation ?!!
                 self.ioctx.remove_omap_keys(op, tuple(keys.keys()))
+                self.ioctx.operate_write_op(op, str(sack),
+                                            flags=self.OMAP_WRITE_FLAGS)
+
+    @contextlib.contextmanager
+    def process_measures_for_sack(self, sack):
+        measures = defaultdict(self._make_measures_array)
+        omaps = self._list_keys_to_process(
+            sack, prefix=self.MEASURE_PREFIX + "_")
+        for k, v in six.iteritems(omaps):
+            try:
+                metric_id = uuid.UUID(k.split("_")[1])
+            except (ValueError, IndexError):
+                LOG.warning("Unable to parse measure object name %s",
+                            k)
+                continue
+            measures[metric_id] = numpy.concatenate(
+                (measures[metric_id], self._unserialize_measures(k, v))
+            )
+
+        yield measures
+
+        # Now clean omap
+        processed_keys = tuple(omaps.keys())
+        if processed_keys:
+            with rados.WriteOpCtx() as op:
+                # NOTE(sileht): come on Ceph, no return code
+                # for this operation ?!!
+                self.ioctx.remove_omap_keys(op, tuple(processed_keys))
                 self.ioctx.operate_write_op(op, str(sack),
                                             flags=self.OMAP_WRITE_FLAGS)

--- a/gnocchi/tests/base.py
+++ b/gnocchi/tests/base.py
@@ -389,5 +389,7 @@ class TestCase(BaseTestCase):
 
     def trigger_processing(self, metrics=None):
         if metrics is None:
-            metrics = [str(self.metric.id)]
-        self.chef.process_new_measures(metrics, sync=True)
+            self.chef.process_new_measures_for_sack(
+                self.incoming.sack_for_metric(self.metric.id), sync=True)
+        else:
+            self.chef.process_new_measures(metrics, sync=True)

--- a/gnocchi/tests/test_chef.py
+++ b/gnocchi/tests/test_chef.py
@@ -41,10 +41,8 @@ class TestChef(base.TestCase):
         self.index.delete_metric(self.metric.id)
         self.trigger_processing()
         __, __, details = self.incoming._build_report(True)
-        self.assertIn(str(self.metric.id), details)
-        self.chef.expunge_metrics(sync=True)
-        __, __, details = self.incoming._build_report(True)
         self.assertNotIn(str(self.metric.id), details)
+        self.chef.expunge_metrics(sync=True)
 
     def test_delete_expunge_metric(self):
         self.incoming.add_measures(self.metric.id, [


### PR DESCRIPTION
This adds a new method process_measures_for_sack to incoming storage driver. It
allows to read an entire sack for new measure rather than individual metrics.
This avoids doing 2 listing to process new metrics and only does one to load
the measures.

The process_new_measures(metrics) is kept for the refresh_metric() use case for
now. Some refactoring might be possible after this patch.

The S3 storage driver is a bit modified to store the incoming measures in
<sack>/<metric>/ rather than <sack><metric>/ so it's easier to list incoming
sacks and metrics.