### PR TITLE
swift: pass the project domain

### DIFF
--- a/gnocchi/common/swift.py
+++ b/gnocchi/common/swift.py
@@ -34,6 +34,7 @@ def get_connection(conf):
         'endpoint_type': conf.swift_endpoint_type,
         'service_type':  conf.swift_service_type,
         'user_domain_name': conf.swift_user_domain_name,
+        'project_domain_name': conf.swift_project_domain_name,
     }
     if conf.swift_region:
         os_options['region_name'] = conf.swift_region


### PR DESCRIPTION
We miss to pass the project domain to swiftclient.
This change does it.