### PR TITLE
Delete stale metrics before policy delete

### DIFF
--- a/gnocchi/indexer/sqlalchemy.py
+++ b/gnocchi/indexer/sqlalchemy.py
@@ -595,6 +595,11 @@ class SQLAlchemyIndexer(indexer.IndexerDriver):
             "fk_apr_ap_name_ap_name"]
         with self.facade.writer() as session:
             try:
+                # cleanup deleted metrics before deleting archive policies to
+                # prevent policy-in-use errors
+                session.query(Metric).filter(
+                    Metric.archive_policy_name == name,
+                    Metric.status == 'delete').delete()
                 if session.query(ArchivePolicy).filter(
                         ArchivePolicy.name == name).delete() == 0:
                     raise indexer.NoSuchArchivePolicy(name)

--- a/gnocchi/tests/test_indexer.py
+++ b/gnocchi/tests/test_indexer.py
@@ -146,6 +146,17 @@ class TestIndexerDriver(tests_base.TestCase):
                           "low")
         self.index.delete_metric(metric_id)
 
+    def test_delete_archive_policy_after_metric_delete(self):
+        name = str(uuid.uuid4())
+        self.index.create_archive_policy(
+            archive_policy.ArchivePolicy(name, 0, {}))
+        metric_id = uuid.uuid4()
+        self.index.create_metric(metric_id, str(uuid.uuid4()), name)
+        self.index.delete_metric(metric_id)
+        self.index.delete_archive_policy(name)
+        self.assertRaises(indexer.NoSuchMetric, self.index.expunge_metric,
+                          metric_id)
+
     def test_list_ap_rules_ordered(self):
         name = str(uuid.uuid4())
         self.index.create_archive_policy(


### PR DESCRIPTION
Usually stale metrics are soft deleted. Later they cleanud up by
metrics daemon. This leads to errors if  smb tries to delete
policy right after metric delete because there is foreign key
restriction between metrics and policies.

Change-Id: I9dd02b7c54b2a8086cd8cf57ff4c20bca67c42ee