### PR TITLE
tests: refresh metric instead of polling

### DIFF
--- a/gnocchi/tests/functional/gabbits/aggregation.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregation.yaml
@@ -94,20 +94,14 @@ tests:
           - ['2015-03-06T14:34:12+00:00', 1.0, 7.0]
 
     - name: get measure aggregates by granularity
-      GET: /v1/aggregation/metric?metric=$HISTORY['get metric list'].$RESPONSE['$[0].id']&metric=$HISTORY['get metric list'].$RESPONSE['$[1].id']&granularity=1
-      poll:
-          count: 10
-          delay: 1
+      GET: /v1/aggregation/metric?metric=$HISTORY['get metric list'].$RESPONSE['$[0].id']&metric=$HISTORY['get metric list'].$RESPONSE['$[1].id']&granularity=1&refresh=true
       response_json_paths:
         $:
           - ['2015-03-06T14:33:57+00:00', 1.0, 23.1]
           - ['2015-03-06T14:34:12+00:00', 1.0, 7.0]
 
     - name: get measure aggregates by granularity with timestamps
-      GET: /v1/aggregation/metric?metric=$HISTORY['get metric list'].$RESPONSE['$[0].id']&metric=$HISTORY['get metric list'].$RESPONSE['$[1].id']&start=2015-03-06T15:33:57%2B01:00&stop=2015-03-06T15:34:00%2B01:00
-      poll:
-          count: 10
-          delay: 1
+      GET: /v1/aggregation/metric?metric=$HISTORY['get metric list'].$RESPONSE['$[0].id']&metric=$HISTORY['get metric list'].$RESPONSE['$[1].id']&start=2015-03-06T15:33:57%2B01:00&stop=2015-03-06T15:34:00%2B01:00&refresh=true
       response_json_paths:
         $:
           - ['2015-03-06T14:30:00+00:00', 300.0, 15.05]
@@ -122,10 +116,7 @@ tests:
         $.description: Aggregation method 'wtf' at granularity '1.0' for metric $HISTORY['get metric list'].$RESPONSE['$[0].id'] does not exist
 
     - name: get measure aggregates and reaggregate
-      GET: /v1/aggregation/metric?metric=$HISTORY['get metric list'].$RESPONSE['$[0].id']&metric=$HISTORY['get metric list'].$RESPONSE['$[1].id']&reaggregation=min
-      poll:
-          count: 10
-          delay: 1
+      GET: /v1/aggregation/metric?metric=$HISTORY['get metric list'].$RESPONSE['$[0].id']&metric=$HISTORY['get metric list'].$RESPONSE['$[1].id']&reaggregation=min&refresh=true
       response_json_paths:
         $:
           - ['2015-03-06T14:30:00+00:00', 300.0, 2.55]
@@ -234,10 +225,7 @@ tests:
           - ['2015-03-06T14:34:12+00:00', 1.0, 7.0]
 
     - name: get measure aggregates by granularity from resources
-      POST: /v1/aggregation/resource/generic/metric/agg_meter?granularity=1
-      poll:
-          count: 10
-          delay: 1
+      POST: /v1/aggregation/resource/generic/metric/agg_meter?granularity=1&refresh=true
       response_json_paths:
         $:
           - ['2015-03-06T14:33:57+00:00', 1.0, 23.1]
@@ -297,10 +285,7 @@ tests:
         - A granularity must be specified to resample
 
     - name: get measure aggregates by granularity with timestamps from resources
-      POST: /v1/aggregation/resource/generic/metric/agg_meter?start=2015-03-06T15:33:57%2B01:00&stop=2015-03-06T15:34:00%2B01:00
-      poll:
-          count: 10
-          delay: 1
+      POST: /v1/aggregation/resource/generic/metric/agg_meter?start=2015-03-06T15:33:57%2B01:00&stop=2015-03-06T15:34:00%2B01:00&refresh=true
       response_json_paths:
         $:
           - ['2015-03-06T14:30:00+00:00', 300.0, 15.05]
@@ -321,10 +306,7 @@ tests:
           - ['2015-03-06T14:33:57+00:00', 1.0, 23.1]
 
     - name: get measure aggregates by granularity from resources and reaggregate
-      POST: /v1/aggregation/resource/generic/metric/agg_meter?granularity=1&reaggregation=min
-      poll:
-          count: 10
-          delay: 1
+      POST: /v1/aggregation/resource/generic/metric/agg_meter?granularity=1&reaggregation=min&refresh=true
       response_json_paths:
         $:
           - ['2015-03-06T14:33:57+00:00', 1.0, 3.1]

--- a/gnocchi/tests/functional/gabbits/async.yaml
+++ b/gnocchi/tests/functional/gabbits/async.yaml
@@ -48,14 +48,8 @@ tests:
             value: 12
       status: 202
 
-# This requires a poll as the measures are not immediately
-# aggregated.
-
     - name: get some measures
