### PR TITLE
speed up iteration over ts

### DIFF
--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -218,7 +218,7 @@ class TimeSerie(object):
         self.ts = ts
 
     def __iter__(self):
-        return (tuple(i) for i in self.ts)
+        return six.moves.zip(self.ts['timestamps'], self.ts['values'])
 
     @classmethod
     def from_data(cls, timestamps=None, values=None):


### PR DESCRIPTION
i have no idea why but:
```python
In [1]: import numpy

In [2]: dates = numpy.array([numpy.datetime64('2018-01-01') +
                             numpy.timedelta64(1, 'D') * i for i in range(1000)])
In [3]: values = numpy.random.rand(1000)
In [4]: arr = numpy.empty(len(values), dtype=[('dates', '<datetime64[D]'),
                                              ('values', '<d')])
In [5]: arr['dates'] = dates
In [6]: arr['values'] = values

In [7]: timeit blah = [tuple(i) for i in arr]
1.52 ms ± 18.9 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
In [8]: timeit blah = [i for i in zip(arr['dates'], arr['values'])]
112 µs ± 2.17 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
In [9]: timeit blah = arr.tolist()
139 µs ± 1.95 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
In [10]: timeit blah = [i for i in arr]
57 µs ± 3.49 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```
looping straight through array is fastest but it returns a tuple-like
value but not exactly the same so some tests will need to be changed.