### PR TITLE
swift: avoid Connection aborted

### DIFF
--- a/gnocchi/incoming/__init__.py
+++ b/gnocchi/incoming/__init__.py
@@ -43,6 +43,9 @@ class IncomingDriver(object):
     SACK_PREFIX = "incoming"
     CFG_PREFIX = 'gnocchi-config'
     CFG_SACKS = 'sacks'
+    # NOTE(sileht): By default we use threads, but some driver can disable
+    # threads by setting this to utils.sequencial_map
+    MAP_METHOD = staticmethod(utils.parallel_map)
 
     @property
     def NUM_SACKS(self):
@@ -122,11 +125,10 @@ class IncomingDriver(object):
                                      and values are a list of
                                      :py:class:`gnocchi.incoming.Measure`.
         """
-        utils.parallel_map(
-            self._store_new_measures,
-            ((metric_id, self._encode_measures(measures))
-             for metric_id, measures
-             in six.iteritems(metrics_and_measures)))
+        self.MAP_METHOD(self._store_new_measures,
+                        ((metric_id, self._encode_measures(measures))
+                         for metric_id, measures
+                         in six.iteritems(metrics_and_measures)))
 
     @staticmethod
     def _store_new_measures(metric_id, data):

--- a/gnocchi/incoming/swift.py
+++ b/gnocchi/incoming/swift.py
@@ -21,12 +21,17 @@ import six
 
 from gnocchi.common import swift
 from gnocchi import incoming
+from gnocchi import utils
 
 swclient = swift.swclient
 swift_utils = swift.swift_utils
 
 
 class SwiftStorage(incoming.IncomingDriver):
+    # NOTE(sileht): Using threads with swiftclient doesn't work
+    # as expected, so disable it
+    MAP_METHOD = staticmethod(utils.sequencial_map)
+
     def __init__(self, conf, greedy=True):
         super(SwiftStorage, self).__init__(conf)
         self.swift = swift.get_connection(conf)

--- a/gnocchi/storage/swift.py
+++ b/gnocchi/storage/swift.py
@@ -82,6 +82,9 @@ OPTS = [
 class SwiftStorage(storage.StorageDriver):
 
     WRITE_FULL = True
+    # NOTE(sileht): Using threads with swiftclient doesn't work
+    # as expected, so disable it
+    MAP_METHOD = staticmethod(utils.sequencial_map)
 
     def __init__(self, conf, coord=None):
         super(SwiftStorage, self).__init__(conf, coord)

--- a/gnocchi/utils.py
+++ b/gnocchi/utils.py
@@ -299,11 +299,15 @@ def get_driver_class(namespace, conf):
                                 conf.driver).driver
 
 
+def sequencial_map(fn, list_of_args):
+    return list(itertools.starmap(fn, list_of_args))
+
+
 def parallel_map(fn, list_of_args):
     """Run a function in parallel."""
 
     if parallel_map.MAX_WORKERS == 1:
-        return list(itertools.starmap(fn, list_of_args))
+        return sequencial_map(fn, list_of_args)
 
     with futures.ThreadPoolExecutor(
             max_workers=parallel_map.MAX_WORKERS) as executor:


### PR DESCRIPTION
This change removes usage of threads with swift driver.

This avoids to get "Connection aborted" because a thread is stuck
and the server side decide to break the connection.

Related-bug: #509
(cherry picked from commit bc18ebded10bc763b98bcba46db925a3a5031ecd)