### PR TITLE
redis: use hiredis parser

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,7 @@ s3 =
     botocore>=1.5
 redis =
     redis>=2.10.0 # MIT
+    hiredis
 swift =
     python-swiftclient>=3.1.0
 ceph =


### PR DESCRIPTION
redis-py has a python and c parser[1]. install the c parser. it offers
~10%-90% performance improvement depending on task using benchmark from
redis-py[2].

[1] https://github.com/andymccurdy/redis-py#parsers
[2] https://github.com/andymccurdy/redis-py/blob/master/benchmarks/basic_operations.py