### PR TITLE
tests: disable py27-mysql-ceph-upgrade-from-4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ env:
   - TARGET: docs
   - TARGET: docs-gnocchi.xyz
 
-  - TARGET: py27-mysql-ceph-upgrade-from-4.0
+  # Temporary disabled because Pandas wheel is wrong
+  # and emits warnings
+  # - TARGET: py27-mysql-ceph-upgrade-from-4.0
   - TARGET: py37-postgresql-file-upgrade-from-4.0
   - TARGET: py27-mysql-ceph-upgrade-from-4.1
   - TARGET: py37-postgresql-file-upgrade-from-4.1


### PR DESCRIPTION
This job does not work anymore because Pandas wheel for Python 2.7 is built
against an old version of Numpy. When imported, it emits those warnings:

  /home/tester/src/.tox/py27-mysql-ceph-upgrade-from-4.0/local/lib/python2.7/site-packages/scipy/linalg/basic.py:17:
    RuntimeWarning: numpy.dtype size changed, may indicate binary incompatibility.
    Expected 96, got 88
   from ._solve_toeplitz import levinson

Those warnings are printed on stderr, as is the version number of `gnocchi-api
--version`. pifpaf uses this command call to get the version number of Gnocchi
and runs the WSGI server either with gnocchi-api or with uwsgi.

Since pifpaf cannot parse stderr to read the correct version number, if fails
to start gnocchi-api and the job fails.