### PR TITLE
tests: Fix debug logging

### DIFF
--- a/gnocchi/service.py
+++ b/gnocchi/service.py
@@ -31,7 +31,8 @@ LOG = daiquiri.getLogger(__name__)
 
 def prepare_service(args=None, conf=None,
                     default_config_files=None,
-                    log_to_std=False, logging_level=None):
+                    log_to_std=False, logging_level=None,
+                    skip_log_opts=False):
     if conf is None:
         conf = cfg.ConfigOpts()
     # FIXME(jd) Use the pkg_entry info to register the options of these libs
@@ -100,7 +101,8 @@ def prepare_service(args=None, conf=None,
             conf.set_default("coordination_url",
                              urlparse.urlunparse(parsed))
 
-    LOG.info("Gnocchi version %s", gnocchi.__version__)
-    conf.log_opt_values(LOG, logging.DEBUG)
+    if not skip_log_opts:
+        LOG.info("Gnocchi version %s", gnocchi.__version__)
+        conf.log_opt_values(LOG, logging.DEBUG)
 
     return conf

--- a/gnocchi/tests/functional/fixtures.py
+++ b/gnocchi/tests/functional/fixtures.py
@@ -16,6 +16,7 @@
 
 from __future__ import absolute_import
 
+import logging
 import os
 import shutil
 import subprocess
@@ -26,7 +27,6 @@ from unittest import case
 import uuid
 import warnings
 
-import daiquiri
 import fixtures
 from gabbi import fixture
 import numpy
@@ -101,9 +101,9 @@ class ConfigFixture(fixture.GabbiFixture):
         else:
             dcf = []
         conf = service.prepare_service([], conf=utils.prepare_conf(),
-                                       default_config_files=dcf)
-        if not os.getenv("GNOCCHI_TEST_DEBUG"):
-            daiquiri.setup(outputs=[])
+                                       default_config_files=dcf,
+                                       logging_level=logging.DEBUG,
+                                       skip_log_opts=True)
 
         py_root = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                                '..', '..',))

--- a/gnocchi/tests/test_archive_policy.py
+++ b/gnocchi/tests/test_archive_policy.py
@@ -11,6 +11,8 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+import logging
+
 import numpy
 
 from gnocchi import archive_policy
@@ -30,7 +32,9 @@ class TestArchivePolicy(base.BaseTestCase):
 
     def test_aggregation_methods(self):
         conf = service.prepare_service([],
-                                       default_config_files=[])
+                                       default_config_files=[],
+                                       logging_level=logging.DEBUG,
+                                       skip_log_opts=True)
 
         ap = archive_policy.ArchivePolicy("foobar",
                                           0,


### PR DESCRIPTION
Even with tests debug disable, each test prints the configuration
options. And when enable some logs are missing.


This change changes the approach. Now by default, we sent log to a
fakelogger. And we print the stdout/stderr/logs when it fails or when
tests debugging is enabled.
