### PR TITLE
storage/file: create directories only on upgrade()

### DIFF
--- a/gnocchi/storage/file.py
+++ b/gnocchi/storage/file.py
@@ -47,12 +47,15 @@ class FileStorage(_carbonara.CarbonaraBasedStorage):
         super(FileStorage, self).__init__(conf)
         self.basepath = conf.file_basepath
         self.basepath_tmp = conf.file_basepath_tmp
+        self.measure_path = os.path.join(self.basepath, self.MEASURE_PREFIX)
+
+    def upgrade(self, index):
+        super(FileStorage, self).upgrade(index)
         try:
             os.mkdir(self.basepath)
         except OSError as e:
             if e.errno != errno.EEXIST:
                 raise
-        self.measure_path = os.path.join(self.basepath, self.MEASURE_PREFIX)
         try:
             os.mkdir(self.measure_path)
         except OSError as e:

--- a/gnocchi/tests/base.py
+++ b/gnocchi/tests/base.py
@@ -20,6 +20,7 @@ import os
 import uuid
 
 import fixtures
+import mock
 from oslotest import base
 import six
 from six.moves.urllib.parse import unquote
@@ -499,7 +500,10 @@ class TestCase(base.BaseTestCase):
         # (TimeSerieArchive) uses a lot of parallel lock, which makes tooz
         # explodes because MySQL does not support that many connections in real
         # life.
-        # self.storage.upgrade(self.index)
+        # NOTE(jd) Upgrade file only because it needs to create directories
+        if self.conf.storage.driver == "file":
+            with mock.patch.object(self.storage, "_check_for_metric_upgrade"):
+                self.storage.upgrade(self.index)
 
     def tearDown(self):
         self.index.disconnect()


### PR DESCRIPTION
Doing so on each storage driver instance slows things down and can make thing
not working in case of (transient) failure for no good reason.