### PR TITLE
git: ignore setuptools_scm 1.16.0/1/2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ def pbr_compat(v):
 
 
 setuptools.setup(
-    setup_requires=['setuptools>=30.3.0', 'setuptools_scm'],
+    setup_requires=['setuptools>=30.3.0',
+                    'setuptools_scm!=1.16.0,!=1.16.1,!=1.16.2'],
     use_scm_version={'version_scheme': pbr_compat},
     cmdclass=cmdclass,
 )


### PR DESCRIPTION
SOURCES.txt generated by this version is wrong and broke bdist*
commands.

This change ignores this version.

Next setuptools_scm version should fix it:
https://github.com/pypa/setuptools_scm/pull/227
https://github.com/pypa/setuptools_scm/pull/233
https://github.com/pypa/setuptools_scm/pull/234