### PR TITLE
Force installation of pbr<4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,7 @@ setenv = GNOCCHI_VARIANT=test,postgresql,file
 deps = gnocchi[{env:GNOCCHI_VARIANT}]>=4.0,<4.1
   pifpaf[gnocchi]>=0.13
   gnocchiclient>=2.8.0
+  pbr<4
 commands = pifpaf --env-prefix INDEXER run postgresql {toxinidir}/run-upgrade-tests.sh {posargs}
 
 [testenv:py27-mysql-ceph-upgrade-from-4.0]
@@ -68,6 +69,7 @@ setenv = GNOCCHI_VARIANT=test,mysql,ceph,ceph_recommended_lib
 deps = gnocchi[{env:GNOCCHI_VARIANT}]>=4.0,<4.1
   gnocchiclient>=2.8.0
   pifpaf[ceph,gnocchi]>=0.13
+  pbr<4
 commands = pifpaf --env-prefix INDEXER run mysql -- pifpaf --env-prefix STORAGE run ceph {toxinidir}/run-upgrade-tests.sh {posargs}
 
 [testenv:py37-postgresql-file-upgrade-from-4.1]
@@ -78,6 +80,7 @@ setenv = GNOCCHI_VARIANT=test,postgresql,file
 deps = gnocchi[{env:GNOCCHI_VARIANT}]>=4.1,<4.2
   pifpaf[gnocchi]>=0.13
   gnocchiclient>=2.8.0
+  pbr<4
 commands = pifpaf --env-prefix INDEXER run postgresql {toxinidir}/run-upgrade-tests.sh {posargs}
 
 [testenv:py27-mysql-ceph-upgrade-from-4.1]
@@ -88,6 +91,7 @@ setenv = GNOCCHI_VARIANT=test,mysql,ceph,ceph_recommended_lib
 deps = gnocchi[{env:GNOCCHI_VARIANT}]>=4.1,<4.2
   gnocchiclient>=2.8.0
   pifpaf[ceph,gnocchi]>=0.13
+  pbr<4
 commands = pifpaf --env-prefix INDEXER run mysql -- pifpaf --env-prefix STORAGE run ceph {toxinidir}/run-upgrade-tests.sh {posargs}
 
 [testenv:py37-postgresql-file-upgrade-from-4.2]


### PR DESCRIPTION
For whatever reason, tox/pip do not honor the dependency during the
installation, breaking the WSGI script gnocchi-api.