### PR TITLE
Stop using deprecated storage.get_measures

### DIFF
--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -194,6 +194,19 @@ def strtobool(varname, v):
         abort(400, "Unable to parse `%s': %s" % (varname, six.text_type(e)))
 
 
+def get_measures_list(measures_agg):
+    return {
+        aggmethod: list(itertools.chain(
+            *[[(timestamp, measures_agg[agg].aggregation.granularity, value)
+               for timestamp, value in measures_agg[agg]]
+              for agg in sorted(aggs,
+                                key=storage.ATTRGETTER_GRANULARITY,
+                                reverse=True)]))
+        for aggmethod, aggs in itertools.groupby(measures_agg.keys(),
+                                                 storage.ATTRGETTER_METHOD)
+    }
+
+
 RESOURCE_DEFAULT_PAGINATION = [u'revision_start:asc',
                                u'started_at:asc']
 
@@ -509,8 +522,10 @@ class MetricController(rest.RestController):
                 abort(503, 'Unable to refresh metric: %s. Metric is locked. '
                       'Please try again.' % self.metric.id)
         try:
-            return pecan.request.storage.get_measures(
-                self.metric, aggregations, start, stop, resample)[aggregation]
+            results = pecan.request.storage.get_aggregated_measures(
+                {self.metric: aggregations},
+                start, stop, resample)[self.metric]
+            return get_measures_list(results)[aggregation]
         except storage.AggregationDoesNotExist as e:
             abort(404, six.text_type(e))
         except storage.MetricDoesNotExist:
@@ -2011,9 +2026,9 @@ class AggregationController(rest.RestController):
                         },
                     })
                 try:
-                    return pecan.request.storage.get_measures(
-                        metric, aggregations, start, stop, resample
-                    )[aggregation]
+                    results = pecan.request.storage.get_aggregated_measures(
+                        {metric: aggregations}, start, stop, resample)[metric]
+                    return get_measures_list(results)[aggregation]
                 except storage.MetricDoesNotExist:
                     return []
             return processor.get_measures(

--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -281,7 +281,8 @@ class StorageDriver(object):
         return name.split("_")[-1] == 'v%s' % v
 
     def get_aggregated_measures(self, metrics_and_aggregations,
-                                from_timestamp=None, to_timestamp=None):
+                                from_timestamp=None, to_timestamp=None,
+                                resample=None):
         """Get aggregated measures from a metric.
 
         :param metrics_and_aggregations: The metrics and aggregations to
@@ -332,6 +333,8 @@ class StorageDriver(object):
                     ts.truncate(aggregation.timespan)
                 results[metric][aggregation] = ts.fetch(
                     from_timestamp, to_timestamp)
+                if resample:
+                    results[metric][aggregation] = ts.resample(resample)
 
         return results
 

--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -331,43 +331,11 @@ class StorageDriver(object):
                 # be processed. Truncate to be sure we don't return them.
                 if aggregation.timespan is not None:
                     ts.truncate(aggregation.timespan)
-                results[metric][aggregation] = ts.fetch(
-                    from_timestamp, to_timestamp)
-                if resample:
-                    results[metric][aggregation] = ts.resample(resample)
-
+                results[metric][aggregation] = ts.resample(resample) if resample \
+                    else ts
+                results[metric][aggregation] = results[metric][
+                    aggregation].fetch(from_timestamp, to_timestamp)
         return results
-
-    def get_measures(self, metric, aggregations,
-                     from_timestamp=None, to_timestamp=None,
-                     resample=None):
-        """Get aggregated measures from a metric.
-
-        Deprecated. Use `get_aggregated_measures` instead.
-
-        :param metric: The metric measured.
-        :param aggregations: The aggregations to retrieve.
-        :param from timestamp: The timestamp to get the measure from.
-        :param to timestamp: The timestamp to get the measure to.
-        :param resample: The granularity to resample to.
-        """
-        timeseries = self.get_aggregated_measures(
-            {metric: aggregations}, from_timestamp, to_timestamp)[metric]
-
-        if resample:
-            for agg, ts in six.iteritems(timeseries):
-                timeseries[agg] = ts.resample(resample)
-
-        return {
-            aggmethod: list(itertools.chain(
-                *[[(timestamp, timeseries[agg].aggregation.granularity, value)
-                   for timestamp, value in timeseries[agg]]
-                  for agg in sorted(aggs,
-                                    key=ATTRGETTER_GRANULARITY,
-                                    reverse=True)]))
-            for aggmethod, aggs in itertools.groupby(timeseries.keys(),
-                                                     ATTRGETTER_METHOD)
-        }
 
     def _get_splits_and_unserialize(self, metrics_aggregations_keys):
         """Get splits and unserialize them

