### PR TITLE
file: allow to create a subdir to create less root directory

### DIFF
--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -64,6 +64,29 @@ class TestStorageDriver(tests_base.TestCase):
         driver = storage.get_driver(self.conf)
         self.assertIsInstance(driver, storage.StorageDriver)
 
+    def test_file_driver_subdir_len(self):
+        driver = storage.get_driver(self.conf)
+        if not isinstance(driver, file.FileStorage):
+            self.skipTest("not file driver")
+
+        # Check the default
+        self.assertEqual(2, driver.SUBDIR_LEN)
+
+        metric = mock.Mock(id=uuid.UUID("12345678901234567890123456789012"))
+        expected = (driver.basepath + "/12/34/56/78/90/12/34/56/78/90/12/34/56"
+                    "/78/90/12/12345678-9012-3456-7890-123456789012")
+        self.assertEqual(expected, driver._build_metric_dir(metric))
+
+        driver._file_subdir_len = 16
+        expected = (driver.basepath + "/1234567890123456/7890123456"
+                    "789012/12345678-9012-3456-7890-123456789012")
+        self.assertEqual(expected, driver._build_metric_dir(metric))
+
+        driver._file_subdir_len = 15
+        expected = (driver.basepath + "/123456789012345/67890123456"
+                    "7890/12/12345678-9012-3456-7890-123456789012")
+        self.assertEqual(expected, driver._build_metric_dir(metric))
+
     def test_corrupted_split(self):
         self.incoming.add_measures(self.metric.id, [
             incoming.Measure(datetime64(2014, 1, 1, 12, 0, 1), 69),

--- a/releasenotes/notes/change-file-driver-layout-41c7a458160c4cb7.yaml
+++ b/releasenotes/notes/change-file-driver-layout-41c7a458160c4cb7.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    By default, the file driver creates a subdirectory every two bytes of the metric
+    uuid. This avoid to reach limitation of certain filesystems and improve
+    performance in certain case. This is configurable with the option ``file_subdir_len``.
+    If the backend already have data coming from a previous version of Gnocchi, it
+    kept unchanged, ``file_subdir_len`` is set to 0.


### PR DESCRIPTION
Some filesystem have a limit in term of number of directory a directory
can have. Also in performance point of view, some filesystem are slower
when too much directories are created in one directory.

To improve the situation is such case, this change adds an option
to create subdirectories for storing metrics.

for example file_subdir_len=2 will create:

de/de3a72c4-5055-43b4-bed1-f9bb1395c52a