### PR TITLE
storage: allow to batch splits retrieval for multiple metrics

### DIFF
--- a/gnocchi/storage/ceph.py
+++ b/gnocchi/storage/ceph.py
@@ -150,7 +150,7 @@ class CephStorage(storage.StorageDriver):
             # It's possible that the object does not exists
             pass
 
-    def _get_measures_unbatched(self, metric, key, aggregation, version=3):
+    def _get_splits_unbatched(self, metric, key, aggregation, version=3):
         try:
             name = self._get_object_name(
                 metric, key, aggregation.method, version)

--- a/gnocchi/storage/file.py
+++ b/gnocchi/storage/file.py
@@ -180,7 +180,7 @@ class FileStorage(storage.StorageDriver):
                 # measures)
                 raise
 
-    def _get_measures_unbatched(self, metric, key, aggregation, version=3):
+    def _get_splits_unbatched(self, metric, key, aggregation, version=3):
         path = self._build_metric_path_for_split(
             metric, aggregation.method, key, version)
         try:

--- a/gnocchi/storage/redis.py
+++ b/gnocchi/storage/redis.py
@@ -13,6 +13,8 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+import collections
+
 import six
 
 from gnocchi import carbonara
@@ -151,10 +153,30 @@ return ids
     def _delete_metric(self, metric):
         self._client.delete(self._metric_key(metric))
 
-    def _get_measures(self, metric, keys_and_aggregations, version=3):
-        if not keys_and_aggregations:
-            return []
-        return self._client.hmget(
-            self._metric_key(metric),
-            [self._aggregated_field_for_split(aggregation.method, key, version)
-             for key, aggregation in keys_and_aggregations])
+    def _get_splits(self, metrics_aggregations_keys, version=3):
+        # Use a list of metric and aggregations with a constant sorting
+        metrics_aggregations = [
+            (metric, aggregation)
+            for metric, aggregation_and_keys in six.iteritems(
+                metrics_aggregations_keys)
+            for aggregation, keys in six.iteritems(aggregation_and_keys)
+            # Do not send any fetch request if keys is empty
+            if keys
+        ]
+
+        pipe = self._client.pipeline(transaction=False)
+        for metric, aggregation in metrics_aggregations:
+            pipe.hmget(
+                self._metric_key(metric),
+                [self._aggregated_field_for_split(aggregation.method,
+                                                  key, version)
+                 for key in metrics_aggregations_keys[metric][aggregation]])
+
+        results = collections.defaultdict(
+            lambda: collections.defaultdict(list))
+
+        for (metric, aggregation), result in six.moves.zip(
+                metrics_aggregations, pipe.execute()):
+            results[metric][aggregation] = result
+
+        return results

--- a/gnocchi/storage/s3.py
+++ b/gnocchi/storage/s3.py
@@ -156,7 +156,7 @@ class S3Storage(storage.StorageDriver):
             s3.bulk_delete(self.s3, bucket,
                            [c['Key'] for c in response.get('Contents', ())])
 
-    def _get_measures_unbatched(self, metric, key, aggregation, version=3):
+    def _get_splits_unbatched(self, metric, key, aggregation, version=3):
         try:
             response = self.s3.get_object(
                 Bucket=self._bucket_name,

--- a/gnocchi/storage/swift.py
+++ b/gnocchi/storage/swift.py
@@ -147,7 +147,7 @@ class SwiftStorage(storage.StorageDriver):
                     # Deleted in the meantime? Whatever.
                     raise
 
-    def _get_measures_unbatched(self, metric, key, aggregation, version=3):
+    def _get_splits_unbatched(self, metric, key, aggregation, version=3):
         try:
             headers, contents = self.swift.get_object(
                 self._container_name(metric), self._object_name(


### PR DESCRIPTION
It also fixes the parallel_map call to be unique, making _get_splits a little
bit faster for unbatched drivers.