### PR TITLE
Add gnocchi-injector

### DIFF
--- a/gnocchi/cli/injector.py
+++ b/gnocchi/cli/injector.py
@@ -1,0 +1,121 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright (c) 2018 Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import random
+import time
+import uuid
+
+import daiquiri
+import numpy
+from oslo_config import cfg
+
+from gnocchi import chef
+from gnocchi.cli import metricd
+from gnocchi import incoming
+from gnocchi import indexer
+from gnocchi import service
+from gnocchi import storage
+from gnocchi import utils
+
+LOG = daiquiri.getLogger(__name__)
+
+
+def injector():
+    conf = cfg.ConfigOpts()
+    conf.register_cli_opts([
+        cfg.IntOpt("--measures",
+                   help="Measures per metric."),
+        cfg.IntOpt("--metrics",
+                   help="Number of metrics to create."),
+        cfg.IntOpt("--archive-policy-name",
+                   help="Name of archive policy to use.",
+                   default="low"),
+        cfg.IntOpt("--interval",
+                   help="Interval to sleep between metrics sending."),
+        cfg.BoolOpt("--process", default=False,
+                    help="Process the ingested measures."),
+    ])
+    return _inject(service.prepare_service(conf=conf, log_to_std=True),
+                   metrics=conf.metrics,
+                   measures=conf.measures,
+                   archive_policy_name=conf.archive_policy_name,
+                   process=conf.process,
+                   interval=conf.interval)
+
+
+def _inject_from_conf(conf,
+                      metrics, measures, archive_policy_name="low",
+                      process=False, interval=None):
+    inc = incoming.get_driver(conf)
+    coord = metricd.get_coordinator_and_start(str(uuid.uuid4()),
+                                              conf.coordination_url)
+    store = storage.get_driver(conf)
+    idx = indexer.get_driver(conf)
+    return _inject(inc, coord, store, idx,
+                   metrics, measures, archive_policy_name, process, interval)
+
+
+def _inject(inc, coord, store, idx,
+            metrics, measures, archive_policy_name="low", process=False,
+            interval=None):
+    LOG.info("Creating %d metrics", metrics)
+    with utils.StopWatch() as sw:
+        metrics = [
+            idx.create_metric(uuid.uuid4(), "admin",
+                              archive_policy_name).id
+            for _ in range(metrics)
+        ]
+    LOG.info("Created %d metrics in %.2fs", metrics, sw.elapsed())
+
+    LOG.info("Generating %d measures per metric for %d metrics… ",
+             measures, metrics)
+    now = numpy.datetime64(utils.utcnow())
+    with utils.StopWatch() as sw:
+        measures = {
+            m_id: [incoming.Measure(
+                now + numpy.timedelta64(seconds=s),
+                random.randint(-999999, 999999)) for s in range(measures)]
+            for m_id in metrics
+        }
+    LOG.info("… done in %.2fs", sw.elapsed())
+
+    interval_timer = utils.StopWatch().start()
+
+    while True:
+        interval_timer.reset()
+        with utils.StopWatch() as sw:
+            inc.add_measures_batch(measures)
+        total_measures = sum(map(len, measures.values()))
+        LOG.info("Pushed %d measures in %.2fs",
+                 total_measures,
+                 sw.elapsed())
+
+        if process:
+            c = chef.Chef(coord, inc, idx, store)
+
+            with utils.StopWatch() as sw:
+                for s in inc.iter_sacks():
+                    c.process_new_measures_for_sack(s, blocking=True)
+            LOG.info("Processed %d sacks in %.2fs",
+                     inc.NUM_SACKS, sw.elapsed())
+            LOG.info("Speed: %.2f measures/s",
+                     float(total_measures) / sw.elapsed())
+
+        if interval is None:
+            break
+        time.sleep(max(0, interval - interval_timer.elapsed()))
+
+    return total_measures

--- a/gnocchi/tests/test_injector.py
+++ b/gnocchi/tests/test_injector.py
@@ -1,0 +1,30 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright © 2018 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from gnocchi.cli import injector
+from gnocchi.tests import base
+
+
+class InjectorTestCase(base.TestCase):
+    def test_inject(self):
+        self.assertEqual(100, injector._inject(
+            self.incoming, self.coord, self.storage, self.index,
+            measures=10, metrics=10))
+
+    def test_inject_process(self):
+        self.assertEqual(100, injector._inject(
+            self.incoming, self.coord, self.storage, self.index,
+            measures=10, metrics=10, process=True))

--- a/releasenotes/notes/injector-af9e68fdfe02d322.yaml
+++ b/releasenotes/notes/injector-af9e68fdfe02d322.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    The `gnocchi-injector` tool has been added. It allows to inject random
+    measures to a configured number of metrics in order to generate load for
+    `metricd`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -145,6 +145,7 @@ console_scripts =
     gnocchi-change-sack-size = gnocchi.cli.manage:change_sack_size
     gnocchi-statsd = gnocchi.cli.statsd:statsd
     gnocchi-metricd = gnocchi.cli.metricd:metricd
+    gnocchi-injector = gnocchi.cli.injector:injector
 
 oslo.config.opts =
     gnocchi = gnocchi.opts:list_opts


### PR DESCRIPTION
This allows to inject measures and maybe process them in a single tool. This is
useful to generate load to test metricd and also profile the processing code.