### PR TITLE
indexer: drop/create missing constraint in slash reencoding migration script

### DIFF
--- a/gnocchi/indexer/alembic/versions/397987e38570_no_more_slash_and_reencode.py
+++ b/gnocchi/indexer/alembic/versions/397987e38570_no_more_slash_and_reencode.py
@@ -87,6 +87,8 @@ def upgrade():
         if rt.tablename != "generic"
     )
 
+    op.drop_constraint("fk_rh_id_resource_id", "resource_history",
+                       type_="foreignkey")
     op.drop_constraint("fk_metric_resource_id_resource_id", "metric",
                        type_="foreignkey")
     for name, table in resource_type_tablenames.items():
@@ -172,6 +174,9 @@ def upgrade():
                           "metric", "resource",
                           ("resource_id",), ("id",),
                           ondelete="SET NULL")
+    op.create_foreign_key("fk_rh_id_resource_id",
+                          "resource_history", "resource",
+                          ("id",), ("id",), ondelete="CASCADE")
 
     for metric in connection.execute(metric_table.select().where(
             metric_table.c.name.like("%/%"))):

--- a/run-upgrade-tests.sh
+++ b/run-upgrade-tests.sh
@@ -40,8 +40,12 @@ inject_data() {
 
     if [ "$have_resource_type_post" ]
     then
-        gnocchi resource-type create ext > /dev/null
-        gnocchi resource create ext --attribute id:$RESOURCE_ID_EXT -n metric:high > /dev/null
+        gnocchi resource create -n metric:high $RESOURCE_ID_EXT > /dev/null
+
+        # Create a resource with an history
+        gnocchi resource-type create ext --attribute someattr:string:false:max_length=32 > /dev/null
+        gnocchi resource create --type ext --attribute someattr:foobar -n metric:high historized_resource > /dev/null
+        gnocchi resource update --type ext --attribute someattr:foobaz historized_resource > /dev/null
     fi
 
     {
@@ -120,7 +124,9 @@ dump_data $GNOCCHI_DATA/new
 
 # NOTE(sileht): change the output of the old gnocchi to compare with the new without '/'
 $GSED -i -e "s,5a301761/dddd/46e2/8900/8b4f6fe6675a,5a301761_dddd_46e2_8900_8b4f6fe6675a,g" \
-      -e "s,19235bb9-35ca-5f55-b7db-165cfb033c86,517920a9-2e50-58b8-88e8-25fd7aae1d8f,g" $GNOCCHI_DATA/old/resources.list
+      -e "s,19235bb9-35ca-5f55-b7db-165cfb033c86,517920a9-2e50-58b8-88e8-25fd7aae1d8f,g" \
+      -e "s,e8bce9ff-5c30-524c-87b8-bfb1dce7855b,bd6eac67-c1e9-5da0-9979-a797d776039e,g" \
+      $GNOCCHI_DATA/old/resources.list
 
 echo "* Checking output difference between Gnocchi $old_version and $new_version"
 diff -uNr $GNOCCHI_DATA/old $GNOCCHI_DATA/new


### PR DESCRIPTION
The current script cannot be executed if a resource has an history entry:

ERROR gnocchi oslo_db.exception.DBReferenceError: (psycopg2.IntegrityError) update or delete on table "resource" violates foreign key constraint "fk_rh_id_resource_id" on table "resource_history"
DEBUG [pifpaf.drivers] gnocchi-upgrade[71041] output: 2018-04-24 09:36:08.029 71041 ERROR gnocchi DETAIL:  Key (id)=(e8bce9ff-5c30-524c-87b8-bfb1dce7855b) is still referenced from table "resource_history".
DEBUG [pifpaf.drivers] gnocchi-upgrade[71041] output: 2018-04-24 09:36:08.029 71041 ERROR gnocchi  [SQL: 'UPDATE resource SET id=%(param_1)s, original_resource_id=%(original_resource_id)s WHERE resource.id = %(id_1)s'] [parameters: {'param_1': 'bd6eac67-c1e9-5da0-9979-a797d776039e', 'original_resource_id': 'historized_resource', 'id_1': UUID('e8bce9ff-5c30-524c-87b8-bfb1dce7855b')}] (Background on this error at: http://sqlalche.me/e/gkpj)

This drops and recreates the constraint at the end of the migration.