### PR TITLE
storage: more batching of store/delete operations in add_measures

### DIFF
--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -354,9 +354,29 @@ class StorageDriver(object):
 
         return self._store_metric_splits(metric, keys_aggregations_data_offset)
 
-    def _add_measures(self, metric, aggregations, grouped_serie,
-                      previous_oldest_mutable_timestamp,
-                      oldest_mutable_timestamp):
+    def _compute_split_operations(self, metric, aggregations,
+                                  grouped_serie,
+                                  previous_oldest_mutable_timestamp,
+                                  oldest_mutable_timestamp):
+        """Compute changes to a metric and return operations to be done.
+
+        Based on an aggregations list and a grouped timeseries, this computes
+        what needs to be deleted and stored for a metric and returns it.
+
+        :param metric: The metric
+        :param aggregations: The aggregations to compute for
+        :param grouped_serie: A grouped timeseries
+        :param previous_oldest_mutable_timestamp: The previous oldest storable
+                                                  timestamp from the previous
+                                                  backwindow.
+        :param oldest_mutable_timestamp: The current oldest storable timestamp
+                                         from the current backwindow.
+        :return: A tuple (keys_to_delete, keys_to_store) where keys_to_delete
+                 is a set of `carbonara.SplitKey` to delete and where
+                 keys_to_store is a dictionary of the form {key: aggts}
+                 where key is a `carbonara.SplitKey` and aggts a
+                 `carbonara.AggregatedTimeSerie` to be serialized.
+        """
         # We only need to check for rewrite if driver is not in WRITE_FULL mode
         # and if we already stored splits once
         need_rewrite = (
@@ -454,9 +474,7 @@ class StorageDriver(object):
                         key, aggregation.method, metric)
                     keys_and_split_to_store[(key, aggregation)] = split
 
-        self._delete_metric_splits(metric, deleted_keys)
-        self._store_timeserie_splits(
-            metric, keys_and_split_to_store, oldest_mutable_timestamp)
+        return (deleted_keys, keys_and_split_to_store)
 
     @staticmethod
     def _delete_metric(metric):
@@ -524,7 +542,7 @@ class StorageDriver(object):
         # sorry.
         computed_points = {"number": 0}
 
-        def _map_add_measures(bound_timeserie):
+        def _map_compute_splits_operations(bound_timeserie):
             # NOTE (gordc): bound_timeserie is entire set of
             # unaggregated measures matching largest
             # granularity. the following takes only the points
@@ -533,6 +551,9 @@ class StorageDriver(object):
             new_first_block_timestamp = bound_timeserie.first_block_timestamp()
             computed_points['number'] = len(bound_timeserie)
 
+            all_deleted_keys = set()
+            all_keys_and_splits_to_store = {}
+
             for granularity, aggregations in itertools.groupby(
                     # No need to sort the aggregation, they are already
                     metric.archive_policy.aggregations,
@@ -540,14 +561,24 @@ class StorageDriver(object):
                 ts = bound_timeserie.group_serie(
                     granularity, carbonara.round_timestamp(
                         tstamp, granularity))
+                deleted_keys, keys_and_splits_to_store = (
+                    self._compute_split_operations(
+                        metric, aggregations, ts,
+                        current_first_block_timestamp,
+                        new_first_block_timestamp)
+                )
+                all_deleted_keys = all_deleted_keys.union(deleted_keys)
+                all_keys_and_splits_to_store.update(keys_and_splits_to_store)
 
-                self._add_measures(metric, aggregations, ts,
-                                   current_first_block_timestamp,
-                                   new_first_block_timestamp)
+            self._delete_metric_splits(metric, all_deleted_keys)
+            self._store_timeserie_splits(metric, all_keys_and_splits_to_store,
+                                         new_first_block_timestamp)
 
         with utils.StopWatch() as sw:
-            ts.set_values(measures,
-                          before_truncate_callback=_map_add_measures)
+            ts.set_values(
+                measures,
+                before_truncate_callback=_map_compute_splits_operations
+            )
 
         number_of_operations = (len(agg_methods) * len(definition))
         perf = ""

--- a/gnocchi/tests/test_aggregates.py
+++ b/gnocchi/tests/test_aggregates.py
@@ -44,7 +44,7 @@ def datetime64(*args):
 class TestAggregatedTimeseries(base.BaseTestCase):
     @staticmethod
     def _resample_and_merge(ts, agg_dict):
-        """Helper method that mimics _add_measures workflow."""
+        """Helper method that mimics _compute_splits_operations workflow."""
         grouped = ts.group_serie(agg_dict['sampling'])
         existing = agg_dict.get('return')
         name = agg_dict.get("name")

--- a/gnocchi/tests/test_carbonara.py
+++ b/gnocchi/tests/test_carbonara.py
@@ -398,7 +398,7 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
 
     @staticmethod
     def _resample_and_merge(ts, agg_dict):
-        """Helper method that mimics _add_measures workflow."""
+        """Helper method that mimics _compute_splits_operations workflow."""
         grouped = ts.group_serie(agg_dict['sampling'])
         existing = agg_dict.get('return')
         agg_dict['return'] = carbonara.AggregatedTimeSerie.from_grouped_serie(


### PR DESCRIPTION
Rather than emitting store and delete on each aggregation computing, this
batches them all at once for a metric by returning the operations from
`_add_measures` directly.