### PR TITLE
gate fix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -90,6 +90,7 @@ doc =
     reno>=1.6.2
 test =
     pifpaf[ceph,gnocchi]>=1.0.1
+    urllib3<1.23 # Temporary fix the gate, for unknown reason gabbi (which require 1.11) download 1.23 while requests requires <1.23
     gabbi>=1.37.0
     coverage>=3.6
     fixtures


### PR DESCRIPTION
requests 2.18.4 has requirement urllib3<1.23,>=1.21.1, but you'll have
urllib3 1.23 which is incompatible.

This explicits set the urllib3 version until requests release a fixed
library