--- a/gnocchi/tests/test_amqp1d.py
+++ b/gnocchi/tests/test_amqp1d.py
@@ -11,7 +11,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 import datetime
-import itertools
 import json
 import uuid
 
@@ -19,26 +18,13 @@ import mock
 import numpy
 
 from gnocchi import amqp1d
-from gnocchi import storage
 from gnocchi.tests import base as tests_base
+from gnocchi.tests.test_utils import get_measures_list
 from gnocchi import utils
 
 
 def datetime64(*args):
     return numpy.datetime64(datetime.datetime(*args))
-
-
-def get_measures_list(measures_agg):
-    return {
-        aggmethod: list(itertools.chain(
-            *[[(timestamp, measures_agg[agg].aggregation.granularity, value)
-               for timestamp, value in measures_agg[agg]]
-              for agg in sorted(aggs,
-                                key=storage.ATTRGETTER_GRANULARITY,
-                                reverse=True)]))
-        for aggmethod, aggs in itertools.groupby(measures_agg.keys(),
-                                                 storage.ATTRGETTER_METHOD)
-    }
 
 
 class TestAmqp1d(tests_base.TestCase):

--- a/gnocchi/tests/test_statsd.py
+++ b/gnocchi/tests/test_statsd.py
@@ -15,7 +15,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 import datetime
-import itertools
 import uuid
 
 import mock
@@ -23,26 +22,13 @@ import numpy
 
 from gnocchi import indexer
 from gnocchi import statsd
-from gnocchi import storage
 from gnocchi.tests import base as tests_base
+from gnocchi.tests.test_utils import get_measures_list
 from gnocchi import utils
 
 
 def datetime64(*args):
     return numpy.datetime64(datetime.datetime(*args))
-
-
-def get_measures_list(measures_agg):
-    return {
-        aggmethod: list(itertools.chain(
-            *[[(timestamp, measures_agg[agg].aggregation.granularity, value)
-               for timestamp, value in measures_agg[agg]]
-              for agg in sorted(aggs,
-                                key=storage.ATTRGETTER_GRANULARITY,
-                                reverse=True)]))
-        for aggmethod, aggs in itertools.groupby(measures_agg.keys(),
-                                                 storage.ATTRGETTER_METHOD)
-    }
 
 
 class TestStatsd(tests_base.TestCase):

--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -14,7 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 import datetime
-import itertools
 import uuid
 
 import mock
@@ -32,23 +31,11 @@ from gnocchi.storage import redis
 from gnocchi.storage import s3
 from gnocchi.storage import swift
 from gnocchi.tests import base as tests_base
+from gnocchi.tests.test_utils import get_measures_list
 
 
 def datetime64(*args):
     return numpy.datetime64(datetime.datetime(*args))
-
-
-def get_measures_list(measures_agg):
-    return {
-        aggmethod: list(itertools.chain(
-            *[[(timestamp, measures_agg[agg].aggregation.granularity, value)
-               for timestamp, value in measures_agg[agg]]
-              for agg in sorted(aggs,
-                                key=storage.ATTRGETTER_GRANULARITY,
-                                reverse=True)]))
-        for aggmethod, aggs in itertools.groupby(measures_agg.keys(),
-                                                 storage.ATTRGETTER_METHOD)
-    }
 
 
 class TestStorageDriver(tests_base.TestCase):

--- a/gnocchi/tests/test_utils.py
+++ b/gnocchi/tests/test_utils.py
@@ -19,6 +19,7 @@ import uuid
 import iso8601
 import mock
 
+from gnocchi import storage
 from gnocchi.tests import base as tests_base
 from gnocchi import utils
 
@@ -148,3 +149,16 @@ class ReturnNoneOnFailureTest(tests_base.TestCase):
             raise Exception("boom")
 
         self.assertIsNone(foobar())
+
+
+def get_measures_list(measures_agg):
+    return {
+        aggmethod: list(itertools.chain(
+            *[[(timestamp, measures_agg[agg].aggregation.granularity, value)
+               for timestamp, value in measures_agg[agg]]
+              for agg in sorted(aggs,
+                                key=storage.ATTRGETTER_GRANULARITY,
+                                reverse=True)]))
+        for aggmethod, aggs in itertools.groupby(measures_agg.keys(),
+                                                 storage.ATTRGETTER_METHOD)
+    }


### PR DESCRIPTION
This stops using deprecated storage.get_measures and instead uses storage.get_aggregated_measures