### PR TITLE
api: catch UnexpectedResourceTypeState properly

### DIFF
--- a/gnocchi/indexer/__init__.py
+++ b/gnocchi/indexer/__init__.py
@@ -192,6 +192,15 @@ class UnexpectedResourceTypeState(IndexerException):
         self.expected_state = expected_state
         self.state = state
 
+    def jsonify(self):
+        return {
+            "cause": "Resource type has an unexpected state",
+            "detail": {
+                "expected_state": self.expected_state,
+                "current_state": self.state
+            },
+        }
+
 
 class NoSuchArchivePolicyRule(IndexerException):
     """Error raised when an archive policy rule does not exist."""

--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -1106,6 +1106,8 @@ class ResourcesController(rest.RestController):
             abort(400, six.text_type(e))
         except indexer.ResourceAlreadyExists as e:
             abort(409, six.text_type(e))
+        except indexer.UnexpectedResourceTypeState as e:
+            abort(500, e)
         set_resp_location_hdr("/resource/"
                               + self._resource_type + "/"
                               + six.text_type(resource.id))


### PR DESCRIPTION
When creating resource, this might happen if the resource type is not
completely created yet (race condition). Rather than crash and return 500,
return a 503 with a parseable reply so it can be retried.