-      GET: /v1/resource/generic/41937416-1644-497d-a0ed-b43d55a2b0ea/metric/some.counter/measures
-      poll:
-          count: 50
-          delay: .1
+      GET: /v1/resource/generic/41937416-1644-497d-a0ed-b43d55a2b0ea/metric/some.counter/measures?refresh=true
       response_strings:
           - "2015"
       response_json_paths:

--- a/gnocchi/tests/functional/gabbits/metric-granularity.yaml
+++ b/gnocchi/tests/functional/gabbits/metric-granularity.yaml
@@ -46,11 +46,8 @@ tests:
         - Aggregation method 'mean' at granularity '42.0' for metric $RESPONSE['$[0].id'] does not exist
 
     - name: get measurements granularity
-      GET: /v1/metric/$HISTORY['get metric list'].$RESPONSE['$[0].id']/measures?granularity=1
+      GET: /v1/metric/$HISTORY['get metric list'].$RESPONSE['$[0].id']/measures?granularity=1&refresh=true
       status: 200
-      poll:
-          count: 50
-          delay: .1
       response_json_paths:
           $:
             - ["2015-03-06T14:33:57+00:00", 1.0, 43.1]

--- a/gnocchi/tests/functional/gabbits/resource-aggregation.yaml
+++ b/gnocchi/tests/functional/gabbits/resource-aggregation.yaml
@@ -43,7 +43,7 @@ tests:
 
     - name: get aggregation with no data
       desc: https://github.com/gnocchixyz/gnocchi/issues/69
-      POST: /v1/aggregation/resource/generic/metric/cpu.util?stop=2012-03-06T00:00:00&fill=0&granularity=300&resample=3600
+      POST: /v1/aggregation/resource/generic/metric/cpu.util?stop=2012-03-06T00:00:00&fill=0&granularity=300&resample=3600&refresh=true
       request_headers:
         x-user-id: 6c865dd0-7945-4e08-8b27-d0d7f1c2b667
         x-project-id: c7f32f1f-c5ef-427a-8ecd-915b219c66e8
@@ -51,9 +51,6 @@ tests:
       data:
         =:
           id: 4ed9c196-4c9f-4ba8-a5be-c9a71a82aac4
-      poll:
-        count: 10
-        delay: 1
       response_json_paths:
         $: []
 
@@ -98,10 +95,7 @@ tests:
       status: 202
 
     - name: aggregate metric with groupby on project_id with filter
-      POST: /v1/aggregation/resource/generic/metric/cpu.util?groupby=project_id&filter=user_id%3D%276c865dd0-7945-4e08-8b27-d0d7f1c2b667%27
-      poll:
-        count: 10
-        delay: 1
+      POST: /v1/aggregation/resource/generic/metric/cpu.util?groupby=project_id&filter=user_id%3D%276c865dd0-7945-4e08-8b27-d0d7f1c2b667%27&refresh=true
       response_json_paths:
         $:
           - measures:
@@ -118,13 +112,10 @@ tests:
               project_id: ee4cfc41-1cdc-4d2f-9a08-f94111d80171
 
     - name: aggregate metric with groupby on project_id
-      POST: /v1/aggregation/resource/generic/metric/cpu.util?groupby=project_id
+      POST: /v1/aggregation/resource/generic/metric/cpu.util?groupby=project_id&refresh=true
       data:
         =:
           user_id: 6c865dd0-7945-4e08-8b27-d0d7f1c2b667
-      poll:
-        count: 10
-        delay: 1
       response_json_paths:
         $:
           - measures:
@@ -150,13 +141,10 @@ tests:
         - Invalid groupby attribute
 
     - name: aggregate metric with groupby on project_id and user_id
-      POST: /v1/aggregation/resource/generic/metric/cpu.util?groupby=project_id&groupby=user_id
+      POST: /v1/aggregation/resource/generic/metric/cpu.util?groupby=project_id&groupby=user_id&refresh=true
       data:
         =:
           user_id: 6c865dd0-7945-4e08-8b27-d0d7f1c2b667
-      poll:
-        count: 10
-        delay: 1
       response_json_paths:
         $:
           - measures:

--- a/gnocchi/tests/functional/gabbits/resource.yaml
+++ b/gnocchi/tests/functional/gabbits/resource.yaml
@@ -510,10 +510,7 @@ tests:
         content-length: 0
 
     - name: request cpuutil measures again
-      GET: $LAST_URL
-      poll:
-          count: 50
-          delay: .1
+      GET: $LAST_URL?refresh=true
       response_json_paths:
           $[0][0]: "2015-03-06T14:33:57+00:00"
           $[0][1]: 1.0

--- a/gnocchi/tests/functional/gabbits/transformedids.yaml
+++ b/gnocchi/tests/functional/gabbits/transformedids.yaml
@@ -141,10 +141,7 @@ tests:
       status: 202
 
     - name: list two measures by external resource id
-      GET: $LAST_URL
-      poll:
-          count: 10
-          delay: 1
+      GET: $LAST_URL?refresh=true
       response_json_paths:
           $[0][2]: 43.1
           $[1][2]: 12


### PR DESCRIPTION
Some times the fake metricd thread is not scheduled on time, to
reduce failing tests when this occurs, this changes use refresh=true
API with available.