### PR TITLE
Stop using deprecated storage.get_measures

### DIFF
--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -509,8 +509,9 @@ class MetricController(rest.RestController):
                 abort(503, 'Unable to refresh metric: %s. Metric is locked. '
                       'Please try again.' % self.metric.id)
         try:
-            return pecan.request.storage.get_measures(
-                self.metric, aggregations, start, stop, resample)[aggregation]
+            return pecan.request.storage.get_aggregated_measures(
+                {self.metric: aggregations}, start, stop,
+                resample)[self.metric][aggregation]
         except storage.AggregationDoesNotExist as e:
             abort(404, six.text_type(e))
         except storage.MetricDoesNotExist:

--- a/gnocchi/tests/test_statsd.py
+++ b/gnocchi/tests/test_statsd.py
@@ -75,7 +75,8 @@ class TestStatsd(tests_base.TestCase):
 
         self.trigger_processing([metric])
 
-        measures = self.storage.get_measures(metric, self.aggregations)
+        measures = self.storage.get_aggregated_measures(
+            {metric: self.aggregations})
         self.assertEqual({"mean": [
             (datetime64(2015, 1, 7), numpy.timedelta64(1, 'D'), 1.0),
             (datetime64(2015, 1, 7, 13), numpy.timedelta64(1, 'h'), 1.0),
@@ -94,7 +95,8 @@ class TestStatsd(tests_base.TestCase):
 
         self.trigger_processing([metric])
 
-        measures = self.storage.get_measures(metric, self.aggregations)
+        measures = self.storage.get_aggregated_measures(
+            {metric: self.aggregations})
         self.assertEqual({"mean": [
             (datetime64(2015, 1, 7), numpy.timedelta64(1, 'D'), 1.5),
             (datetime64(2015, 1, 7, 13), numpy.timedelta64(1, 'h'), 1.5),
@@ -126,7 +128,8 @@ class TestStatsd(tests_base.TestCase):
 
         self.trigger_processing([metric])
 
-        measures = self.storage.get_measures(metric, self.aggregations)
+        measures = self.storage.get_aggregated_measures(
+            {metric: self.aggregations})
         self.assertEqual({"mean": [
             (datetime64(2015, 1, 7), numpy.timedelta64(1, 'D'), 1.0),
             (datetime64(2015, 1, 7, 13), numpy.timedelta64(1, 'h'), 1.0),
@@ -144,7 +147,8 @@ class TestStatsd(tests_base.TestCase):
 
         self.trigger_processing([metric])
 
-        measures = self.storage.get_measures(metric, self.aggregations)
+        measures = self.storage.get_aggregated_measures(
+            {metric: self.aggregations})
         self.assertEqual({"mean": [
             (datetime64(2015, 1, 7), numpy.timedelta64(1, 'D'), 28),
             (datetime64(2015, 1, 7, 13), numpy.timedelta64(1, 'h'), 28),


### PR DESCRIPTION
This stops using deprecated storage.get_measures and
instead uses storge.get_aggregated_measures