### PR TITLE
Fix computation for metrics with multiple granularities

### DIFF
--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -488,16 +488,17 @@ class StorageDriver(object):
         )
 
         aggregations_needing_list_of_keys = set()
+        oldest_values = {}
 
         for aggregation, ts in six.iteritems(aggregations_and_timeseries):
             # Don't do anything if the timeseries is empty
             if not ts:
                 continue
 
-            if aggregation.timespan:
-                oldest_point_to_keep = ts.truncate(aggregation.timespan)
-            else:
-                oldest_point_to_keep = None
+            agg_oldest_values = {
+                'oldest_point_to_keep': ts.truncate(aggregation.timespan)
+                if aggregation.timespan else None,
+                'prev_oldest_mutable_key': None, 'oldest_mutable_key': None}
 
             if previous_oldest_mutable_timestamp and (aggregation.timespan or
                                                       need_rewrite):
@@ -509,6 +510,12 @@ class StorageDriver(object):
                 # object for an old object to be cleanup
                 if previous_oldest_mutable_key != oldest_mutable_key:
                     aggregations_needing_list_of_keys.add(aggregation)
+                    agg_oldest_values['prev_oldest_mutable_key'] = (
+                        previous_oldest_mutable_key)
+                    agg_oldest_values['oldest_mutable_key'] = (
+                        oldest_mutable_key)
+
+            oldest_values[aggregation.granularity] = agg_oldest_values
 
         all_existing_keys = self._list_split_keys(
             {metric: aggregations_needing_list_of_keys})[metric]
@@ -524,7 +531,10 @@ class StorageDriver(object):
             if not ts:
                 continue
 
-            oldest_key_to_keep = ts.get_split_key(oldest_point_to_keep)
+            agg_oldest_values = oldest_values[aggregation.granularity]
+
+            oldest_key_to_keep = ts.get_split_key(
+                agg_oldest_values['oldest_point_to_keep'])
 
             # If we listed the keys for the aggregation, that's because we need
             # to check for cleanup and/or rewrite
@@ -552,8 +562,8 @@ class StorageDriver(object):
                 # not the first time we treat this timeserie.
                 if need_rewrite:
                     for key in existing_keys:
-                        if previous_oldest_mutable_key <= key:
-                            if key >= oldest_mutable_key:
+                        if agg_oldest_values['prev_oldest_mutable_key'] <= key:
+                            if key >= agg_oldest_values['oldest_mutable_key']:
                                 break
                             LOG.debug(
                                 "Compressing previous split %s (%s) for "

--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -639,6 +639,34 @@ class TestStorageDriver(tests_base.TestCase):
             (datetime64(2016, 1, 10, 17, 12), numpy.timedelta64(1, 'm'), 46),
         ]}, self.storage.get_measures(self.metric, [aggregation]))
 
+    def test_rewrite_measures_multiple_granularities(self):
+        apname = str(uuid.uuid4())
+        # Create an archive policy with two different granularities
+        ap = archive_policy.ArchivePolicy(apname, 0, [(36000, 60), (36000, 1)])
+        self.index.create_archive_policy(ap)
+        self.metric = indexer.Metric(uuid.uuid4(), ap)
+        self.index.create_metric(self.metric.id, str(uuid.uuid4()),
+                                 apname)
+
+        # First store some points
+        self.incoming.add_measures(self.metric.id, [
+            incoming.Measure(datetime64(2016, 1, 6, 18, 15, 46), 43),
+            incoming.Measure(datetime64(2016, 1, 6, 18, 15, 47), 43),
+            incoming.Measure(datetime64(2016, 1, 6, 18, 15, 48), 43),
+        ])
+        self.trigger_processing()
+
+        # Add some more points, mocking out WRITE_FULL attribute of the current
+        # driver, so that rewrite happens
+        self.incoming.add_measures(self.metric.id, [
+            incoming.Measure(datetime64(2016, 1, 7, 18, 15, 49), 43),
+            incoming.Measure(datetime64(2016, 1, 7, 18, 15, 50), 43),
+            incoming.Measure(datetime64(2016, 1, 7, 18, 18, 46), 43),
+        ])
+        driver = storage.get_driver(self.conf)
+        with mock.patch.object(driver.__class__, 'WRITE_FULL', False):
+            self.trigger_processing()
+
     def test_rewrite_measures_oldest_mutable_timestamp_eq_next_key(self):
         """See LP#1655422"""
         # Create an archive policy that spans on several splits. Each split


### PR DESCRIPTION
The high archive policy created by default contains three different
granularity definitions - 1 second, 1 hour and one day. For such
metrics the split computation has been done incorrectly as it was
using oldest keys not taking into account those keys granularity.
It caused TypeErrors when comparing two SplitKeys with different
granularities.

closes: gnocchixyz/gnocchi#959