### PR TITLE
Pull request for stable-3.1-fix-mkdir-on-init

### DIFF
--- a/gnocchi/storage/_carbonara.py
+++ b/gnocchi/storage/_carbonara.py
@@ -424,6 +424,7 @@ class CarbonaraBasedStorage(storage.StorageDriver):
             LOG.info("Migrated metric %s to new format", metric)
 
     def upgrade(self, index):
+        super(CarbonaraBasedStorage, self).upgrade(index)
         marker = None
         while True:
             metrics = [(metric,) for metric in

--- a/gnocchi/storage/file.py
+++ b/gnocchi/storage/file.py
@@ -40,6 +40,9 @@ class FileStorage(_carbonara.CarbonaraBasedStorage):
         super(FileStorage, self).__init__(conf, incoming)
         self.basepath = conf.file_basepath
         self.basepath_tmp = os.path.join(self.basepath, 'tmp')
+
+    def upgrade(self, indexer):
+        super(FileStorage, self).upgrade(indexer)
         utils.ensure_paths([self.basepath_tmp])
 
     def _atomic_file_store(self, dest, data):

--- a/gnocchi/storage/incoming/file.py
+++ b/gnocchi/storage/incoming/file.py
@@ -30,6 +30,9 @@ class FileStorage(_carbonara.CarbonaraBasedStorage):
         self.basepath = conf.file_basepath
         self.basepath_tmp = os.path.join(self.basepath, 'tmp')
         self.measure_path = os.path.join(self.basepath, 'measure')
+
+    def upgrade(self, indexer):
+        super(FileStorage, self).upgrade(indexer)
         utils.ensure_paths([self.basepath_tmp, self.measure_path])
 
     def _build_measure_path(self, metric_id, random_id=None):

--- a/gnocchi/storage/incoming/s3.py
+++ b/gnocchi/storage/incoming/s3.py
@@ -42,6 +42,9 @@ class S3Storage(_carbonara.CarbonaraBasedStorage):
         self._bucket_name_measures = (
             self._bucket_prefix + "-" + self.MEASURE_PREFIX
         )
+
+    def upgrade(self, indexer):
+        super(S3Storage, self).upgrade(indexer)
         try:
             s3.create_bucket(self.s3, self._bucket_name_measures,
                              self._region_name)

--- a/gnocchi/storage/incoming/swift.py
+++ b/gnocchi/storage/incoming/swift.py
@@ -33,6 +33,9 @@ class SwiftStorage(_carbonara.CarbonaraBasedStorage):
     def __init__(self, conf):
         super(SwiftStorage, self).__init__(conf)
         self.swift = swift.get_connection(conf)
+
+    def upgrade(self, indexer):
+        super(SwiftStorage, self).upgrade(indexer)
         self.swift.put_container(self.MEASURE_PREFIX)
 
     def _store_new_measures(self, metric, data):

--- a/gnocchi/tests/base.py
+++ b/gnocchi/tests/base.py
@@ -299,12 +299,8 @@ class TestCase(base.BaseTestCase):
                                "storage")
 
         self.storage = storage.get_driver(self.conf)
-        # NOTE(jd) Do not upgrade the storage. We don't really need the storage
-        # upgrade for now, and the code that upgrade from pre-1.3
-        # (TimeSerieArchive) uses a lot of parallel lock, which makes tooz
-        # explodes because MySQL does not support that many connections in real
-        # life.
-        # self.storage.upgrade(self.index)
+        if self.conf.storage.driver in ("file", "swift", "s3"):
+            self.storage.upgrade(self.index)
 
     def tearDown(self):
         self.index.disconnect()

--- a/gnocchi/tests/test_statsd.py
+++ b/gnocchi/tests/test_statsd.py
@@ -40,10 +40,10 @@ class TestStatsd(tests_base.TestCase):
         self.conf.set_override("archive_policy_name",
                                self.STATSD_ARCHIVE_POLICY_NAME, "statsd")
 
-        # NOTE(jd) Always use self.stats.storage and self.stats.indexer to
-        # pick at the right storage/indexer used by the statsd server, and not
-        # new instances from the base test class.
         self.stats = statsd.Stats(self.conf)
+        # Replace storage/indexer with correct ones that have been upgraded
+        self.stats.storage = self.storage
+        self.stats.indexer = self.index
         self.server = statsd.StatsdServer(self.stats)
 
     def test_flush_empty(self):


### PR DESCRIPTION
file, s3, swift: create incoming buckets/containers on upgrade
file: move directory creation in the upgrade path, not init