### PR TITLE
api: avoid some indexer queries

### DIFF
--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -1549,9 +1549,14 @@ class ResourcesMetricsMeasuresBatchController(rest.RestController):
         attribute_filter = {"or": []}
         for original_resource_id, resource_id in body:
             names = list(body[(original_resource_id, resource_id)].keys())
-            attribute_filter["or"].append({"and": [
-                {"=": {"resource_id": resource_id}},
-                {"in": {"name": names}}]})
+            if names:
+                attribute_filter["or"].append({"and": [
+                    {"=": {"resource_id": resource_id}},
+                    {"in": {"name": names}}]})
+
+        if not attribute_filter["or"]:
+            pecan.response.status = 202
+            return
 
         all_metrics = collections.defaultdict(list)
         for metric in pecan.request.indexer.list_metrics(


### PR DESCRIPTION
If no resource_id or no metric names are passed in the batch payload,
we can skip some sql queries.

This change does that.

Closes-bug: #911