### PR TITLE
Support domain-scoped Gnocchi resources

### DIFF
--- a/gnocchi/rest/auth_helper.py
+++ b/gnocchi/rest/auth_helper.py
@@ -26,6 +26,9 @@ class KeystoneAuthHelper(object):
         # FIXME(jd) should have domain but should not break existing :(
         user_id = request.headers.get("X-User-Id", "")
         project_id = request.headers.get("X-Project-Id", "")
+        domain_id = request.headers.get("X-Domain-Id", "")
+        if not project_id and domain_id:
+            project_id = domain_id
         return user_id + ":" + project_id
 
     @staticmethod
@@ -50,6 +53,9 @@ class KeystoneAuthHelper(object):
         except webob.exc.HTTPForbidden:
             policy_filter = []
             project_id = request.headers.get("X-Project-Id")
+            domain_id = request.headers.get("X-Domain-Id", "")
+            if not project_id and domain_id:
+                project_id = domain_id
             target = {}
             if prefix:
                 resource = target[prefix] = {}

--- a/gnocchi/rest/policy.json
+++ b/gnocchi/rest/policy.json
@@ -1,7 +1,7 @@
 {
     "admin_or_creator": "role:admin or user:%(creator)s or project_id:%(created_by_project_id)s",
-    "resource_owner": "project_id:%(project_id)s",
-    "metric_owner": "project_id:%(resource.project_id)s",
+    "resource_owner": "project_id:%(project_id)s or domain_id:%(project_id)s",
+    "metric_owner": "project_id:%(resource.project_id)s or domain_id:%(resource.project_id)s",
 
     "get status": "role:admin",
 


### PR DESCRIPTION
Add support for the Identity service domain-scoped tokens.
Such tokens have domain_id value and empty project_id value.
This commit tunes the API controller KeystoneAuthHelper to allow
domain-scoped tokens and updates standard policy rules.

For #6 