### PR TITLE
indexer: drop/create missing constraint in slash reencoding migration script

### DIFF
--- a/gnocchi/indexer/alembic/versions/397987e38570_no_more_slash_and_reencode.py
+++ b/gnocchi/indexer/alembic/versions/397987e38570_no_more_slash_and_reencode.py
@@ -87,6 +87,8 @@ def upgrade():
         if rt.tablename != "generic"
     )
 
+    op.drop_constraint("fk_rh_id_resource_id", "resource_history",
+                       type_="foreignkey")
     op.drop_constraint("fk_metric_resource_id_resource_id", "metric",
                        type_="foreignkey")
     for name, table in resource_type_tablenames.items():
@@ -172,6 +174,9 @@ def upgrade():
                           "metric", "resource",
                           ("resource_id",), ("id",),
                           ondelete="SET NULL")
+    op.create_foreign_key("fk_rh_id_resource_id",
+                          "resource_history", "resource",
+                          ("id",), ("id",), ondelete="CASCADE")
 
     for metric in connection.execute(metric_table.select().where(
             metric_table.c.name.like("%/%"))):

--- a/run-upgrade-tests.sh
+++ b/run-upgrade-tests.sh
@@ -33,6 +33,11 @@ inject_data() {
         gnocchi resource create generic --attribute id:$resource_id -n metric:high > /dev/null
     done
 
+    # Create a resource with an history
+    gnocchi resource-type create ext --attribute someattr:string:false:max_length=32 > /dev/null
+    gnocchi resource create --type ext --attribute someattr:foobar -n metric:high historized_resource > /dev/null
+    gnocchi resource update --type ext --attribute someattr:foobaz historized_resource > /dev/null
+
     {
         measures_sep=""
         MEASURES=$(python -c 'import datetime, random, json; now = datetime.datetime.utcnow(); print(json.dumps([{"timestamp": (now - datetime.timedelta(seconds=i)).isoformat(), "value": random.uniform(-100000, 100000)} for i in range(0, 288000, 10)]))')


### PR DESCRIPTION
The current script cannot be executed if a resource has an history entry:

ERROR gnocchi oslo_db.exception.DBReferenceError: (psycopg2.IntegrityError) update or delete on table "resource" violates foreign key constraint "fk_rh_id_resource_id" on table "resource_history"
DEBUG [pifpaf.drivers] gnocchi-upgrade[71041] output: 2018-04-24 09:36:08.029 71041 ERROR gnocchi DETAIL:  Key (id)=(e8bce9ff-5c30-524c-87b8-bfb1dce7855b) is still referenced from table "resource_history".
DEBUG [pifpaf.drivers] gnocchi-upgrade[71041] output: 2018-04-24 09:36:08.029 71041 ERROR gnocchi  [SQL: 'UPDATE resource SET id=%(param_1)s, original_resource_id=%(original_resource_id)s WHERE resource.id = %(id_1)s'] [parameters: {'param_1': 'bd6eac67-c1e9-5da0-9979-a797d776039e', 'original_resource_id': 'historized_resource', 'id_1': UUID('e8bce9ff-5c30-524c-87b8-bfb1dce7855b')}] (Background on this error at: http://sqlalche.me/e/gkpj)

This drops and recreates the constraint at the end of the migration.