### PR TITLE
Make the build reproducible

### DIFF
--- a/gnocchi/common/redis.py
+++ b/gnocchi/common/redis.py
@@ -103,7 +103,7 @@ OPTS = [
   - http://redis.io/topics/sentinel
   - http://redis.io/topics/cluster-spec
 
-""" % "`, `".join(CLIENT_ARGS)),
+""" % "`, `".join(sorted(CLIENT_ARGS))),
 ]
 
 


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that gnocchi could not be built reproducibly as it iterates over
a Python set when generating documentation.

This was originally filed in Debian as #892419.

 [0] https://reproducible-builds.org/
 [1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=892419

Signed-off-by: Chris Lamb <lamby@debian.org>