### PR TITLE
Remove cradox dependency

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -23,8 +23,7 @@ The list of variants available is:
 * `postgresql` – provides PostgreSQL indexer support
 * `swift` – provides OpenStack Swift storage support
 * `s3` – provides Amazon S3 storage support
-* `ceph` – provides Ceph (>= 0.80) storage support
-* `ceph_alternative` – provides Ceph (>= 12.2.0) storage support
+* `ceph` – provides Ceph (>= 12.2.0) storage support
 * `redis` – provides Redis storage support
 * `prometheus` – provides Prometheus Remote Write support
 * `doc` – documentation building support
@@ -44,6 +43,9 @@ install extra variants using, for example::
 Ceph requirements
 -----------------
 
+Gnocchi requires python-rados >= 12.2. The package is part of Ceph and is not
+available on Pypi.
+
 The Ceph driver needs to have a Ceph user and a pool already created. They can
 be created for example with:
 
@@ -54,12 +56,7 @@ be created for example with:
 
 
 Gnocchi leverages some _librados_ features (omap, async, operation context)
-available in the Python binding only since python-rados >= 12.2.0. To handle
-this, Gnocchi uses _cradox_ python library which has exactly the same API but
-works with Ceph >= 0.80.0.
-
-If Ceph and python-rados are >= 12.2.0, the cradox Python library becomes
-optional but is still recommended.
+available in the Python binding only since python-rados >= 12.2.0.
 
 
 Configuration

--- a/gnocchi/common/ceph.py
+++ b/gnocchi/common/ceph.py
@@ -20,20 +20,10 @@ import daiquiri
 LOG = daiquiri.getLogger(__name__)
 
 
-for RADOS_MODULE_NAME in ('cradox', 'rados'):
-    try:
-        rados = __import__(RADOS_MODULE_NAME)
-    except ImportError:
-        pass
-    else:
-        break
-else:
-    RADOS_MODULE_NAME = None
+try:
+    rados = __import__('rados')
+except ImportError:
     rados = None
-
-if rados is not None and hasattr(rados, 'run_in_thread'):
-    rados.run_in_thread = lambda target, args, timeout=None: target(*args)
-    LOG.info("rados.run_in_thread is monkeypatched.")
 
 
 def create_rados_connection(conf):
@@ -48,15 +38,9 @@ def create_rados_connection(conf):
         options['client_mount_timeout'] = conf.ceph_timeout
 
     if not rados:
-        raise ImportError("No module named 'rados' nor 'cradox'")
+        raise ImportError("No module named 'rados'")
 
-    if not hasattr(rados, 'OmapIterator'):
-        raise ImportError("Your rados python module does not support "
-                          "omap feature. Install 'cradox' (recommended) "
-                          "or upgrade 'python-rados' >= 9.1.0 ")
-
-    LOG.info("Ceph storage backend use '%s' python library",
-             RADOS_MODULE_NAME)
+    LOG.info("Ceph storage backend use 'rados' python library")
 
     # NOTE(sileht): librados handles reconnection itself,
     # by default if a call timeout (30sec), it raises

--- a/run-upgrade-tests.sh
+++ b/run-upgrade-tests.sh
@@ -82,7 +82,7 @@ pifpaf_stop
 
 new_version=$(python setup.py --version)
 echo "* Upgrading Gnocchi from $old_version to $new_version"
-pip install -v -U .[${GNOCCHI_VARIANT}]
+pip install -v -U --upgrade-strategy eager .[${GNOCCHI_VARIANT}]
 
 eval $(pifpaf --debug run gnocchi --indexer-url $INDEXER_URL --storage-url $STORAGE_URL)
 # Gnocchi 3.1 uses basic auth by default

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,9 +76,7 @@ redis =
 swift =
     python-swiftclient>=3.1.0
 ceph =
-    cradox>=2.0.0
-ceph_alternative =
-    python-rados>=12.2.0 # not available on pypi
+    # python-rados>=12.2.0 # not available on pypi
 prometheus =
     python-snappy
     protobuf

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,8 @@ skipsdist = True
 
 [testenv]
 skip_install = True
-sitepackages = False
+sitepackages = True
+install_command = pip install -U --upgrade-strategy eager {packages}
 passenv = LANG GNOCCHI_TEST_* AWS_*
 setenv =
     GNOCCHI_TEST_STORAGE_DRIVER=file
@@ -149,6 +150,7 @@ setenv = GNOCCHI_STORAGE_DEPS=file
 deps = {[testenv:docs]deps}
        sphinxcontrib-versioning
 # for < 4.3 doc
+       cradox
        pbr
        WebOb<1.8
 # for <= 4.2 doc


### PR DESCRIPTION
We can now just depend on ceph 12.2, and not rely on cradox anymore.