### PR TITLE
Docs: add reference to a Go SDK

### DIFF
--- a/doc/source/client.rst
+++ b/doc/source/client.rst
@@ -2,7 +2,10 @@
  Client
 ========
 
-Gnocchi currently only provides a Python client and SDK which can be installed
+Python
+------
+
+Gnocchi officially provides a Python client and SDK which can be installed
 using *pip*::
 
   pip install gnocchiclient
@@ -10,4 +13,17 @@ using *pip*::
 This package provides the `gnocchi` command line tool that can be used to send
 requests to Gnocchi. You can read the `full documentation online`_.
 
+Go
+--
+
+There is an open source Go implementation for the SDK, provided by the
+`Gophercloud` project.
+It can be installed using *go get*::
+
+  go get github.com/gophercloud/utils/gnocchi
+
+This package provides the Go SDK only. You can read the `godoc reference`_.
+
 .. _full documentation online: http://gnocchi.xyz/gnocchiclient
+.. _Gophercloud: https://github.com/gophercloud
+.. _godoc reference: https://godoc.org/github.com/gophercloud/utils


### PR DESCRIPTION
Add notes about open source Go SDK implementation for the Gnocchi API
with links and installation instruction.

For #926 