### PR TITLE
Replace hacking by flake8 + extensions

### DIFF
--- a/gnocchi/amqp1d.py
+++ b/gnocchi/amqp1d.py
@@ -17,9 +17,12 @@ import itertools
 import uuid
 
 import daiquiri
+
 import proton.handlers
 import proton.reactor
+
 import six
+
 import ujson
 
 from gnocchi import incoming
@@ -178,11 +181,11 @@ class CollectdFormatHandler(object):
         suffix = ("-%s" % message["dsnames"][index]
                   if len(message["dsnames"]) > 1 else "")
         return (message["plugin"] + ("-" + message["plugin_instance"]
-                                     if message["plugin_instance"] else "")
-                + "@"
-                + message["type"] + ("-" + message["type_instance"]
-                                     if message["type_instance"] else "")
-                + suffix)
+                                     if message["plugin_instance"] else "") +
+                "@" +
+                message["type"] + ("-" + message["type_instance"]
+                                   if message["type_instance"] else "") +
+                suffix)
 
     def on_message(self, event):
         json_message = ujson.loads(event.message.body)

--- a/gnocchi/archive_policy.py
+++ b/gnocchi/archive_policy.py
@@ -19,8 +19,10 @@ import datetime
 import operator
 
 import numpy
+
 from oslo_config import cfg
 from oslo_config import types
+
 import six
 
 from gnocchi import carbonara
@@ -150,11 +152,11 @@ class ArchivePolicy(object):
                    d.get('aggregation_methods'))
 
     def __eq__(self, other):
-        return (isinstance(other, ArchivePolicy)
-                and self.name == other.name
-                and self.back_window == other.back_window
-                and self.definition == other.definition
-                and self.aggregation_methods == other.aggregation_methods)
+        return (isinstance(other, ArchivePolicy) and
+                self.name == other.name and
+                self.back_window == other.back_window and
+                self.definition == other.definition and
+                self.aggregation_methods == other.aggregation_methods)
 
     def jsonify(self):
         return {
@@ -183,9 +185,9 @@ OPTS = [
 
 class ArchivePolicyItem(dict):
     def __init__(self, granularity=None, points=None, timespan=None):
-        if (granularity is not None
-           and points is not None
-           and timespan is not None):
+        if (granularity is not None and
+           points is not None and
+           timespan is not None):
             if timespan != granularity * points:
                 raise ValueError(
                     u"timespan ≠ granularity × points")
@@ -199,8 +201,8 @@ class ArchivePolicyItem(dict):
         if points is not None and points <= 0:
             raise ValueError("Number of points should be > 0")
 
-        if (timespan is not None
-           and not isinstance(timespan, numpy.timedelta64)):
+        if (timespan is not None and
+           not isinstance(timespan, numpy.timedelta64)):
             timespan = numpy.timedelta64(int(timespan * 10e8), 'ns')
 
         if granularity is None:

--- a/gnocchi/chef.py
+++ b/gnocchi/chef.py
@@ -17,6 +17,7 @@
 import hashlib
 
 import daiquiri
+
 import six
 
 from gnocchi import indexer

--- a/gnocchi/cli/api.py
+++ b/gnocchi/cli/api.py
@@ -14,20 +14,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
-from distutils import spawn
 import math
 import os
 import sys
+from distutils import spawn
 
 import daiquiri
+
 from oslo_config import cfg
+
 from oslo_policy import opts as policy_opts
 
 from gnocchi import opts
-from gnocchi.rest import app
 from gnocchi import service
 from gnocchi import utils
-
+from gnocchi.rest import app
 
 LOG = daiquiri.getLogger(__name__)
 

--- a/gnocchi/cli/injector.py
+++ b/gnocchi/cli/injector.py
@@ -19,7 +19,9 @@ import time
 import uuid
 
 import daiquiri
+
 import numpy
+
 from oslo_config import cfg
 
 from gnocchi import chef

--- a/gnocchi/cli/manage.py
+++ b/gnocchi/cli/manage.py
@@ -18,8 +18,10 @@ import os
 import sys
 
 import daiquiri
+
 from oslo_config import cfg
 from oslo_config import generator
+
 import six
 
 from gnocchi import archive_policy
@@ -38,8 +40,7 @@ def config_generator():
         args = ['--output-file', 'etc/gnocchi/gnocchi.conf']
     return generator.main(['--config-file',
                            '%s/../gnocchi-config-generator.conf' %
-                           os.path.dirname(__file__)]
-                          + args)
+                           os.path.dirname(__file__)] + args)
 
 
 _SACK_NUMBER_OPT = cfg.IntOpt(
@@ -76,9 +77,9 @@ def upgrade():
         LOG.info("Upgrading incoming storage %s", i)
         i.upgrade(conf.sacks_number)
 
-    if (not conf.skip_archive_policies_creation
-            and not index.list_archive_policies()
-            and not index.list_archive_policy_rules()):
+    if (not conf.skip_archive_policies_creation and
+            not index.list_archive_policies() and
+            not index.list_archive_policy_rules()):
         if conf.skip_index:
             index = indexer.get_driver(conf)
         for name, ap in six.iteritems(archive_policy.DEFAULT_ARCHIVE_POLICIES):

--- a/gnocchi/cli/metricd.py
+++ b/gnocchi/cli/metricd.py
@@ -19,11 +19,16 @@ import time
 import uuid
 
 import cachetools.func
+
 import cotyledon
 from cotyledon import oslo_config_glue
+
 import daiquiri
+
 from oslo_config import cfg
+
 import tenacity
+
 import tooz
 from tooz import coordination
 
@@ -227,8 +232,8 @@ class MetricProcessor(MetricProcessBase):
         if self._last_full_sack_scan.elapsed() >= self.interval_delay:
             sacks = self._get_sacks_to_process()
         else:
-            sacks = (self.sacks_with_measures_to_process.copy()
-                     or self._get_sacks_to_process())
+            sacks = (self.sacks_with_measures_to_process.copy() or
+                     self._get_sacks_to_process())
         for s in sacks:
             try:
                 try:
@@ -256,7 +261,7 @@ class MetricProcessor(MetricProcessBase):
 class MetricJanitor(MetricProcessBase):
     name = "janitor"
 
-    def __init__(self,  worker_id, conf):
+    def __init__(self, worker_id, conf):
         super(MetricJanitor, self).__init__(
             worker_id, conf, conf.metricd.metric_cleanup_delay)
 

--- a/gnocchi/common/redis.py
+++ b/gnocchi/common/redis.py
@@ -17,6 +17,7 @@
 from __future__ import absolute_import
 
 from oslo_config import cfg
+
 import six
 from six.moves.urllib import parse
 

--- a/gnocchi/common/s3.py
+++ b/gnocchi/common/s3.py
@@ -30,8 +30,8 @@ LOG = daiquiri.getLogger(__name__)
 
 
 def retry_if_operationaborted(exception):
-    return (isinstance(exception, botocore.exceptions.ClientError)
-            and exception.response['Error'].get('Code') == "OperationAborted")
+    return (isinstance(exception, botocore.exceptions.ClientError) and
+            exception.response['Error'].get('Code') == "OperationAborted")
 
 
 def get_connection(conf):

--- a/gnocchi/common/swift.py
+++ b/gnocchi/common/swift.py
@@ -12,6 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 import daiquiri
+
 from six.moves.urllib.parse import quote
 
 try:
@@ -32,7 +33,7 @@ def get_connection(conf):
 
     os_options = {
         'endpoint_type': conf.swift_endpoint_type,
-        'service_type':  conf.swift_service_type,
+        'service_type': conf.swift_service_type,
         'user_domain_name': conf.swift_user_domain_name,
         'project_domain_name': conf.swift_project_domain_name,
     }

--- a/gnocchi/exceptions.py
+++ b/gnocchi/exceptions.py
@@ -15,5 +15,6 @@
 # under the License.
 
 
-class NotImplementedError(NotImplementedError):
+class NotImplementedError(NotImplementedError):  # noqa
+
     pass

--- a/gnocchi/gendoc.py
+++ b/gnocchi/gendoc.py
@@ -14,6 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 from __future__ import absolute_import
+
 import json
 import os
 import subprocess
@@ -21,10 +22,14 @@ import sys
 import tempfile
 
 import jinja2
+
 from oslo_config import generator
+
 import six
 import six.moves
+
 import webob.request
+
 import yaml
 
 from gnocchi.tests import test_rest
@@ -91,9 +96,8 @@ def _request_to_httpdomain(request):
 
 
 def _format_request_reply(request, response):
-    return (_request_to_httpdomain(request)
-            + "\n"
-            + _response_to_httpdomain(response))
+    return (_request_to_httpdomain(request) +
+            "\n" + _response_to_httpdomain(response))
 
 
 class ScenarioList(list):
@@ -214,8 +218,8 @@ def setup(app):
             request = webapp.RequestClass.from_file(fake_file)
 
             # TODO(jd) Fix this lame bug in webob < 1.7
-            if (hasattr(webob.request, "http_method_probably_has_body")
-               and request.method == "DELETE"):
+            if (hasattr(webob.request, "http_method_probably_has_body") and
+               request.method == "DELETE"):
                 # Webob has a bug it does not read the body for DELETE, l4m3r
                 clen = request.content_length
                 if clen is None:
@@ -223,7 +227,7 @@ def setup(app):
                 else:
                     request.body = fake_file.read(clen)
 
-            app.info("Doing request %s: %s" % (entry['name'],
+            app.info("Doing request %s: %s" % (entry['name'],  # noqa
                                                six.text_type(request)))
             with webapp.use_admin_user():
                 response = webapp.request(request)
@@ -244,7 +248,7 @@ def setup(app):
         f.write(content)
 
     config_output_file = 'doc/source/gnocchi.conf.sample'
-    app.info("Generating %s" % config_output_file)
+    app.info("Generating %s" % config_output_file)  # noqa
     generator.main([
         '--config-file',
         '%s/gnocchi-config-generator.conf' % os.path.dirname(__file__),

--- a/gnocchi/incoming/__init__.py
+++ b/gnocchi/incoming/__init__.py
@@ -20,12 +20,14 @@ import itertools
 import operator
 
 import daiquiri
+
 import numpy
+
 import six
 
-from gnocchi.carbonara import TIMESERIES_ARRAY_DTYPE
 from gnocchi import exceptions
 from gnocchi import utils
+from gnocchi.carbonara import TIMESERIES_ARRAY_DTYPE
 
 LOG = daiquiri.getLogger(__name__)
 
@@ -189,7 +191,7 @@ class IncomingDriver(object):
 
         :param metrics_and_measures: A dict where keys are metric objects
                                      and values are a list of
-                                     :py:class:`gnocchi.incoming.Measure`.
+                                     py:class:`gnocchi.incoming.Measure`.
         """
         self.MAP_METHOD(self._store_new_measures,
                         ((metric_id, self._encode_measures(measures))
@@ -260,7 +262,7 @@ class IncomingDriver(object):
 
 @utils.retry_on_exception_and_log("Unable to initialize incoming driver")
 def get_driver(conf):
-    """Return configured incoming driver only
+    """Return configured incoming driver only.
 
     :param conf: incoming configuration only (not global)
     """

--- a/gnocchi/incoming/ceph.py
+++ b/gnocchi/incoming/ceph.py
@@ -11,18 +11,20 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from collections import defaultdict
 import contextlib
-import daiquiri
 import datetime
 import json
 import uuid
+from collections import defaultdict
+
+import daiquiri
 
 import numpy
+
 import six
 
-from gnocchi.common import ceph
 from gnocchi import incoming
+from gnocchi.common import ceph
 
 rados = ceph.rados
 

--- a/gnocchi/incoming/file.py
+++ b/gnocchi/incoming/file.py
@@ -21,7 +21,9 @@ import tempfile
 import uuid
 
 import daiquiri
+
 import numpy
+
 import six
 
 from gnocchi import incoming

--- a/gnocchi/incoming/redis.py
+++ b/gnocchi/incoming/redis.py
@@ -17,10 +17,11 @@ import contextlib
 import uuid
 
 import daiquiri
+
 import six
 
-from gnocchi.common import redis
 from gnocchi import incoming
+from gnocchi.common import redis
 
 
 LOG = daiquiri.getLogger(__name__)

--- a/gnocchi/incoming/s3.py
+++ b/gnocchi/incoming/s3.py
@@ -13,17 +13,18 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from collections import defaultdict
 import contextlib
-import daiquiri
 import datetime
 import json
 import uuid
+from collections import defaultdict
+
+import daiquiri
 
 import numpy
 
-from gnocchi.common import s3
 from gnocchi import incoming
+from gnocchi.common import s3
 
 boto3 = s3.boto3
 botocore = s3.botocore

--- a/gnocchi/incoming/swift.py
+++ b/gnocchi/incoming/swift.py
@@ -11,18 +11,19 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from collections import defaultdict
 import contextlib
-import daiquiri
 import datetime
 import json
 import uuid
+from collections import defaultdict
+
+import daiquiri
 
 import six
 
-from gnocchi.common import swift
 from gnocchi import incoming
 from gnocchi import utils
+from gnocchi.common import swift
 
 swclient = swift.swclient
 swift_utils = swift.swift_utils

--- a/gnocchi/indexer/__init__.py
+++ b/gnocchi/indexer/__init__.py
@@ -18,9 +18,12 @@ import hashlib
 import os
 
 import iso8601
+
 from oslo_config import cfg
+
 import six
 from six.moves.urllib import parse
+
 from stevedore import driver
 
 from gnocchi import exceptions
@@ -45,16 +48,16 @@ class Resource(object):
                 return m
 
     def __eq__(self, other):
-        return (self.id == other.id
-                and self.type == other.type
-                and self.revision == other.revision
-                and self.revision_start == other.revision_start
-                and self.revision_end == other.revision_end
-                and self.creator == other.creator
-                and self.user_id == other.user_id
-                and self.project_id == other.project_id
-                and self.started_at == other.started_at
-                and self.ended_at == other.ended_at)
+        return (self.id == other.id and
+                self.type == other.type and
+                self.revision == other.revision and
+                self.revision_start == other.revision_start and
+                self.revision_end == other.revision_end and
+                self.creator == other.creator and
+                self.user_id == other.user_id and
+                self.project_id == other.project_id and
+                self.started_at == other.started_at and
+                self.ended_at == other.ended_at)
 
     @property
     def etag(self):
@@ -89,12 +92,12 @@ class Metric(object):
         return str(self.id)
 
     def __eq__(self, other):
-        return (isinstance(other, Metric)
-                and self.id == other.id
-                and self.archive_policy == other.archive_policy
-                and self.creator == other.creator
-                and self.name == other.name
-                and self.resource_id == other.resource_id)
+        return (isinstance(other, Metric) and
+                self.id == other.id and
+                self.archive_policy == other.archive_policy and
+                self.creator == other.creator and
+                self.name == other.name and
+                self.resource_id == other.resource_id)
 
     __hash__ = object.__hash__
 
@@ -114,6 +117,7 @@ class IndexerException(Exception):
 
 class NoSuchResourceType(IndexerException):
     """Error raised when the resource type is unknown."""
+
     def __init__(self, type):
         super(NoSuchResourceType, self).__init__(
             "Resource type %s does not exist" % type)
@@ -128,6 +132,7 @@ class NoSuchResourceType(IndexerException):
 
 class NoSuchMetric(IndexerException):
     """Error raised when a metric does not exist."""
+
     def __init__(self, metric):
         super(NoSuchMetric, self).__init__("Metric %s does not exist" %
                                            metric)
@@ -136,6 +141,7 @@ class NoSuchMetric(IndexerException):
 
 class NoSuchResource(IndexerException):
     """Error raised when a resource does not exist."""
+
     def __init__(self, resource):
         super(NoSuchResource, self).__init__("Resource %s does not exist" %
                                              resource)
@@ -144,6 +150,7 @@ class NoSuchResource(IndexerException):
 
 class NoSuchArchivePolicy(IndexerException):
     """Error raised when an archive policy does not exist."""
+
     def __init__(self, archive_policy):
         super(NoSuchArchivePolicy, self).__init__(
             "Archive policy %s does not exist" % archive_policy)
@@ -158,6 +165,7 @@ class NoSuchArchivePolicy(IndexerException):
 
 class UnsupportedArchivePolicyChange(IndexerException):
     """Error raised when modifying archive policy if not supported."""
+
     def __init__(self, archive_policy, message):
         super(UnsupportedArchivePolicyChange, self).__init__(
             "Archive policy %s does not support change: %s" %
@@ -168,6 +176,7 @@ class UnsupportedArchivePolicyChange(IndexerException):
 
 class ArchivePolicyInUse(IndexerException):
     """Error raised when an archive policy is still being used."""
+
     def __init__(self, archive_policy):
         super(ArchivePolicyInUse, self).__init__(
             "Archive policy %s is still in use" % archive_policy)
@@ -176,6 +185,7 @@ class ArchivePolicyInUse(IndexerException):
 
 class ResourceTypeInUse(IndexerException):
     """Error raised when an resource type is still being used."""
+
     def __init__(self, resource_type):
         super(ResourceTypeInUse, self).__init__(
             "Resource type %s is still in use" % resource_type)
@@ -184,6 +194,7 @@ class ResourceTypeInUse(IndexerException):
 
 class UnexpectedResourceTypeState(IndexerException):
     """Error raised when an resource type state is not expected."""
+
     def __init__(self, resource_type, expected_state, state):
         super(UnexpectedResourceTypeState, self).__init__(
             "Resource type %s state is %s (expected: %s)" % (
@@ -195,6 +206,7 @@ class UnexpectedResourceTypeState(IndexerException):
 
 class NoSuchArchivePolicyRule(IndexerException):
     """Error raised when an archive policy rule does not exist."""
+
     def __init__(self, archive_policy_rule):
         super(NoSuchArchivePolicyRule, self).__init__(
             "Archive policy rule %s does not exist" %
@@ -204,6 +216,7 @@ class NoSuchArchivePolicyRule(IndexerException):
 
 class NoArchivePolicyRuleMatch(IndexerException):
     """Error raised when no archive policy rule found for metric."""
+
     def __init__(self, metric_name):
         super(NoArchivePolicyRuleMatch, self).__init__(
             "No Archive policy rule found for metric %s" %
@@ -213,6 +226,7 @@ class NoArchivePolicyRuleMatch(IndexerException):
 
 class UnsupportedArchivePolicyRuleChange(IndexerException):
     """Error raised when modifying archive policy rule if not supported."""
+
     def __init__(self, archive_policy_rule, message):
         super(UnsupportedArchivePolicyRuleChange, self).__init__(
             "Archive policy rule %s does not support change: %s" %
@@ -223,6 +237,7 @@ class UnsupportedArchivePolicyRuleChange(IndexerException):
 
 class NamedMetricAlreadyExists(IndexerException):
     """Error raised when a named metric already exists."""
+
     def __init__(self, metric_name):
         super(NamedMetricAlreadyExists, self).__init__(
             "Named metric %s already exists" % metric_name)
@@ -235,6 +250,7 @@ class NamedMetricAlreadyExists(IndexerException):
 
 class ResourceAlreadyExists(IndexerException):
     """Error raised when a resource already exists."""
+
     def __init__(self, resource):
         super(ResourceAlreadyExists, self).__init__(
             "Resource %s already exists" % resource)
@@ -247,6 +263,7 @@ class ResourceAlreadyExists(IndexerException):
 
 class ResourceTypeAlreadyExists(IndexerException):
     """Error raised when a resource type already exists."""
+
     def __init__(self, resource_type):
         super(ResourceTypeAlreadyExists, self).__init__(
             "Resource type %s already exists" % resource_type)
@@ -255,6 +272,7 @@ class ResourceTypeAlreadyExists(IndexerException):
 
 class ResourceAttributeError(IndexerException, AttributeError):
     """Error raised when an attribute does not exist for a resource type."""
+
     def __init__(self, resource, attribute):
         super(ResourceAttributeError, self).__init__(
             "Resource type %s has no %s attribute" % (resource, attribute))
@@ -264,6 +282,7 @@ class ResourceAttributeError(IndexerException, AttributeError):
 
 class ResourceValueError(IndexerException, ValueError):
     """Error raised when an attribute value is invalid for a resource type."""
+
     def __init__(self, resource_type, attribute, value):
         super(ResourceValueError, self).__init__(
             "Value %s for attribute %s on resource type %s is invalid"
@@ -275,6 +294,7 @@ class ResourceValueError(IndexerException, ValueError):
 
 class ArchivePolicyAlreadyExists(IndexerException):
     """Error raised when an archive policy already exists."""
+
     def __init__(self, name):
         super(ArchivePolicyAlreadyExists, self).__init__(
             "Archive policy %s already exists" % name)
@@ -283,6 +303,7 @@ class ArchivePolicyAlreadyExists(IndexerException):
 
 class ArchivePolicyRuleAlreadyExists(IndexerException):
     """Error raised when an archive policy rule already exists."""
+
     def __init__(self, name):
         super(ArchivePolicyRuleAlreadyExists, self).__init__(
             "Archive policy rule %s already exists" % name)
@@ -313,6 +334,7 @@ class QueryAttributeError(QueryError, ResourceAttributeError):
 
 class InvalidPagination(IndexerException):
     """Error raised when a resource does not exist."""
+
     def __init__(self, reason):
         self.reason = reason
         super(InvalidPagination, self).__init__(
@@ -438,7 +460,7 @@ class IndexerDriver(object):
         raise exceptions.NotImplementedError
 
     def get_archive_policy_for_metric(self, metric_name):
-        """Helper to get the archive policy according archive policy rules."""
+        """Get the archive policy according to archive policy rules."""
         rules = self.list_archive_policy_rules()
         for rule in rules:
             if fnmatch.fnmatch(metric_name or "", rule.metric_pattern):

--- a/gnocchi/indexer/alembic/env.py
+++ b/gnocchi/indexer/alembic/env.py
@@ -78,6 +78,7 @@ def run_migrations_online():
 
     indexer.disconnect()
 
+
 # If `alembic' was used directly from the CLI
 if not hasattr(config, "conf"):
     from gnocchi import service

--- a/gnocchi/indexer/alembic/script.py.mako
+++ b/gnocchi/indexer/alembic/script.py.mako
@@ -13,7 +13,7 @@
 #    under the License.
 #
 
-"""${message}
+"""${message}.
 
 Revision ID: ${up_revision}
 Revises: ${down_revision | comma,n}

--- a/gnocchi/indexer/alembic/versions/0718ed97e5b3_add_tablename_to_resource_type.py
+++ b/gnocchi/indexer/alembic/versions/0718ed97e5b3_add_tablename_to_resource_type.py
@@ -13,7 +13,7 @@
 #    under the License.
 #
 
-"""Add tablename to resource_type
+"""Add tablename to resource_type.
 
 Revision ID: 0718ed97e5b3
 Revises: 828c16f70cce
@@ -22,6 +22,7 @@ Create Date: 2016-01-20 08:14:04.893783
 """
 
 from alembic import op
+
 import sqlalchemy as sa
 
 

--- a/gnocchi/indexer/alembic/versions/1c2c61ac1f4c_add_original_resource_id_column.py
+++ b/gnocchi/indexer/alembic/versions/1c2c61ac1f4c_add_original_resource_id_column.py
@@ -13,7 +13,7 @@
 #    under the License.
 #
 
-"""add original resource id column
+"""Add original resource id column.
 
 Revision ID: 1c2c61ac1f4c
 Revises: 1f21cbdd6bc2
@@ -22,6 +22,7 @@ Create Date: 2016-01-27 05:57:48.909012
 """
 
 from alembic import op
+
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.

--- a/gnocchi/indexer/alembic/versions/1c98ac614015_initial_base.py
+++ b/gnocchi/indexer/alembic/versions/1c98ac614015_initial_base.py
@@ -13,7 +13,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-"""Initial base for Gnocchi 1.0.0
+"""Initial base for Gnocchi 1.0.0.
 
 Revision ID: 1c98ac614015
 Revises: 

--- a/gnocchi/indexer/alembic/versions/1e1a63d3d186_original_resource_id_not_null.py
+++ b/gnocchi/indexer/alembic/versions/1e1a63d3d186_original_resource_id_not_null.py
@@ -13,7 +13,7 @@
 #    under the License.
 #
 
-"""Make sure resource.original_resource_id is NOT NULL
+"""Make sure resource.original_resource_id is NOT NULL.
 
 Revision ID: 1e1a63d3d186
 Revises: 397987e38570
@@ -22,8 +22,10 @@ Create Date: 2017-01-26 19:33:35.209688
 """
 
 from alembic import op
+
 import sqlalchemy as sa
 from sqlalchemy import func
+
 import sqlalchemy_utils
 
 

--- a/gnocchi/indexer/alembic/versions/1f21cbdd6bc2_allow_volume_display_name_to_be_null.py
+++ b/gnocchi/indexer/alembic/versions/1f21cbdd6bc2_allow_volume_display_name_to_be_null.py
@@ -13,7 +13,7 @@
 #    under the License.
 #
 
-"""allow volume display name to be null
+"""Allow volume display name to be null.
 
 Revision ID: 1f21cbdd6bc2
 Revises: 469b308577a9
@@ -22,6 +22,7 @@ Create Date: 2015-12-08 02:12:20.273880
 """
 
 from alembic import op
+
 import sqlalchemy as sa
 
 

--- a/gnocchi/indexer/alembic/versions/27d2a1d205ff_add_updating_resource_type_states.py
+++ b/gnocchi/indexer/alembic/versions/27d2a1d205ff_add_updating_resource_type_states.py
@@ -13,7 +13,7 @@
 #    under the License.
 #
 
-"""Add updating resource type states
+"""Add updating resource type states.
 
 Revision ID: 27d2a1d205ff
 Revises: 7e6f9d542f8b
@@ -22,10 +22,11 @@ Create Date: 2016-08-31 14:05:34.316496
 """
 
 from alembic import op
+
 import sqlalchemy as sa
 
-from gnocchi.indexer import sqlalchemy_types
 from gnocchi import utils
+from gnocchi.indexer import sqlalchemy_types
 
 # revision identifiers, used by Alembic.
 revision = '27d2a1d205ff'

--- a/gnocchi/indexer/alembic/versions/2e0b912062d1_drop_useless_enum.py
+++ b/gnocchi/indexer/alembic/versions/2e0b912062d1_drop_useless_enum.py
@@ -13,7 +13,7 @@
 #    under the License.
 #
 
-"""drop_useless_enum
+"""Drop useless enum.
 
 Revision ID: 2e0b912062d1
 Revises: 34c517bcc2dd

--- a/gnocchi/indexer/alembic/versions/34c517bcc2dd_shorter_foreign_key.py
+++ b/gnocchi/indexer/alembic/versions/34c517bcc2dd_shorter_foreign_key.py
@@ -13,7 +13,7 @@
 #    under the License.
 #
 
-"""shorter_foreign_key
+"""Shorten foreign keys.
 
 Revision ID: 34c517bcc2dd
 Revises: ed9c6ddc5c35
@@ -22,6 +22,7 @@ Create Date: 2016-04-13 16:58:42.536431
 """
 
 from alembic import op
+
 import sqlalchemy
 
 # revision identifiers, used by Alembic.

--- a/gnocchi/indexer/alembic/versions/3901f5ea2b8e_create_instance_disk_and_instance_.py
+++ b/gnocchi/indexer/alembic/versions/3901f5ea2b8e_create_instance_disk_and_instance_.py
@@ -13,7 +13,7 @@
 #    under the License.
 #
 
-"""create instance_disk and instance_net_int tables
+"""Create instance_disk and instance_net_int tables.
 
 Revision ID: 3901f5ea2b8e
 Revises: 42ee7f3e25f8
@@ -21,15 +21,17 @@ Create Date: 2015-08-27 17:00:25.092891
 
 """
 
+from alembic import op
+
+import sqlalchemy as sa
+
+import sqlalchemy_utils
+
 # revision identifiers, used by Alembic.
 revision = '3901f5ea2b8e'
 down_revision = '42ee7f3e25f8'
 branch_labels = None
 depends_on = None
-
-from alembic import op
-import sqlalchemy as sa
-import sqlalchemy_utils
 
 
 def upgrade():

--- a/gnocchi/indexer/alembic/versions/397987e38570_no_more_slash_and_reencode.py
+++ b/gnocchi/indexer/alembic/versions/397987e38570_no_more_slash_and_reencode.py
@@ -13,7 +13,7 @@
 #    under the License.
 #
 
-"""Remove slashes from original resource IDs, recompute their id with creator
+"""Remove slashes from original resource IDs, recompute their id with creator.
 
 Revision ID: 397987e38570
 Revises: aba5a217ca9b
@@ -23,8 +23,11 @@ Create Date: 2017-01-11 16:32:40.421758
 import uuid
 
 from alembic import op
+
 import six
+
 import sqlalchemy as sa
+
 import sqlalchemy_utils
 
 from gnocchi import utils

--- a/gnocchi/indexer/alembic/versions/39b7d449d46a_create_metric_status_column.py
+++ b/gnocchi/indexer/alembic/versions/39b7d449d46a_create_metric_status_column.py
@@ -13,7 +13,7 @@
 #    under the License.
 #
 
-"""create metric status column
+"""Create metric status column.
 
 Revision ID: 39b7d449d46a
 Revises: 3901f5ea2b8e
@@ -22,6 +22,7 @@ Create Date: 2015-09-16 13:25:34.249237
 """
 
 from alembic import op
+
 import sqlalchemy as sa
 
 

--- a/gnocchi/indexer/alembic/versions/40c6aae14c3f_ck_started_before_ended.py
+++ b/gnocchi/indexer/alembic/versions/40c6aae14c3f_ck_started_before_ended.py
@@ -1,4 +1,3 @@
-#
 # Copyright 2015 OpenStack Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -13,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-"""ck_started_before_ended
+"""Create ck_started_before_ended.
 
 Revision ID: 40c6aae14c3f
 Revises: 1c98ac614015
@@ -21,13 +20,13 @@ Create Date: 2015-04-28 16:35:11.999144
 
 """
 
+from alembic import op
+
 # revision identifiers, used by Alembic.
 revision = '40c6aae14c3f'
 down_revision = '1c98ac614015'
 branch_labels = None
 depends_on = None
-
-from alembic import op
 
 
 def upgrade():

--- a/gnocchi/indexer/alembic/versions/42ee7f3e25f8_alter_flavorid_from_int_to_string.py
+++ b/gnocchi/indexer/alembic/versions/42ee7f3e25f8_alter_flavorid_from_int_to_string.py
@@ -1,4 +1,3 @@
-#
 # Copyright 2015 OpenStack Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -13,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-"""alter flavorid from int to string
+"""Alter flavorid from int to string.
 
 Revision ID: 42ee7f3e25f8
 Revises: f7d44b47928
@@ -21,14 +20,15 @@ Create Date: 2015-05-10 21:20:24.941263
 
 """
 
+from alembic import op
+
+import sqlalchemy as sa
+
 # revision identifiers, used by Alembic.
 revision = '42ee7f3e25f8'
 down_revision = 'f7d44b47928'
 branch_labels = None
 depends_on = None
-
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/gnocchi/indexer/alembic/versions/469b308577a9_allow_image_ref_to_be_null.py
+++ b/gnocchi/indexer/alembic/versions/469b308577a9_allow_image_ref_to_be_null.py
@@ -13,7 +13,7 @@
 #    under the License.
 #
 
-"""allow image_ref to be null
+"""Allow image_ref to be null.
 
 Revision ID: 469b308577a9
 Revises: 39b7d449d46a
@@ -22,6 +22,7 @@ Create Date: 2015-11-29 00:23:39.998256
 """
 
 from alembic import op
+
 import sqlalchemy as sa
 
 

--- a/gnocchi/indexer/alembic/versions/5c4f93e5bb4_mysql_float_to_timestamp.py
+++ b/gnocchi/indexer/alembic/versions/5c4f93e5bb4_mysql_float_to_timestamp.py
@@ -15,7 +15,7 @@
 #    under the License.
 #
 
-"""mysql_float_to_timestamp
+"""Convert MySQL float to timestamp.
 
 Revision ID: 5c4f93e5bb4
 Revises: 7e6f9d542f8b
@@ -24,6 +24,7 @@ Create Date: 2016-07-25 15:36:36.469847
 """
 
 from alembic import op
+
 import sqlalchemy as sa
 from sqlalchemy.sql import func
 

--- a/gnocchi/indexer/alembic/versions/62a8dfb139bb_change_uuid_to_string.py
+++ b/gnocchi/indexer/alembic/versions/62a8dfb139bb_change_uuid_to_string.py
@@ -13,7 +13,7 @@
 #    under the License.
 #
 
-"""Change uuid to string
+"""Change uuid to string.
 
 Revision ID: 62a8dfb139bb
 Revises: 1f21cbdd6bc2
@@ -22,7 +22,9 @@ Create Date: 2016-01-20 11:57:45.954607
 """
 
 from alembic import op
+
 import sqlalchemy as sa
+
 import sqlalchemy_utils
 
 

--- a/gnocchi/indexer/alembic/versions/7e6f9d542f8b_resource_type_state_column.py
+++ b/gnocchi/indexer/alembic/versions/7e6f9d542f8b_resource_type_state_column.py
@@ -13,7 +13,7 @@
 #    under the License.
 #
 
-"""resource_type state column
+"""Add resource_type state column.
 
 Revision ID: 7e6f9d542f8b
 Revises: c62df18bf4ee
@@ -22,6 +22,7 @@ Create Date: 2016-05-19 16:52:58.939088
 """
 
 from alembic import op
+
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.

--- a/gnocchi/indexer/alembic/versions/828c16f70cce_create_resource_type_table.py
+++ b/gnocchi/indexer/alembic/versions/828c16f70cce_create_resource_type_table.py
@@ -13,7 +13,7 @@
 #    under the License.
 #
 
-"""create resource_type table
+"""Create resource_type table.
 
 Revision ID: 828c16f70cce
 Revises: 9901e5ea4b6e
@@ -22,6 +22,7 @@ Create Date: 2016-01-19 12:47:19.384127
 """
 
 from alembic import op
+
 import sqlalchemy as sa
 
 

--- a/gnocchi/indexer/alembic/versions/8f376189b9eb_migrate_legacy_resources_to_db.py
+++ b/gnocchi/indexer/alembic/versions/8f376189b9eb_migrate_legacy_resources_to_db.py
@@ -13,7 +13,7 @@
 #    under the License.
 #
 
-"""Migrate legacy resources to DB
+"""Migrate legacy resources to DB.
 
 Revision ID: 8f376189b9eb
 Revises: d24877c22ab0
@@ -23,6 +23,7 @@ Create Date: 2016-01-20 15:03:28.115656
 import json
 
 from alembic import op
+
 import sqlalchemy as sa
 
 from gnocchi.indexer import sqlalchemy_legacy_resources as legacy

--- a/gnocchi/indexer/alembic/versions/9901e5ea4b6e_create_host.py
+++ b/gnocchi/indexer/alembic/versions/9901e5ea4b6e_create_host.py
@@ -13,7 +13,7 @@
 #    under the License.
 #
 
-"""create host tables
+"""Create host tables.
 
 Revision ID: 9901e5ea4b6e
 Revises: a54c57ada3f5
@@ -21,15 +21,17 @@ Create Date: 2015-12-15 17:20:25.092891
 
 """
 
+from alembic import op
+
+import sqlalchemy as sa
+
+import sqlalchemy_utils
+
 # revision identifiers, used by Alembic.
 revision = '9901e5ea4b6e'
 down_revision = 'a54c57ada3f5'
 branch_labels = None
 depends_on = None
-
-from alembic import op
-import sqlalchemy as sa
-import sqlalchemy_utils
 
 
 def upgrade():

--- a/gnocchi/indexer/alembic/versions/a54c57ada3f5_removes_useless_indexes.py
+++ b/gnocchi/indexer/alembic/versions/a54c57ada3f5_removes_useless_indexes.py
@@ -13,7 +13,7 @@
 #    under the License.
 #
 
-"""merges primarykey and indexes
+"""Merges primarykey and indexes.
 
 Revision ID: a54c57ada3f5
 Revises: 1c2c61ac1f4c

--- a/gnocchi/indexer/alembic/versions/aba5a217ca9b_merge_created_in_creator.py
+++ b/gnocchi/indexer/alembic/versions/aba5a217ca9b_merge_created_in_creator.py
@@ -13,7 +13,7 @@
 #    under the License.
 #
 
-"""merge_created_in_creator
+"""Merge created in creator.
 
 Revision ID: aba5a217ca9b
 Revises: 5c4f93e5bb4
@@ -22,6 +22,7 @@ Create Date: 2016-12-06 17:40:25.344578
 """
 
 from alembic import op
+
 import sqlalchemy as sa
 
 
@@ -47,7 +48,7 @@ def upgrade():
             t.update().values(
                 creator=(
                     created_by_user_id_col + ":" + created_by_project_id_col
-                )).where((created_by_user_id_col is not None)
-                         | (created_by_project_id_col is not None)))
+                )).where((created_by_user_id_col is not None) |
+                         (created_by_project_id_col is not None)))
         op.drop_column(table_name, "created_by_user_id")
         op.drop_column(table_name, "created_by_project_id")

--- a/gnocchi/indexer/alembic/versions/c62df18bf4ee_add_unit_column_for_metric.py
+++ b/gnocchi/indexer/alembic/versions/c62df18bf4ee_add_unit_column_for_metric.py
@@ -13,7 +13,7 @@
 #    under the License.
 #
 
-"""add unit column for metric
+"""Add unit column for metric.
 
 Revision ID: c62df18bf4ee
 Revises: 2e0b912062d1
@@ -22,6 +22,7 @@ Create Date: 2016-05-04 12:31:25.350190
 """
 
 from alembic import op
+
 import sqlalchemy as sa
 
 

--- a/gnocchi/indexer/alembic/versions/d24877c22ab0_add_attributes_to_resource_type.py
+++ b/gnocchi/indexer/alembic/versions/d24877c22ab0_add_attributes_to_resource_type.py
@@ -13,7 +13,7 @@
 #    under the License.
 #
 
-"""Add attributes to resource_type
+"""Add attributes to resource_type.
 
 Revision ID: d24877c22ab0
 Revises: 0718ed97e5b3
@@ -22,7 +22,9 @@ Create Date: 2016-01-19 22:45:06.431190
 """
 
 from alembic import op
+
 import sqlalchemy as sa
+
 import sqlalchemy_utils as sa_utils
 
 

--- a/gnocchi/indexer/alembic/versions/ed9c6ddc5c35_fix_host_foreign_key.py
+++ b/gnocchi/indexer/alembic/versions/ed9c6ddc5c35_fix_host_foreign_key.py
@@ -13,7 +13,7 @@
 #    under the License.
 #
 
-"""fix_host_foreign_key
+"""Fix host foreign key.
 
 Revision ID: ed9c6ddc5c35
 Revises: ffc7bbeec0b0
@@ -22,6 +22,7 @@ Create Date: 2016-04-15 06:25:34.649934
 """
 
 from alembic import op
+
 from sqlalchemy import inspect
 
 # revision identifiers, used by Alembic.

--- a/gnocchi/indexer/alembic/versions/f7d44b47928_uuid_to_binary.py
+++ b/gnocchi/indexer/alembic/versions/f7d44b47928_uuid_to_binary.py
@@ -13,7 +13,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-"""uuid_to_binary
+"""Convert uuid from string to binary.
 
 Revision ID: f7d44b47928
 Revises: 40c6aae14c3f
@@ -21,14 +21,15 @@ Create Date: 2015-04-30 13:29:29.074794
 
 """
 
+from alembic import op
+
+import sqlalchemy_utils.types.uuid
+
 # revision identifiers, used by Alembic.
 revision = 'f7d44b47928'
 down_revision = '40c6aae14c3f'
 branch_labels = None
 depends_on = None
-
-from alembic import op
-import sqlalchemy_utils.types.uuid
 
 
 def upgrade():

--- a/gnocchi/indexer/alembic/versions/ffc7bbeec0b0_migrate_legacy_resources_to_db2.py
+++ b/gnocchi/indexer/alembic/versions/ffc7bbeec0b0_migrate_legacy_resources_to_db2.py
@@ -13,7 +13,7 @@
 #    under the License.
 #
 
-"""migrate_legacy_resources_to_db2
+"""Migrate legacy resources to database.
 
 Revision ID: ffc7bbeec0b0
 Revises: 8f376189b9eb
@@ -23,6 +23,7 @@ Create Date: 2016-04-14 15:57:13.072128
 import json
 
 from alembic import op
+
 import sqlalchemy as sa
 
 from gnocchi.indexer import sqlalchemy_legacy_resources as legacy

--- a/gnocchi/indexer/sqlalchemy.py
+++ b/gnocchi/indexer/sqlalchemy.py
@@ -14,6 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 from __future__ import absolute_import
+
 import datetime
 import itertools
 import operator
@@ -23,11 +24,14 @@ import uuid
 
 from alembic import migration
 from alembic import operations
+
 import daiquiri
+
 import oslo_db.api
 from oslo_db import exception
 from oslo_db.sqlalchemy import enginefacade
 from oslo_db.sqlalchemy import utils as oslo_db_utils
+
 try:
     import psycopg2
 except ImportError:
@@ -37,20 +41,23 @@ try:
     import pymysql.err
 except ImportError:
     pymysql = None
+
 import six
 from six.moves.urllib import parse as urlparse
+
 import sqlalchemy
-from sqlalchemy.engine import url as sqlalchemy_url
 import sqlalchemy.exc
 from sqlalchemy import types as sa_types
+from sqlalchemy.engine import url as sqlalchemy_url
+
 import sqlalchemy_utils
 
 from gnocchi import exceptions
 from gnocchi import indexer
-from gnocchi.indexer import sqlalchemy_base as base
-from gnocchi.indexer import sqlalchemy_types as types
 from gnocchi import resource_type
 from gnocchi import utils
+from gnocchi.indexer import sqlalchemy_base as base
+from gnocchi.indexer import sqlalchemy_types as types
 
 Base = base.Base
 Metric = base.Metric
@@ -83,10 +90,10 @@ def _retry_on_exceptions(exc):
         # Base.metadata.create_all(), sqlalchemy itself gets an error it does
         # not catch or something. So this is why this function exists. To
         # paperover I guess.
-        psycopg2
-        and isinstance(inn_e.orig, psycopg2.InternalError)
+        psycopg2 and
+        isinstance(inn_e.orig, psycopg2.InternalError) and
         # current transaction is aborted
-        and inn_e.orig.pgcode == '25P02'
+        inn_e.orig.pgcode == '25P02'
     ))
 
 
@@ -171,8 +178,8 @@ class ResourceClassMapper(object):
         try:
             mappers = self._cache[resource_type.tablename]
             # Cache is outdated
-            if (resource_type.name != "generic"
-                    and resource_type.updated_at > mappers['updated_at']):
+            if (resource_type.name != "generic" and
+                    resource_type.updated_at > mappers['updated_at']):
                 for table_purpose in ['resource', 'history']:
                     Base.metadata.remove(Base.metadata.tables[
                         mappers[table_purpose].__tablename__])
@@ -262,7 +269,7 @@ class SQLAlchemyIndexer(indexer.IndexerDriver):
 
     @classmethod
     def _create_new_database(cls, url):
-        """Used by testing to create a new database."""
+        """Create a new database (used by testing)."""
         purl = sqlalchemy_url.make_url(
             cls.dress_url(
                 url))
@@ -781,9 +788,9 @@ class SQLAlchemyIndexer(indexer.IndexerDriver):
                         started_at=None, ended_at=None, metrics=None,
                         original_resource_id=None,
                         **kwargs):
-        if (started_at is not None
-           and ended_at is not None
-           and started_at > ended_at):
+        if (started_at is not None and
+           ended_at is not None and
+           started_at > ended_at):
             raise ValueError(
                 "Start timestamp cannot be after end timestamp")
         if original_resource_id is None:
@@ -1100,7 +1107,7 @@ class SQLAlchemyIndexer(indexer.IndexerDriver):
                 grouped_by_type = itertools.groupby(
                     all_resources, lambda r: (r.revision != -1, r.type))
                 all_resources = []
-                for (is_history, type), resources in grouped_by_type:
+                for (is_history, type), resources in grouped_by_type:  # noqa
                     if type == 'generic':
                         # No need for a second query
                         all_resources.extend(resources)
@@ -1133,13 +1140,13 @@ class SQLAlchemyIndexer(indexer.IndexerDriver):
                             #    (pymysql.err.ProgrammingError)
                             #    (1146, "Table \'test.rt_f00\' doesn\'t exist")
                             # In that case, just ignore those resources.
-                            if (not pymysql
-                               or not isinstance(
-                                   e, sqlalchemy.exc.ProgrammingError)
-                               or not isinstance(
-                                   e.orig, pymysql.err.ProgrammingError)
-                               or (e.orig.args[0]
-                                   != pymysql.constants.ER.NO_SUCH_TABLE)):
+                            if (not pymysql or
+                               not isinstance(
+                                   e, sqlalchemy.exc.ProgrammingError) or
+                               not isinstance(
+                                   e.orig, pymysql.err.ProgrammingError) or
+                               (e.orig.args[0] !=
+                                   pymysql.constants.ER.NO_SUCH_TABLE)):
                                 raise
 
             return all_resources

--- a/gnocchi/indexer/sqlalchemy_base.py
+++ b/gnocchi/indexer/sqlalchemy_base.py
@@ -17,16 +17,19 @@
 from __future__ import absolute_import
 
 from oslo_db.sqlalchemy import models
+
 import six
+
 import sqlalchemy
 from sqlalchemy.ext import declarative
+
 import sqlalchemy_utils
 
 from gnocchi import archive_policy
 from gnocchi import indexer
-from gnocchi.indexer import sqlalchemy_types as types
 from gnocchi import resource_type
 from gnocchi import utils
+from gnocchi.indexer import sqlalchemy_types as types
 
 Base = declarative.declarative_base()
 
@@ -134,14 +137,14 @@ class Metric(Base, GnocchiBase, indexer.Metric):
         # archive_policy_name, and we don't compare archive_policy that might
         # not be loaded. Otherwise we fallback to the original comparison for
         # indexer.Metric.
-        return ((isinstance(other, Metric)
-                 and self.id == other.id
-                 and self.archive_policy_name == other.archive_policy_name
-                 and self.creator == other.creator
-                 and self.name == other.name
-                 and self.unit == other.unit
-                 and self.resource_id == other.resource_id)
-                or (indexer.Metric.__eq__(self, other)))
+        return ((isinstance(other, Metric) and
+                 self.id == other.id and
+                 self.archive_policy_name == other.archive_policy_name and
+                 self.creator == other.creator and
+                 self.name == other.name and
+                 self.unit == other.unit and
+                 self.resource_id == other.resource_id) or
+                indexer.Metric.__eq__(self, other))
 
     __hash__ = indexer.Metric.__hash__
 
@@ -288,7 +291,7 @@ class ResourceHistory(ResourceMixin, Base, GnocchiBase):
 
 
 class ResourceExt(object):
-    """Default extension class for plugin
+    """Default extension class for plugin.
 
     Used for plugin that doesn't need additional columns
     """

--- a/gnocchi/indexer/sqlalchemy_extension.py
+++ b/gnocchi/indexer/sqlalchemy_extension.py
@@ -15,10 +15,11 @@
 from __future__ import absolute_import
 
 import sqlalchemy
+
 import sqlalchemy_utils
 
-from gnocchi.indexer import sqlalchemy_types
 from gnocchi import resource_type
+from gnocchi.indexer import sqlalchemy_types
 
 
 class SchemaMixin(object):

--- a/gnocchi/indexer/sqlalchemy_types.py
+++ b/gnocchi/indexer/sqlalchemy_types.py
@@ -21,9 +21,10 @@ import datetime
 import decimal
 
 import iso8601
+
 import sqlalchemy
-from sqlalchemy.dialects import mysql
 from sqlalchemy import types
+from sqlalchemy.dialects import mysql
 
 from gnocchi import utils
 

--- a/gnocchi/json.py
+++ b/gnocchi/json.py
@@ -17,14 +17,16 @@ import datetime
 import uuid
 
 import numpy
+
 import six
+
 import ujson
 
 
 def to_primitive(obj):
-    if isinstance(obj, ((six.text_type,)
-                        + six.integer_types
-                        + (type(None), bool, float))):
+    if isinstance(obj, ((six.text_type,) +
+                        six.integer_types +
+                        (type(None), bool, float))):
         return obj
     if isinstance(obj, uuid.UUID):
         return six.text_type(obj)

--- a/gnocchi/opts.py
+++ b/gnocchi/opts.py
@@ -14,10 +14,11 @@
 import copy
 import itertools
 import operator
-import pkg_resources
 import uuid
 
 from oslo_config import cfg
+
+import pkg_resources
 
 import gnocchi.archive_policy
 import gnocchi.common.redis

--- a/gnocchi/resource_type.py
+++ b/gnocchi/resource_type.py
@@ -14,8 +14,11 @@
 
 import numbers
 import re
+
 import six
+
 import stevedore
+
 import voluptuous
 
 from gnocchi import utils
@@ -34,11 +37,13 @@ VALID_CHARS = re.compile("[a-zA-Z0-9][a-zA-Z0-9_]*")
 
 
 class InvalidResourceAttribute(ValueError):
+
     pass
 
 
 class InvalidResourceAttributeName(InvalidResourceAttribute):
     """Error raised when the resource attribute name is invalid."""
+
     def __init__(self, name):
         super(InvalidResourceAttributeName, self).__init__(
             "Resource attribute name %s is invalid" % str(name))
@@ -46,7 +51,8 @@ class InvalidResourceAttributeName(InvalidResourceAttribute):
 
 
 class InvalidResourceAttributeValue(InvalidResourceAttribute):
-    """Error raised when the resource attribute min is greater than max"""
+    """Error raised when the resource attribute min is greater than max."""
+
     def __init__(self, min, max):
         super(InvalidResourceAttributeValue, self).__init__(
             "Resource attribute value min (or min_length) %s must be less  "
@@ -57,6 +63,7 @@ class InvalidResourceAttributeValue(InvalidResourceAttribute):
 
 class InvalidResourceAttributeOption(InvalidResourceAttribute):
     """Error raised when the resource attribute name is invalid."""
+
     def __init__(self, name, option, reason):
         super(InvalidResourceAttributeOption, self).__init__(
             "Option '%s' of resource attribute %s is invalid: %s" %
@@ -83,8 +90,8 @@ class CommonAttributeSchema(object):
     schema_ext = None
 
     def __init__(self, type, name, required, options=None):
-        if (len(name) > 63 or name in INVALID_NAMES
-                or not VALID_CHARS.match(name)):
+        if (len(name) > 63 or name in INVALID_NAMES or
+                not VALID_CHARS.match(name)):
             raise InvalidResourceAttributeName(name)
 
         self.name = name

--- a/gnocchi/rest/aggregates/api.py
+++ b/gnocchi/rest/aggregates/api.py
@@ -19,17 +19,20 @@ import itertools
 
 import pecan
 from pecan import rest
+
 import pyparsing
+
 import six
+
 import voluptuous
 
 from gnocchi import indexer
+from gnocchi import storage
+from gnocchi import utils
+from gnocchi.rest import api
 from gnocchi.rest.aggregates import exceptions
 from gnocchi.rest.aggregates import operations as agg_operations
 from gnocchi.rest.aggregates import processor
-from gnocchi.rest import api
-from gnocchi import storage
-from gnocchi import utils
 
 
 def _OperationsSubNodeSchema(v):
@@ -37,7 +40,7 @@ def _OperationsSubNodeSchema(v):
 
 
 def MetricSchema(v):
-    """metric keyword schema
+    """Metric keyword schema.
 
     It could be:
 
@@ -126,7 +129,7 @@ def OperationsSchema(v):
 
 
 class ReferencesList(list):
-    "A very simplified OrderedSet with list interface"
+    """A very simplified OrderedSet with list interface."""
 
     def append(self, ref):
         if ref not in self:
@@ -263,8 +266,8 @@ class AggregatesController(rest.RestController):
 
             metrics = pecan.request.indexer.list_metrics(
                 attribute_filter={"in": {"id": metric_ids}})
-            missing_metric_ids = (set(metric_ids)
-                                  - set(six.text_type(m.id) for m in metrics))
+            missing_metric_ids = (set(metric_ids) -
+                                  set(six.text_type(m.id) for m in metrics))
             if missing_metric_ids:
                 api.abort(404, {"cause": "Unknown metrics",
                                 "reason": "Provided metrics don't exists",

--- a/gnocchi/rest/aggregates/exceptions.py
+++ b/gnocchi/rest/aggregates/exceptions.py
@@ -17,6 +17,7 @@
 
 class UnAggregableTimeseries(Exception):
     """Error raised when timeseries cannot be aggregated."""
+
     def __init__(self, references, reason):
         self.references = references
         self.reason = reason

--- a/gnocchi/rest/aggregates/operations.py
+++ b/gnocchi/rest/aggregates/operations.py
@@ -265,9 +265,11 @@ def evaluate(nodes, granularity, timestamps, initial_values, is_aggregated,
                                      references)
     elif nodes[0] == "metric":
         if isinstance(nodes[1], list):
-            predicat = lambda r: r in nodes[1:]
+            def predicat(r):
+                return r in nodes[1:]
         else:
-            predicat = lambda r: r == nodes[1:]
+            def predicat(r):
+                return r == nodes[1:]
         indexes = [i for i, r in enumerate(references) if predicat(r)]
         return (granularity, timestamps, initial_values.T[indexes].T,
                 is_aggregated)

--- a/gnocchi/rest/aggregates/processor.py
+++ b/gnocchi/rest/aggregates/processor.py
@@ -18,14 +18,16 @@
 import collections
 
 import daiquiri
+
 import numpy
+
 import six
 
 from gnocchi import carbonara
-from gnocchi.rest.aggregates import exceptions
-from gnocchi.rest.aggregates import operations as agg_operations
 from gnocchi import storage as gnocchi_storage
 from gnocchi import utils
+from gnocchi.rest.aggregates import exceptions
+from gnocchi.rest.aggregates import operations as agg_operations
 
 
 LOG = daiquiri.getLogger(__name__)
@@ -78,7 +80,6 @@ def get_measures(storage, references, operations,
     :param granularities: The granularities to retrieve.
     :param fill: The value to use to fill in missing data in series.
     """
-
     if granularities is None:
         all_granularities = (
             definition.granularity

--- a/gnocchi/rest/app.py
+++ b/gnocchi/rest/app.py
@@ -15,28 +15,34 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 import os
-import pkg_resources
 import threading
 import uuid
 
 import daiquiri
+
 from oslo_middleware import cors
+
 from oslo_policy import policy
+
 from paste import deploy
+
 import pecan
 from pecan import jsonify
 from pecan import templating
+
+import pkg_resources
+
 from stevedore import driver
+
 import webob.exc
 
 from gnocchi import chef
-from gnocchi.cli import metricd
 from gnocchi import exceptions
 from gnocchi import incoming as gnocchi_incoming
 from gnocchi import indexer as gnocchi_indexer
 from gnocchi import json
 from gnocchi import storage as gnocchi_storage
-
+from gnocchi.cli import metricd
 
 LOG = daiquiri.getLogger(__name__)
 

--- a/gnocchi/rest/auth_helper.py
+++ b/gnocchi/rest/auth_helper.py
@@ -15,6 +15,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 import webob
+
 import werkzeug.http
 
 from gnocchi.rest import api

--- a/gnocchi/rest/influxdb.py
+++ b/gnocchi/rest/influxdb.py
@@ -16,24 +16,29 @@
 import collections
 import time
 
-import gnocchi
-from gnocchi import incoming
-from gnocchi import indexer
-from gnocchi.rest import api
-from gnocchi import utils
-
 import daiquiri
+
 import numpy
+
 import pecan
 from pecan import rest
+
 import pyparsing
+
 import six
+
 import tenacity
+
 try:
     import uwsgi
 except ImportError:
     uwsgi = None
 
+import gnocchi
+from gnocchi import incoming
+from gnocchi import indexer
+from gnocchi import utils
+from gnocchi.rest import api
 
 LOG = daiquiri.getLogger(__name__)
 
@@ -61,7 +66,7 @@ integer = (
     pyparsing.Word(pyparsing.nums).setParseAction(
         lambda s, loc, tok: int(tok[0])) +
     pyparsing.Suppress("i")
-    )
+)
 field_value = integer | number | quoted_string
 timestamp = pyparsing.Word(pyparsing.nums).setParseAction(
     lambda s, loc, tok: numpy.datetime64(int(tok[0]), 'ns'))

--- a/gnocchi/rest/wsgi.py
+++ b/gnocchi/rest/wsgi.py
@@ -10,7 +10,8 @@
 # implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""This file is loaded by gnocchi-api when executing uwsgi"""
+"""This file is loaded by gnocchi-api when executing uwsgi."""
 from gnocchi.cli import api
 from gnocchi.rest import app
+
 application = app.load_app(api.prepare_service())

--- a/gnocchi/service.py
+++ b/gnocchi/service.py
@@ -17,8 +17,11 @@
 import logging
 
 import daiquiri
+
 from oslo_config import cfg
+
 from oslo_db import options as db_options
+
 from six.moves.urllib import parse as urlparse
 
 import gnocchi

--- a/gnocchi/setuptools.py
+++ b/gnocchi/setuptools.py
@@ -18,8 +18,8 @@ from __future__ import absolute_import
 import os
 import subprocess
 import sys
-
 from distutils import version
+
 from setuptools.command import develop
 from setuptools.command import easy_install
 from setuptools.command import egg_info

--- a/gnocchi/statsd.py
+++ b/gnocchi/statsd.py
@@ -19,8 +19,11 @@ try:
     import asyncio
 except ImportError:
     import trollius as asyncio
+
 import daiquiri
+
 from oslo_config import cfg
+
 import six
 
 from gnocchi import incoming

--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -19,8 +19,11 @@ import itertools
 import operator
 
 import daiquiri
+
 import numpy
+
 from oslo_config import cfg
+
 import six
 
 from gnocchi import carbonara
@@ -103,7 +106,7 @@ def get_driver(conf):
 
 
 class Statistics(collections.defaultdict):
-    class StatisticsTimeContext(object):
+    class StatisticsTimeContext(object):  # noqa
         def __init__(self, stats, name):
             self.stats = stats
             self.name = name + " time"
@@ -223,10 +226,9 @@ class StorageDriver(object):
         Store a bunch of splits for some metrics.
 
         :param metrics_keys_aggregations_data_offset: A dict where keys are
-                                                      `storage.Metric` and
-                                                      values are a list of
-                                                      (key, aggregation,
-                                                       data, offset) tuples.
+          `storage.Metric` and values are a list of
+          (key, aggregation, data, offset) tuples.
+
         :param version: Storage engine format version.
         """
         self.MAP_METHOD(
@@ -253,13 +255,12 @@ class StorageDriver(object):
         """List split keys for metrics.
 
         :param metrics_and_aggregations: Dict of
-                                         {`storage.Metric`:
-                                          [`carbonara.Aggregation`]}
-                                         to look for.
+         {`storage.Metric`: [`carbonara.Aggregation`]} to look for.
         :param version: Storage engine format version.
         :return: A dict where keys are `storage.Metric` and values are dicts
-                 where keys are `carbonara.Aggregation` objects and values are
-                 a set of `carbonara.SplitKey` objects.
+         where keys are `carbonara.Aggregation` objects and values are
+         a set of `carbonara.SplitKey` objects.
+
         """
         metrics = list(metrics_and_aggregations.keys())
         r = self.MAP_METHOD(
@@ -273,7 +274,6 @@ class StorageDriver(object):
 
     @staticmethod
     def _version_check(name, v):
-
         """Validate object matches expected version.
 
         Version should be last attribute and start with 'v'
@@ -283,7 +283,7 @@ class StorageDriver(object):
     def get_aggregated_measures(self, metrics_and_aggregations,
                                 from_timestamp=None, to_timestamp=None,
                                 resample=None):
-        """Get aggregated measures from a metric.
+        u"""Get aggregated measures from a metric.
 
         :param metrics_and_aggregations: The metrics and aggregations to
                                          retrieve in format
@@ -308,8 +308,8 @@ class StorageDriver(object):
                 # Replace keys with filtered version
                 metrics_aggs_keys[metric][aggregation] = [
                     key for key in sorted(keys)
-                    if ((not start or key >= start)
-                        and (not stop or key <= stop))
+                    if ((not start or key >= start) and
+                        (not stop or key <= stop))
                 ]
 
         metrics_aggregations_splits = self._get_splits_and_unserialize(
@@ -331,21 +331,21 @@ class StorageDriver(object):
                 # be processed. Truncate to be sure we don't return them.
                 if aggregation.timespan is not None:
                     ts.truncate(aggregation.timespan)
-                results[metric][aggregation] = ts.resample(resample) if resample \
-                    else ts
+                results[metric][aggregation] = (
+                    ts.resample(resample) if resample else ts
+                )
                 results[metric][aggregation] = results[metric][
                     aggregation].fetch(from_timestamp, to_timestamp)
         return results
 
     def _get_splits_and_unserialize(self, metrics_aggregations_keys):
-        """Get splits and unserialize them
+        """Get splits and unserialize them.
 
         :param metrics_aggregations_keys: A dict where keys are
-                                         `storage.Metric` and values are dict
-                                          of {Aggregation: [SplitKey]} to
-                                          retrieve.
+         `storage.Metric` and values are dict of {Aggregation: [SplitKey]} to
+         retrieve.
         :return: A dict where keys are `storage.Metric` and values are dict
-                 {aggregation: [`carbonara.AggregatedTimeSerie`]}.
+         {aggregation: [`carbonara.AggregatedTimeSerie`]}.
         """
         raw_measures = self._get_splits(metrics_aggregations_keys)
         results = collections.defaultdict(
@@ -374,10 +374,8 @@ class StorageDriver(object):
         argument, then writing it to the storage.
 
         :param metrics_keys_aggregations_splits: A dict where keys are
-                                                 `storage.Metric` and values
-                                                 are tuples of the form
-                                                 ({(key, aggregation): split},
-                                                  oldest_mutable_timestamp)
+         `storage.Metric` and values are tuples of the form
+         ({(key, aggregation): split}, oldest_mutable_timestamp).
         """
         metrics_splits_to_store = {}
         keys_to_get = collections.defaultdict(
@@ -454,8 +452,8 @@ class StorageDriver(object):
         # We only need to check for rewrite if driver is not in WRITE_FULL mode
         # and if we already stored splits once
         need_rewrite = (
-            not self.WRITE_FULL
-            and previous_oldest_mutable_timestamp is not None
+            not self.WRITE_FULL and
+            previous_oldest_mutable_timestamp is not None
         )
 
         aggregations_needing_list_of_keys = set()

--- a/gnocchi/storage/ceph.py
+++ b/gnocchi/storage/ceph.py
@@ -17,12 +17,13 @@
 import collections
 
 from oslo_config import cfg
+
 import six
 
 from gnocchi import carbonara
-from gnocchi.common import ceph
 from gnocchi import storage
 from gnocchi import utils
+from gnocchi.common import ceph
 
 
 OPTS = [
@@ -192,8 +193,8 @@ class CephStorage(storage.StorageDriver):
             for timestamp, method, granularity in six.moves.zip(
                     k_timestamps, k_methods, k_granularities):
                 for aggregation in aggregations:
-                    if (aggregation.method == method
-                       and aggregation.granularity == granularity):
+                    if (aggregation.method == method and
+                       aggregation.granularity == granularity):
                         keys[aggregation].add(carbonara.SplitKey(
                             timestamp,
                             sampling=granularity))
@@ -202,8 +203,8 @@ class CephStorage(storage.StorageDriver):
 
     @staticmethod
     def _build_unaggregated_timeserie_path(metric, version):
-        return (('gnocchi_%s_none' % metric.id)
-                + ("_v%s" % version if version else ""))
+        return (('gnocchi_%s_none' % metric.id) +
+                ("_v%s" % version if version else ""))
 
     def _get_or_create_unaggregated_timeseries_unbatched(
             self, metric, version=3):

--- a/gnocchi/storage/file.py
+++ b/gnocchi/storage/file.py
@@ -25,7 +25,9 @@ import tempfile
 import uuid
 
 import daiquiri
+
 from oslo_config import cfg
+
 import six
 
 from gnocchi import carbonara
@@ -51,7 +53,7 @@ LOG = daiquiri.getLogger(__name__)
 try:
     FileNotFoundError
 except NameError:
-    FileNotFoundError = None
+    FileNotFoundError = None  # noqa
 
 
 class FileStorage(storage.StorageDriver):
@@ -121,7 +123,7 @@ class FileStorage(storage.StorageDriver):
         if self.SUBDIR_LEN > 0:
             metric_id = metric.id.hex
             path_parts.extend(
-                [metric_id[start:start+self.SUBDIR_LEN]
+                [metric_id[start:start + self.SUBDIR_LEN]
                  for start in range(0, 32, self.SUBDIR_LEN)
                  ])
         path_parts.append(str(metric.id))
@@ -140,9 +142,9 @@ class FileStorage(storage.StorageDriver):
                                      key, version=3):
         path = os.path.join(
             self._build_metric_path(metric, aggregation),
-            str(key)
-            + "_"
-            + str(utils.timespan_total_seconds(key.sampling)))
+            str(key) +
+            "_" +
+            str(utils.timespan_total_seconds(key.sampling)))
         return path + '_v%s' % version if version else path
 
     def _create_metric(self, metric):

--- a/gnocchi/storage/redis.py
+++ b/gnocchi/storage/redis.py
@@ -18,9 +18,9 @@ import collections
 import six
 
 from gnocchi import carbonara
-from gnocchi.common import redis
 from gnocchi import storage
 from gnocchi import utils
+from gnocchi.common import redis
 
 
 class RedisStorage(storage.StorageDriver):

--- a/gnocchi/storage/s3.py
+++ b/gnocchi/storage/s3.py
@@ -16,12 +16,13 @@
 import os
 
 from oslo_config import cfg
+
 import tenacity
 
 from gnocchi import carbonara
-from gnocchi.common import s3
 from gnocchi import storage
 from gnocchi import utils
+from gnocchi.common import s3
 
 boto3 = s3.boto3
 botocore = s3.botocore
@@ -59,8 +60,8 @@ OPTS = [
 
 
 def retry_if_operationaborted(exception):
-    return (isinstance(exception, botocore.exceptions.ClientError)
-            and exception.response['Error'].get('Code') == "OperationAborted")
+    return (isinstance(exception, botocore.exceptions.ClientError) and
+            exception.response['Error'].get('Code') == "OperationAborted")
 
 
 class S3Storage(storage.StorageDriver):

--- a/gnocchi/storage/swift.py
+++ b/gnocchi/storage/swift.py
@@ -17,12 +17,13 @@
 import collections
 
 from oslo_config import cfg
+
 import six
 
 from gnocchi import carbonara
-from gnocchi.common import swift
 from gnocchi import storage
 from gnocchi import utils
+from gnocchi.common import swift
 
 swclient = swift.swclient
 swift_utils = swift.swift_utils
@@ -174,8 +175,8 @@ class SwiftStorage(storage.StorageDriver):
         raw_keys = list(map(
             lambda k: k.split("_"),
             (f['name'] for f in files
-             if self._version_check(f['name'], version)
-             and not f['name'].startswith('none'))))
+             if self._version_check(f['name'], version) and
+             not f['name'].startswith('none'))))
         keys = collections.defaultdict(set)
         if not raw_keys:
             return keys
@@ -187,8 +188,8 @@ class SwiftStorage(storage.StorageDriver):
         for timestamp, method, granularity in six.moves.zip(
                 k_timestamps, k_methods, k_granularities):
             for aggregation in aggregations:
-                if (aggregation.method == method
-                   and aggregation.granularity == granularity):
+                if (aggregation.method == method and
+                   aggregation.granularity == granularity):
                     keys[aggregation].add(carbonara.SplitKey(
                         timestamp,
                         sampling=granularity))

--- a/gnocchi/tests/base.py
+++ b/gnocchi/tests/base.py
@@ -22,24 +22,29 @@ import threading
 import uuid
 
 import daiquiri
+
 import fixtures
+
 import numpy
+
 import six
 from six.moves.urllib.parse import unquote
+
 try:
     from swiftclient import exceptions as swexc
 except ImportError:
     swexc = None
+
 from testtools import testcase
 
 from gnocchi import archive_policy
 from gnocchi import chef
-from gnocchi.cli import metricd
 from gnocchi import exceptions
 from gnocchi import incoming
 from gnocchi import indexer
 from gnocchi import service
 from gnocchi import storage
+from gnocchi.cli import metricd
 from gnocchi.tests import utils
 
 
@@ -181,15 +186,10 @@ class FakeSwiftClient(object):
 class CaptureOutput(fixtures.Fixture):
     """Optionally capture the output streams.
 
-    .. py:attribute:: stdout
-
-       The ``stream`` attribute from a :class:`StringStream` instance
-       replacing stdout.
-
-    .. py:attribute:: stderr
-
-       The ``stream`` attribute from a :class:`StringStream` instance
-       replacing stderr.
+    :ivar stdout: The ``stream`` attribute from a py:class:`StringStream`
+     instance replacing stdout.
+    :ivar stderr: The ``stream`` attribute from a py:class:`StringStream`
+     instance replacing stderr.
 
     """
 
@@ -380,7 +380,7 @@ class TestCase(BaseTestCase):
         super(TestCase, self).tearDown()
 
     def _create_metric(self, archive_policy_name="low"):
-        """Create a metric and return it"""
+        """Create a metric and return it."""
         m = indexer.Metric(uuid.uuid4(),
                            self.archive_policies[archive_policy_name])
         m_sql = self.index.create_metric(m.id, str(uuid.uuid4()),

--- a/gnocchi/tests/functional/fixtures.py
+++ b/gnocchi/tests/functional/fixtures.py
@@ -23,26 +23,32 @@ import subprocess
 import tempfile
 import threading
 import time
-from unittest import case
 import uuid
 import warnings
+from unittest import case
 
 import fixtures
+
 from gabbi import fixture
+
 import numpy
+
 from oslo_config import cfg
+
 from oslo_middleware import cors
+
 import sqlalchemy_utils
+
 import yaml
 
 from gnocchi import chef
-from gnocchi.cli import metricd
 from gnocchi import incoming
 from gnocchi import indexer
-from gnocchi.indexer import sqlalchemy
-from gnocchi.rest import app
 from gnocchi import service
 from gnocchi import storage
+from gnocchi.cli import metricd
+from gnocchi.indexer import sqlalchemy
+from gnocchi.rest import app
 from gnocchi.tests import base
 from gnocchi.tests import utils
 
@@ -217,7 +223,6 @@ class ConfigFixture(fixture.GabbiFixture):
 
     def stop_fixture(self):
         """Clean up the config fixture and storage artifacts."""
-
         if hasattr(self, 'metricd_thread'):
             self.metricd_thread.stop()
             self.metricd_thread.join()

--- a/gnocchi/tests/functional/test_gabbi.py
+++ b/gnocchi/tests/functional/test_gabbi.py
@@ -18,6 +18,7 @@
 import os
 
 from gabbi import driver
+
 import wsgi_intercept
 
 from gnocchi.tests.functional import fixtures

--- a/gnocchi/tests/functional_live/test_gabbi_live.py
+++ b/gnocchi/tests/functional_live/test_gabbi_live.py
@@ -18,6 +18,7 @@
 import os
 
 from gabbi import driver
+
 import six.moves.urllib.parse as urlparse
 
 

--- a/gnocchi/tests/indexer/sqlalchemy/test_migrations.py
+++ b/gnocchi/tests/indexer/sqlalchemy/test_migrations.py
@@ -15,11 +15,16 @@
 import abc
 
 import fixtures
+
 import mock
+
 import oslo_db.exception
 from oslo_db.sqlalchemy import test_migrations
+
 import six
+
 import sqlalchemy.schema
+
 import sqlalchemy_utils
 
 from gnocchi import indexer

--- a/gnocchi/tests/test_aggregates.py
+++ b/gnocchi/tests/test_aggregates.py
@@ -18,14 +18,15 @@ import functools
 import uuid
 
 import mock
+
 import numpy
 
 from gnocchi import carbonara
 from gnocchi import incoming
 from gnocchi import indexer
+from gnocchi import storage
 from gnocchi.rest.aggregates import exceptions
 from gnocchi.rest.aggregates import processor
-from gnocchi import storage
 from gnocchi.tests import base
 
 
@@ -44,7 +45,7 @@ def datetime64(*args):
 class TestAggregatedTimeseries(base.BaseTestCase):
     @staticmethod
     def _resample_and_merge(ts, agg_dict):
-        """Helper method that mimics _compute_splits_operations workflow."""
+        """Mimic _compute_splits_operations workflow."""
         grouped = ts.group_serie(agg_dict['sampling'])
         existing = agg_dict.get('return')
         name = agg_dict.get("name")

--- a/gnocchi/tests/test_amqp1d.py
+++ b/gnocchi/tests/test_amqp1d.py
@@ -15,12 +15,13 @@ import json
 import uuid
 
 import mock
+
 import numpy
 
 from gnocchi import amqp1d
+from gnocchi import utils
 from gnocchi.tests import base as tests_base
 from gnocchi.tests.test_utils import get_measures_list
-from gnocchi import utils
 
 
 def datetime64(*args):

--- a/gnocchi/tests/test_archive_policy.py
+++ b/gnocchi/tests/test_archive_policy.py
@@ -57,8 +57,8 @@ class TestArchivePolicy(base.BaseTestCase):
                                           [],
                                           ["*", "-mean"])
         self.assertEqual(
-            (archive_policy.ArchivePolicy.VALID_AGGREGATION_METHODS
-             - set(["mean"])),
+            (archive_policy.ArchivePolicy.VALID_AGGREGATION_METHODS -
+             set(["mean"])),
             ap.aggregation_methods)
 
         ap = archive_policy.ArchivePolicy("foobar",
@@ -66,8 +66,8 @@ class TestArchivePolicy(base.BaseTestCase):
                                           [],
                                           ["-mean", "-last"])
         self.assertEqual(
-            (set(conf.archive_policy.default_aggregation_methods)
-             - set(["mean", "last"])),
+            (set(conf.archive_policy.default_aggregation_methods) -
+             set(["mean", "last"])),
             ap.aggregation_methods)
 
         ap = archive_policy.ArchivePolicy("foobar",

--- a/gnocchi/tests/test_carbonara.py
+++ b/gnocchi/tests/test_carbonara.py
@@ -19,8 +19,11 @@ import math
 import operator
 
 import fixtures
+
 import iso8601
+
 import numpy
+
 import six
 
 from gnocchi import carbonara
@@ -398,7 +401,7 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
 
     @staticmethod
     def _resample_and_merge(ts, agg_dict):
-        """Helper method that mimics _compute_splits_operations workflow."""
+        """Mimic _compute_splits_operations workflow."""
         grouped = ts.group_serie(agg_dict['sampling'])
         existing = agg_dict.get('return')
         agg_dict['return'] = carbonara.AggregatedTimeSerie.from_grouped_serie(
@@ -860,8 +863,8 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
         grouped_points = list(agg.split())
 
         self.assertEqual(
-            math.ceil((points / sampling.astype(float))
-                      / carbonara.SplitKey.POINTS_PER_SPLIT),
+            math.ceil((points / sampling.astype(float)) /
+                      carbonara.SplitKey.POINTS_PER_SPLIT),
             len(grouped_points))
         self.assertEqual("0.0",
                          str(carbonara.SplitKey(grouped_points[0][0], 0)))

--- a/gnocchi/tests/test_indexer.py
+++ b/gnocchi/tests/test_indexer.py
@@ -18,12 +18,13 @@ import operator
 import uuid
 
 import mock
+
 import numpy
 
 from gnocchi import archive_policy
 from gnocchi import indexer
-from gnocchi.tests import base as tests_base
 from gnocchi import utils
+from gnocchi.tests import base as tests_base
 
 
 class MockException(Exception):
@@ -39,12 +40,11 @@ class TestIndexer(tests_base.TestCase):
 class TestIndexerDriver(tests_base.TestCase):
 
     def test_str(self):
-        self.assertEqual("%s: %s" % (self.index.__class__.__name__,
-                                     self.conf.indexer.url.replace(
-                                         "root@", "").replace(
-                                             "localhost", "***:***@localhost"
-                                         )),
-                         str(self.index))
+        self.assertEqual("%s: %s" % (
+            self.index.__class__.__name__,
+            self.conf.indexer.url.replace("root@", "").replace(
+                "localhost", "***:***@localhost")
+        ), str(self.index))
 
     def test_create_archive_policy_already_exists(self):
         # NOTE(jd) This archive policy

--- a/gnocchi/tests/test_influxdb.py
+++ b/gnocchi/tests/test_influxdb.py
@@ -14,6 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 import numpy
+
 import pyparsing
 
 from gnocchi.rest import influxdb

--- a/gnocchi/tests/test_rest.py
+++ b/gnocchi/tests/test_rest.py
@@ -18,26 +18,33 @@ import base64
 import calendar
 import contextlib
 import datetime
-from email import utils as email_utils
 import hashlib
 import json
 import uuid
+from email import utils as email_utils
 
 import fixtures
+
 import iso8601
+
 from keystonemiddleware import fixture as ksm_fixture
+
 import mock
+
 import six
+
 import testscenarios
+
 from testtools import testcase
+
 import webtest
 
 import gnocchi
 from gnocchi import archive_policy
+from gnocchi import utils
 from gnocchi.rest import api
 from gnocchi.rest import app
 from gnocchi.tests import base as tests_base
-from gnocchi import utils
 
 
 load_tests = testscenarios.load_tests_apply_scenarios
@@ -271,8 +278,8 @@ class ArchivePolicyTest(RestTest):
         self.assertEqual("application/json", result.content_type)
         ap = json.loads(result.text)
         self.assertEqual(
-            (set(self.conf.archive_policy.default_aggregation_methods)
-             - set(['mean'])),
+            (set(self.conf.archive_policy.default_aggregation_methods) -
+             set(['mean'])),
             set(ap['aggregation_methods']))
 
     def test_get_archive_policy(self):
@@ -526,13 +533,13 @@ class MetricTest(RestTest):
         now = utils.datetime_utc(2014, 1, 1, 10, 23)
         self.assertEqual([
             ['2014-01-01T10:00:00+00:00', 3600.0, 1234.2],
-            [(now
-              - datetime.timedelta(
+            [(now -
+              datetime.timedelta(
                   seconds=now.second,
                   microseconds=now.microsecond)).isoformat(),
              60.0, 1234.2],
-            [(now
-              - datetime.timedelta(
+            [(now -
+              datetime.timedelta(
                   microseconds=now.microsecond)).isoformat(),
              1.0, 1234.2]], result)
 
@@ -712,8 +719,8 @@ class ResourceTest(RestTest):
             params=self.attributes,
             status=201)
         resource = json.loads(result.text)
-        self.assertEqual("http://localhost/v1/resource/"
-                         + self.resource_type + "/" + self.attributes['id'],
+        self.assertEqual("http://localhost/v1/resource/" +
+                         self.resource_type + "/" + self.attributes['id'],
                          result.headers['Location'])
         self.assertIsNone(resource['revision_end'])
         self.assertEqual(resource['revision_start'],
@@ -786,10 +793,10 @@ class ResourceTest(RestTest):
         result = self.app.post_json("/v1/resource/" + self.resource_type,
                                     params=self.attributes,
                                     status=201)
-        result = self.app.get("/v1/resource/"
-                              + self.resource_type
-                              + "/"
-                              + self.attributes['id'])
+        result = self.app.get("/v1/resource/" +
+                              self.resource_type +
+                              "/" +
+                              self.attributes['id'])
         resource = json.loads(result.text)
         self.assertIsNone(resource['revision_end'])
         self.assertEqual(resource['revision_start'],
@@ -803,10 +810,10 @@ class ResourceTest(RestTest):
         result = self.app.post_json("/v1/resource/" + self.resource_type,
                                     params=self.attributes,
                                     status=201)
-        result = self.app.get("/v1/resource/"
-                              + self.resource_type
-                              + "/"
-                              + self.attributes['id'])
+        result = self.app.get("/v1/resource/" +
+                              self.resource_type +
+                              "/" +
+                              self.attributes['id'])
         resource = json.loads(result.text)
         etag = hashlib.sha1()
         etag.update(resource['id'].encode('utf-8'))
@@ -816,116 +823,116 @@ class ResourceTest(RestTest):
         oldlastmodified = self._strtime_to_httpdate("2000-01-01 00:00:00")
 
         # if-match and if-unmodified-since
-        self.app.get("/v1/resource/" + self.resource_type
-                     + "/" + self.attributes['id'],
+        self.app.get("/v1/resource/" + self.resource_type +
+                     "/" + self.attributes['id'],
                      headers={'if-match': 'fake'},
                      status=412)
-        self.app.get("/v1/resource/" + self.resource_type
-                     + "/" + self.attributes['id'],
+        self.app.get("/v1/resource/" + self.resource_type +
+                     "/" + self.attributes['id'],
                      headers={'if-match': etag},
                      status=200)
-        self.app.get("/v1/resource/" + self.resource_type
-                     + "/" + self.attributes['id'],
+        self.app.get("/v1/resource/" + self.resource_type +
+                     "/" + self.attributes['id'],
                      headers={'if-unmodified-since': lastmodified},
                      status=200)
-        self.app.get("/v1/resource/" + self.resource_type
-                     + "/" + self.attributes['id'],
+        self.app.get("/v1/resource/" + self.resource_type +
+                     "/" + self.attributes['id'],
                      headers={'if-unmodified-since': oldlastmodified},
                      status=412)
         # Some case with '*'
-        self.app.get("/v1/resource/" + self.resource_type
-                     + "/" + self.attributes['id'],
+        self.app.get("/v1/resource/" + self.resource_type +
+                     "/" + self.attributes['id'],
                      headers={'if-none-match': '*'},
                      status=304)
-        self.app.get("/v1/resource/" + self.resource_type
-                     + "/wrongid",
+        self.app.get("/v1/resource/" + self.resource_type +
+                     "/wrongid",
                      headers={'if-none-match': '*'},
                      status=404)
         # always prefers if-match if both provided
-        self.app.get("/v1/resource/" + self.resource_type
-                     + "/" + self.attributes['id'],
+        self.app.get("/v1/resource/" + self.resource_type +
+                     "/" + self.attributes['id'],
                      headers={'if-match': etag,
                               'if-unmodified-since': lastmodified},
                      status=200)
-        self.app.get("/v1/resource/" + self.resource_type
-                     + "/" + self.attributes['id'],
+        self.app.get("/v1/resource/" + self.resource_type +
+                     "/" + self.attributes['id'],
                      headers={'if-match': etag,
                               'if-unmodified-since': oldlastmodified},
                      status=200)
-        self.app.get("/v1/resource/" + self.resource_type
-                     + "/" + self.attributes['id'],
+        self.app.get("/v1/resource/" + self.resource_type +
+                     "/" + self.attributes['id'],
                      headers={'if-match': '*',
                               'if-unmodified-since': oldlastmodified},
                      status=200)
 
         # if-none-match and if-modified-since
-        self.app.get("/v1/resource/" + self.resource_type
-                     + "/" + self.attributes['id'],
+        self.app.get("/v1/resource/" + self.resource_type +
+                     "/" + self.attributes['id'],
                      headers={'if-none-match': etag},
                      status=304)
-        self.app.get("/v1/resource/" + self.resource_type
-                     + "/" + self.attributes['id'],
+        self.app.get("/v1/resource/" + self.resource_type +
+                     "/" + self.attributes['id'],
                      headers={'if-none-match': 'fake'},
                      status=200)
-        self.app.get("/v1/resource/" + self.resource_type
-                     + "/" + self.attributes['id'],
+        self.app.get("/v1/resource/" + self.resource_type +
+                     "/" + self.attributes['id'],
                      headers={'if-modified-since': lastmodified},
                      status=304)
-        self.app.get("/v1/resource/" + self.resource_type
-                     + "/" + self.attributes['id'],
+        self.app.get("/v1/resource/" + self.resource_type +
+                     "/" + self.attributes['id'],
                      headers={'if-modified-since': oldlastmodified},
                      status=200)
         # always prefers if-none-match if both provided
-        self.app.get("/v1/resource/" + self.resource_type
-                     + "/" + self.attributes['id'],
+        self.app.get("/v1/resource/" + self.resource_type +
+                     "/" + self.attributes['id'],
                      headers={'if-modified-since': oldlastmodified,
                               'if-none-match': etag},
                      status=304)
-        self.app.get("/v1/resource/" + self.resource_type
-                     + "/" + self.attributes['id'],
+        self.app.get("/v1/resource/" + self.resource_type +
+                     "/" + self.attributes['id'],
                      headers={'if-modified-since': oldlastmodified,
                               'if-none-match': '*'},
                      status=304)
-        self.app.get("/v1/resource/" + self.resource_type
-                     + "/" + self.attributes['id'],
+        self.app.get("/v1/resource/" + self.resource_type +
+                     "/" + self.attributes['id'],
                      headers={'if-modified-since': lastmodified,
                               'if-none-match': '*'},
                      status=304)
         # Some case with '*'
-        self.app.get("/v1/resource/" + self.resource_type
-                     + "/" + self.attributes['id'],
+        self.app.get("/v1/resource/" + self.resource_type +
+                     "/" + self.attributes['id'],
                      headers={'if-match': '*'},
                      status=200)
-        self.app.get("/v1/resource/" + self.resource_type
-                     + "/wrongid",
+        self.app.get("/v1/resource/" + self.resource_type +
+                     "/wrongid",
                      headers={'if-match': '*'},
                      status=404)
 
         # if-none-match and if-match
-        self.app.get("/v1/resource/" + self.resource_type
-                     + "/" + self.attributes['id'],
+        self.app.get("/v1/resource/" + self.resource_type +
+                     "/" + self.attributes['id'],
                      headers={'if-none-match': etag,
                               'if-match': etag},
                      status=304)
 
         # if-none-match returns 412 instead 304 for PUT/PATCH/DELETE
-        self.app.patch_json("/v1/resource/" + self.resource_type
-                            + "/" + self.attributes['id'],
+        self.app.patch_json("/v1/resource/" + self.resource_type +
+                            "/" + self.attributes['id'],
                             headers={'if-none-match': '*'},
                             status=412)
-        self.app.delete("/v1/resource/" + self.resource_type
-                        + "/" + self.attributes['id'],
+        self.app.delete("/v1/resource/" + self.resource_type +
+                        "/" + self.attributes['id'],
                         headers={'if-none-match': '*'},
                         status=412)
 
         # if-modified-since is ignored with PATCH/PUT/DELETE
-        self.app.patch_json("/v1/resource/" + self.resource_type
-                            + "/" + self.attributes['id'],
+        self.app.patch_json("/v1/resource/" + self.resource_type +
+                            "/" + self.attributes['id'],
                             params=self.patchable_attributes,
                             headers={'if-modified-since': lastmodified},
                             status=200)
-        self.app.delete("/v1/resource/" + self.resource_type
-                        + "/" + self.attributes['id'],
+        self.app.delete("/v1/resource/" + self.resource_type +
+                        "/" + self.attributes['id'],
                         headers={'if-modified-since': lastmodified},
                         status=204)
 
@@ -934,10 +941,10 @@ class ResourceTest(RestTest):
             self.app.post_json("/v1/resource/" + self.resource_type,
                                params=self.attributes,
                                status=201)
-            self.app.get("/v1/resource/"
-                         + self.resource_type
-                         + "/"
-                         + self.attributes['id'],
+            self.app.get("/v1/resource/" +
+                         self.resource_type +
+                         "/" +
+                         self.attributes['id'],
                          status=200)
 
     def test_get_resource_unauthorized(self):
@@ -945,21 +952,21 @@ class ResourceTest(RestTest):
                            params=self.attributes,
                            status=201)
         with self.app.use_another_user():
-            self.app.get("/v1/resource/"
-                         + self.resource_type
-                         + "/"
-                         + self.attributes['id'],
+            self.app.get("/v1/resource/" +
+                         self.resource_type +
+                         "/" +
+                         self.attributes['id'],
                          status=403)
 
     def test_get_resource_named_metric(self):
         self.attributes['metrics'] = {'foo': {'archive_policy_name': "high"}}
         self.app.post_json("/v1/resource/" + self.resource_type,
                            params=self.attributes)
-        self.app.get("/v1/resource/"
-                     + self.resource_type
-                     + "/"
-                     + self.attributes['id']
-                     + "/metric/foo/measures",
+        self.app.get("/v1/resource/" +
+                     self.resource_type +
+                     "/" +
+                     self.attributes['id'] +
+                     "/metric/foo/measures",
                      status=200)
 
     def test_list_resource_metrics_unauthorized(self):
@@ -968,35 +975,35 @@ class ResourceTest(RestTest):
                            params=self.attributes)
         with self.app.use_another_user():
             self.app.get(
-                "/v1/resource/" + self.resource_type
-                + "/" + self.attributes['id'] + "/metric",
+                "/v1/resource/" + self.resource_type +
+                "/" + self.attributes['id'] + "/metric",
                 status=403)
 
     def test_delete_resource_named_metric(self):
         self.attributes['metrics'] = {'foo': {'archive_policy_name': "high"}}
         self.app.post_json("/v1/resource/" + self.resource_type,
                            params=self.attributes)
-        self.app.delete("/v1/resource/"
-                        + self.resource_type
-                        + "/"
-                        + self.attributes['id']
-                        + "/metric/foo",
+        self.app.delete("/v1/resource/" +
+                        self.resource_type +
+                        "/" +
+                        self.attributes['id'] +
+                        "/metric/foo",
                         status=204)
-        self.app.delete("/v1/resource/"
-                        + self.resource_type
-                        + "/"
-                        + self.attributes['id']
-                        + "/metric/foo/measures",
+        self.app.delete("/v1/resource/" +
+                        self.resource_type +
+                        "/" +
+                        self.attributes['id'] +
+                        "/metric/foo/measures",
                         status=404)
 
     def test_get_resource_unknown_named_metric(self):
         self.app.post_json("/v1/resource/" + self.resource_type,
                            params=self.attributes)
-        self.app.get("/v1/resource/"
-                     + self.resource_type
-                     + "/"
-                     + self.attributes['id']
-                     + "/metric/foo",
+        self.app.get("/v1/resource/" +
+                     self.resource_type +
+                     "/" +
+                     self.attributes['id'] +
+                     "/metric/foo",
                      status=404)
 
     def test_post_append_metrics_already_exists(self):
@@ -1004,19 +1011,19 @@ class ResourceTest(RestTest):
                            params=self.attributes)
 
         metrics = {'foo': {'archive_policy_name': "high"}}
-        self.app.post_json("/v1/resource/" + self.resource_type
-                           + "/" + self.attributes['id'] + "/metric",
+        self.app.post_json("/v1/resource/" + self.resource_type +
+                           "/" + self.attributes['id'] + "/metric",
                            params=metrics, status=200)
         metrics = {'foo': {'archive_policy_name': "low"}}
-        self.app.post_json("/v1/resource/" + self.resource_type
-                           + "/" + self.attributes['id']
-                           + "/metric",
+        self.app.post_json("/v1/resource/" + self.resource_type +
+                           "/" + self.attributes['id'] +
+                           "/metric",
                            params=metrics,
                            status=409)
 
-        result = self.app.get("/v1/resource/"
-                              + self.resource_type + "/"
-                              + self.attributes['id'])
+        result = self.app.get("/v1/resource/" +
+                              self.resource_type + "/" +
+                              self.attributes['id'])
         result = json.loads(result.text)
         self.assertTrue(uuid.UUID(result['metrics']['foo']))
 
@@ -1025,12 +1032,12 @@ class ResourceTest(RestTest):
                            params=self.attributes)
 
         metrics = {'foo': {'archive_policy_name': "high"}}
-        self.app.post_json("/v1/resource/" + self.resource_type
-                           + "/" + self.attributes['id'] + "/metric",
+        self.app.post_json("/v1/resource/" + self.resource_type +
+                           "/" + self.attributes['id'] + "/metric",
                            params=metrics, status=200)
-        result = self.app.get("/v1/resource/"
-                              + self.resource_type + "/"
-                              + self.attributes['id'])
+        result = self.app.get("/v1/resource/" +
+                              self.resource_type + "/" +
+                              self.attributes['id'])
         result = json.loads(result.text)
         self.assertTrue(uuid.UUID(result['metrics']['foo']))
 
@@ -1042,8 +1049,8 @@ class ResourceTest(RestTest):
                 "/v1/metric",
                 params={'archive_policy_name': "high"})
         metric_id = json.loads(metric.text)['id']
-        result = self.app.post_json("/v1/resource/" + self.resource_type
-                                    + "/" + self.attributes['id'] + "/metric",
+        result = self.app.post_json("/v1/resource/" + self.resource_type +
+                                    "/" + self.attributes['id'] + "/metric",
                                     params={str(uuid.uuid4()): metric_id},
                                     status=400)
         self.assertIn("Metric %s does not exist" % metric_id, result.text)
@@ -1059,13 +1066,13 @@ class ResourceTest(RestTest):
         utcnow.return_value = utils.datetime_utc(2014, 1, 2, 6, 49)
         new_metrics = {'foo': {'archive_policy_name': "medium"}}
         self.app.patch_json(
-            "/v1/resource/" + self.resource_type + "/"
-            + self.attributes['id'],
+            "/v1/resource/" + self.resource_type + "/" +
+            self.attributes['id'],
             params={'metrics': new_metrics},
             status=200)
-        result = self.app.get("/v1/resource/"
-                              + self.resource_type + "/"
-                              + self.attributes['id'])
+        result = self.app.get("/v1/resource/" +
+                              self.resource_type + "/" +
+                              self.attributes['id'])
         result = json.loads(result.text)
         self.assertTrue(uuid.UUID(result['metrics']['foo']))
         self.assertIsNone(result['revision_end'])
@@ -1090,17 +1097,17 @@ class ResourceTest(RestTest):
                 params={'archive_policy_name': "medium"})
         metric_id = json.loads(result.text)['id']
         result = self.app.patch_json(
-            "/v1/resource/"
-            + self.resource_type
-            + "/"
-            + self.attributes['id'],
+            "/v1/resource/" +
+            self.resource_type +
+            "/" +
+            self.attributes['id'],
             params={'metrics': {'foo': metric_id}},
             status=400)
         self.assertIn("Metric %s does not exist" % metric_id, result.text)
-        result = self.app.get("/v1/resource/"
-                              + self.resource_type
-                              + "/"
-                              + self.attributes['id'])
+        result = self.app.get("/v1/resource/" +
+                              self.resource_type +
+                              "/" +
+                              self.attributes['id'])
         result = json.loads(result.text)
         self.assertEqual({}, result['metrics'])
 
@@ -1110,17 +1117,17 @@ class ResourceTest(RestTest):
                            status=201)
         e1 = str(uuid.uuid4())
         result = self.app.patch_json(
-            "/v1/resource/"
-            + self.resource_type
-            + "/"
-            + self.attributes['id'],
+            "/v1/resource/" +
+            self.resource_type +
+            "/" +
+            self.attributes['id'],
             params={'metrics': {'foo': e1}},
             status=400)
         self.assertIn("Metric %s does not exist" % e1, result.text)
-        result = self.app.get("/v1/resource/"
-                              + self.resource_type
-                              + "/"
-                              + self.attributes['id'])
+        result = self.app.get("/v1/resource/" +
+                              self.resource_type +
+                              "/" +
+                              self.attributes['id'])
         result = json.loads(result.text)
         self.assertEqual({}, result['metrics'])
 
@@ -1132,12 +1139,12 @@ class ResourceTest(RestTest):
                            status=201)
         utcnow.return_value = utils.datetime_utc(2014, 1, 2, 6, 48)
         presponse = self.app.patch_json(
-            "/v1/resource/" + self.resource_type
-            + "/" + self.attributes['id'],
+            "/v1/resource/" + self.resource_type +
+            "/" + self.attributes['id'],
             params=self.patchable_attributes,
             status=200)
-        response = self.app.get("/v1/resource/" + self.resource_type
-                                + "/" + self.attributes['id'])
+        response = self.app.get("/v1/resource/" + self.resource_type +
+                                "/" + self.attributes['id'])
         result = json.loads(response.text)
         presult = json.loads(presponse.text)
         self.assertEqual(result, presult)
@@ -1172,8 +1179,8 @@ class ResourceTest(RestTest):
                            status=201)
         with self.app.use_another_user():
             self.app.patch_json(
-                "/v1/resource/" + self.resource_type
-                + "/" + self.attributes['id'],
+                "/v1/resource/" + self.resource_type +
+                "/" + self.attributes['id'],
                 params=self.patchable_attributes,
                 status=403)
 
@@ -1182,10 +1189,10 @@ class ResourceTest(RestTest):
                            params=self.attributes,
                            status=201)
         self.app.patch_json(
-            "/v1/resource/"
-            + self.resource_type
-            + "/"
-            + self.attributes['id'],
+            "/v1/resource/" +
+            self.resource_type +
+            "/" +
+            self.attributes['id'],
             params={'ended_at': "2000-05-05 23:23:23"},
             status=400)
 
@@ -1195,15 +1202,15 @@ class ResourceTest(RestTest):
                            status=201)
         e1 = str(uuid.uuid4())
         result = self.app.patch_json(
-            "/v1/resource/" + self.resource_type + "/"
-            + self.attributes['id'],
+            "/v1/resource/" + self.resource_type + "/" +
+            self.attributes['id'],
             params={'ended_at': "2044-05-05 23:23:23",
                     'metrics': {"foo": e1}},
             status=400)
         self.assertIn("Metric %s does not exist" % e1, result.text)
-        result = self.app.get("/v1/resource/"
-                              + self.resource_type + "/"
-                              + self.attributes['id'])
+        result = self.app.get("/v1/resource/" +
+                              self.resource_type + "/" +
+                              self.attributes['id'])
         result = json.loads(result.text)
         del result['revision_start']
         del result['revision_end']
@@ -1211,15 +1218,15 @@ class ResourceTest(RestTest):
 
     def test_patch_resource_non_existent(self):
         self.app.patch_json(
-            "/v1/resource/" + self.resource_type
-            + "/" + str(uuid.uuid4()),
+            "/v1/resource/" + self.resource_type +
+            "/" + str(uuid.uuid4()),
             params={},
             status=404)
 
     def test_patch_resource_non_existent_with_body(self):
         self.app.patch_json(
-            "/v1/resource/" + self.resource_type
-            + "/" + str(uuid.uuid4()),
+            "/v1/resource/" + self.resource_type +
+            "/" + str(uuid.uuid4()),
             params=self.patchable_attributes,
             status=404)
 
@@ -1227,25 +1234,25 @@ class ResourceTest(RestTest):
         self.app.post_json("/v1/resource/" + self.resource_type,
                            params=self.attributes)
         result = self.app.patch_json(
-            "/v1/resource/" + self.resource_type + "/"
-            + self.attributes['id'],
+            "/v1/resource/" + self.resource_type + "/" +
+            self.attributes['id'],
             params={'foobar': 123},
             status=400)
-        self.assertIn(b'Invalid input: extra keys not allowed @ data['
-                      + repr(u'foobar').encode('ascii') + b"]",
+        self.assertIn(b'Invalid input: extra keys not allowed @ data[' +
+                      repr(u'foobar').encode('ascii') + b"]",
                       result.body)
 
     def test_delete_resource(self):
         self.app.post_json("/v1/resource/" + self.resource_type,
                            params=self.attributes)
-        self.app.get("/v1/resource/" + self.resource_type + "/"
-                     + self.attributes['id'],
+        self.app.get("/v1/resource/" + self.resource_type + "/" +
+                     self.attributes['id'],
                      status=200)
-        self.app.delete("/v1/resource/" + self.resource_type + "/"
-                        + self.attributes['id'],
+        self.app.delete("/v1/resource/" + self.resource_type + "/" +
+                        self.attributes['id'],
                         status=204)
-        self.app.get("/v1/resource/" + self.resource_type + "/"
-                     + self.attributes['id'],
+        self.app.get("/v1/resource/" + self.resource_type + "/" +
+                     self.attributes['id'],
                      status=404)
 
     def test_delete_resource_with_metrics(self):
@@ -1259,14 +1266,14 @@ class ResourceTest(RestTest):
                      status=200)
         self.app.post_json("/v1/resource/" + self.resource_type,
                            params=self.attributes)
-        self.app.get("/v1/resource/" + self.resource_type + "/"
-                     + self.attributes['id'],
+        self.app.get("/v1/resource/" + self.resource_type + "/" +
+                     self.attributes['id'],
                      status=200)
-        self.app.delete("/v1/resource/" + self.resource_type + "/"
-                        + self.attributes['id'],
+        self.app.delete("/v1/resource/" + self.resource_type + "/" +
+                        self.attributes['id'],
                         status=204)
-        self.app.get("/v1/resource/" + self.resource_type + "/"
-                     + self.attributes['id'],
+        self.app.get("/v1/resource/" + self.resource_type + "/" +
+                     self.attributes['id'],
                      status=404)
         self.app.get("/v1/metric/" + metric_id,
                      status=404)
@@ -1275,13 +1282,13 @@ class ResourceTest(RestTest):
         self.app.post_json("/v1/resource/" + self.resource_type,
                            params=self.attributes)
         with self.app.use_another_user():
-            self.app.delete("/v1/resource/" + self.resource_type + "/"
-                            + self.attributes['id'],
+            self.app.delete("/v1/resource/" + self.resource_type + "/" +
+                            self.attributes['id'],
                             status=403)
 
     def test_delete_resource_non_existent(self):
-        result = self.app.delete("/v1/resource/" + self.resource_type + "/"
-                                 + self.attributes['id'],
+        result = self.app.delete("/v1/resource/" + self.resource_type + "/" +
+                                 self.attributes['id'],
                                  status=404)
         self.assertIn(
             "Resource %s does not exist" % self.attributes['id'],
@@ -1296,9 +1303,9 @@ class ResourceTest(RestTest):
                                     params=self.attributes,
                                     status=201)
         resource = json.loads(result.text)
-        self.assertEqual("http://localhost/v1/resource/"
-                         + self.resource_type + "/"
-                         + self.attributes['id'],
+        self.assertEqual("http://localhost/v1/resource/" +
+                         self.resource_type + "/" +
+                         self.attributes['id'],
                          result.headers['Location'])
         self.resource['metrics'] = self.attributes['metrics']
         del resource['revision_start']
@@ -1311,9 +1318,9 @@ class ResourceTest(RestTest):
                                     params=self.attributes,
                                     status=201)
         resource = json.loads(result.text)
-        self.assertEqual("http://localhost/v1/resource/"
-                         + self.resource_type + "/"
-                         + self.attributes['id'],
+        self.assertEqual("http://localhost/v1/resource/" +
+                         self.resource_type + "/" +
+                         self.attributes['id'],
                          result.headers['Location'])
         self.assertEqual(self.attributes['id'], resource["id"])
         metric_id = uuid.UUID(resource['metrics']['foo'])
@@ -1324,8 +1331,8 @@ class ResourceTest(RestTest):
         self.app.post_json("/v1/resource/" + self.resource_type,
                            params=self.attributes,
                            status=201)
-        result = self.app.get("/v1/resource/" + self.resource_type
-                              + "/" + self.attributes['id'])
+        result = self.app.get("/v1/resource/" + self.resource_type +
+                              "/" + self.attributes['id'])
         result = json.loads(result.text)
 
         resources = self.app.post_json(
@@ -1432,8 +1439,8 @@ class ResourceTest(RestTest):
             "/v1/search/resource/" + self.resource_type,
             params={"=": {"foobar": "baz"}},
             status=400)
-        self.assertIn("Resource type " + self.resource_type
-                      + " has no foobar attribute",
+        self.assertIn("Resource type " + self.resource_type +
+                      " has no foobar attribute",
                       result.text)
 
     def test_search_resources_started_after(self):
@@ -1620,8 +1627,8 @@ class ResourceTest(RestTest):
                            params=self.attributes)
 
         result = self.app.post_json(
-            "/v1/aggregation/resource/"
-            + self.resource_type + "/metric/foo?aggregation=max",
+            "/v1/aggregation/resource/" +
+            self.resource_type + "/metric/foo?aggregation=max",
             params={"=": {"name": name}},
             status=400,
             headers={"Accept": "application/json"})
@@ -1663,25 +1670,25 @@ class ResourceTest(RestTest):
                            params=self.attributes)
 
         result = self.app.post_json(
-            "/v1/aggregation/resource/" + self.resource_type
-            + "/metric/foo?aggregation=max",
+            "/v1/aggregation/resource/" + self.resource_type +
+            "/metric/foo?aggregation=max",
             params={"=": {"name": name}},
             expect_errors=True)
         self.assertEqual(400, result.status_code, result.text)
         self.assertIn("No overlap", result.text)
 
         result = self.app.post_json(
-            "/v1/aggregation/resource/" + self.resource_type
-            + "/metric/foo?aggregation=max&needed_overlap=5&start=2013-01-01",
+            "/v1/aggregation/resource/" + self.resource_type +
+            "/metric/foo?aggregation=max&needed_overlap=5&start=2013-01-01",
             params={"=": {"name": name}},
             expect_errors=True)
         self.assertEqual(400, result.status_code, result.text)
         self.assertIn("No overlap", result.text)
 
         result = self.app.post_json(
-            "/v1/aggregation/resource/"
-            + self.resource_type + "/metric/foo?aggregation=min"
-            + "&needed_overlap=0&start=2013-01-01T00:00:00%2B00:00",
+            "/v1/aggregation/resource/" +
+            self.resource_type + "/metric/foo?aggregation=min" +
+            "&needed_overlap=0&start=2013-01-01T00:00:00%2B00:00",
             params={"=": {"name": name}})
         self.assertEqual(200, result.status_code, result.text)
         measures = json.loads(result.text)
@@ -1725,8 +1732,8 @@ class ResourceTest(RestTest):
                            params=self.attributes)
 
         result = self.app.post_json(
-            "/v1/aggregation/resource/" + self.resource_type
-            + "/metric/foo?aggregation=max",
+            "/v1/aggregation/resource/" + self.resource_type +
+            "/metric/foo?aggregation=max",
             params={"=": {"name": name}},
             expect_errors=True)
 
@@ -1738,8 +1745,8 @@ class ResourceTest(RestTest):
                          measures)
 
         result = self.app.post_json(
-            "/v1/aggregation/resource/"
-            + self.resource_type + "/metric/foo?aggregation=min",
+            "/v1/aggregation/resource/" +
+            self.resource_type + "/metric/foo?aggregation=min",
             params={"=": {"name": name}},
             expect_errors=True)
 
@@ -1752,8 +1759,8 @@ class ResourceTest(RestTest):
 
     def test_get_aggregated_measures_across_entities_no_match(self):
         result = self.app.post_json(
-            "/v1/aggregation/resource/"
-            + self.resource_type + "/metric/foo?aggregation=min",
+            "/v1/aggregation/resource/" +
+            self.resource_type + "/metric/foo?aggregation=min",
             params={"=": {"name": "none!"}},
             expect_errors=True)
 
@@ -1866,8 +1873,8 @@ class GenericResourceTest(RestTest):
             params={"wrongoperator": {"user_id": "bar"}},
             status=400)
         self.assertIn(
-            "Invalid input: extra keys not allowed @ data["
-            + repr(u'wrongoperator') + "]",
+            "Invalid input: extra keys not allowed @ data[" +
+            repr(u'wrongoperator') + "]",
             result.text)
 
 

--- a/gnocchi/tests/test_statsd.py
+++ b/gnocchi/tests/test_statsd.py
@@ -18,13 +18,14 @@ import datetime
 import uuid
 
 import mock
+
 import numpy
 
 from gnocchi import indexer
 from gnocchi import statsd
+from gnocchi import utils
 from gnocchi.tests import base as tests_base
 from gnocchi.tests.test_utils import get_measures_list
-from gnocchi import utils
 
 
 def datetime64(*args):

--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -17,7 +17,9 @@ import datetime
 import uuid
 
 import mock
+
 import numpy
+
 import six.moves
 
 from gnocchi import archive_policy
@@ -334,8 +336,8 @@ class TestStorageDriver(tests_base.TestCase):
             for metric, key_agg_data_offset in six.iteritems(args[0]):
                 if metric.id == m_sql.id:
                     for key, aggregation, data, offset in key_agg_data_offset:
-                        if (key.sampling == numpy.timedelta64(1, 'm')
-                           and aggregation.method == "mean"):
+                        if (key.sampling == numpy.timedelta64(1, 'm') and
+                           aggregation.method == "mean"):
                             count += 1
         self.assertEqual(1, count)
 
@@ -646,8 +648,8 @@ class TestStorageDriver(tests_base.TestCase):
             (datetime64(2016, 1, 6, 15, 12), numpy.timedelta64(1, 'm'), 44),
             (datetime64(2016, 1, 10, 16, 18), numpy.timedelta64(1, 'm'), 45),
             (datetime64(2016, 1, 10, 17, 12), numpy.timedelta64(1, 'm'), 46),
-            ]}, get_measures_list(self.storage.get_aggregated_measures(
-                {self.metric: [aggregation]})[self.metric]))
+        ]}, get_measures_list(self.storage.get_aggregated_measures(
+            {self.metric: [aggregation]})[self.metric]))
 
     def test_rewrite_measures_multiple_granularities(self):
         apname = str(uuid.uuid4())
@@ -678,7 +680,7 @@ class TestStorageDriver(tests_base.TestCase):
             self.trigger_processing()
 
     def test_rewrite_measures_oldest_mutable_timestamp_eq_next_key(self):
-        """See LP#1655422"""
+        # See LP#1655422
         # Create an archive policy that spans on several splits. Each split
         # being 3600 points, let's go for 36k points so we have 10 splits.
         apname = str(uuid.uuid4())
@@ -1229,7 +1231,7 @@ class TestStorageDriver(tests_base.TestCase):
             {m: [aggregation]})[m]))
 
     def test_resample_no_metric(self):
-        """https://github.com/gnocchixyz/gnocchi/issues/69"""
+        # https://github.com/gnocchixyz/gnocchi/issues/69
         aggregation = self.metric.archive_policy.get_aggregation(
             "mean", numpy.timedelta64(300, 's'))
         self.assertRaises(storage.MetricDoesNotExist,

--- a/gnocchi/tests/test_utils.py
+++ b/gnocchi/tests/test_utils.py
@@ -17,11 +17,12 @@ import os
 import uuid
 
 import iso8601
+
 import mock
 
 from gnocchi import storage
-from gnocchi.tests import base as tests_base
 from gnocchi import utils
+from gnocchi.tests import base as tests_base
 
 
 class TestUtils(tests_base.TestCase):

--- a/gnocchi/tests/utils.py
+++ b/gnocchi/tests/utils.py
@@ -12,6 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 from oslo_config import cfg
+
 from oslo_policy import opts as policy_opts
 
 from gnocchi import opts

--- a/gnocchi/utils.py
+++ b/gnocchi/utils.py
@@ -21,15 +21,22 @@ import itertools
 import multiprocessing
 import os
 import uuid
-
 from concurrent import futures
+
 import daiquiri
+
 import iso8601
+
 import monotonic
+
 import numpy
+
 import pytimeparse
+
 import six
+
 from stevedore import driver
+
 import tenacity
 
 
@@ -150,7 +157,7 @@ def timespan_total_seconds(td):
 
 
 def utcnow():
-    """Version of utcnow() that returns utcnow with a correct TZ."""
+    """Return utcnow timestamp with a correct TZ."""
     return datetime.datetime.now(tz=iso8601.iso8601.UTC)
 
 
@@ -225,6 +232,7 @@ class StopWatch(object):
 
     .. _monotonic: https://pypi.python.org/pypi/monotonic/
     """
+
     _STARTED = object()
     _STOPPED = object()
 
@@ -234,7 +242,7 @@ class StopWatch(object):
         self._state = None
 
     def start(self):
-        """Starts the watch (if not already started).
+        """Start the watch (if not already started).
 
         NOTE(harlowja): resets any splits previously captured (if any).
         """
@@ -250,7 +258,7 @@ class StopWatch(object):
         return max(0.0, later - earlier)
 
     def elapsed(self):
-        """Returns how many seconds have elapsed."""
+        """Return how many seconds have elapsed."""
         if self._state not in (self._STARTED, self._STOPPED):
             raise RuntimeError("Can not get the elapsed time of a stopwatch"
                                " if it has not been started/stopped")
@@ -262,19 +270,19 @@ class StopWatch(object):
         return elapsed
 
     def __enter__(self):
-        """Starts the watch."""
+        """Start the watch."""
         self.start()
         return self
 
     def __exit__(self, type, value, traceback):
-        """Stops the watch (ignoring errors if stop fails)."""
+        """Stop the watch (ignoring errors if stop fails)."""
         try:
             self.stop()
         except RuntimeError:
             pass
 
     def stop(self):
-        """Stops the watch."""
+        """Stop the watch."""
         if self._state == self._STOPPED:
             return self
         if self._state != self._STARTED:
@@ -305,7 +313,6 @@ def sequencial_map(fn, list_of_args):
 
 def parallel_map(fn, list_of_args):
     """Run a function in parallel."""
-
     if parallel_map.MAX_WORKERS == 1:
         return sequencial_map(fn, list_of_args)
 

--- a/tools/duration_perf_analyse.py
+++ b/tools/duration_perf_analyse.py
@@ -75,5 +75,6 @@ def main():
         print(append.describe())
         print("")
 
+
 if __name__ == '__main__':
     main()

--- a/tools/duration_perf_test.py
+++ b/tools/duration_perf_test.py
@@ -42,6 +42,7 @@ import random
 import time
 
 from keystoneclient.v2_0 import client as keystone_client
+
 import requests
 
 
@@ -189,6 +190,7 @@ def main():
                         default=100,
                         type=int)
     PerfTools(parser.parse_args()).run()
+
 
 if __name__ == '__main__':
     main()

--- a/tools/measures_injector.py
+++ b/tools/measures_injector.py
@@ -15,9 +15,10 @@
 # limitations under the License.
 import random
 import uuid
-
 from concurrent import futures
+
 from oslo_config import cfg
+
 import six
 
 from gnocchi import incoming

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,14 @@ deps = gnocchi[{env:GNOCCHI_VARIANT}]>=4.3,<4.4
 commands = pifpaf --env-prefix INDEXER run mysql -- pifpaf --env-prefix STORAGE run ceph {toxinidir}/run-upgrade-tests.sh {posargs}
 
 [testenv:pep8]
-deps = hacking>=0.12,<0.13
+basepython = python3
+deps = flake8
+       flake8-import-order
+       flake8-blind-except
+       flake8-builtins
+       flake8-docstrings
+       flake8-rst-docstrings
+       flake8-logging-format
 commands = flake8
 
 [testenv:py27-cover]
@@ -82,7 +89,9 @@ commands = pifpaf -g GNOCCHI_INDEXER_URL run postgresql -- python setup.py testr
 [flake8]
 exclude = .tox,.eggs,doc,gnocchi/rest/prometheus/remote_pb2.py
 show-source = true
-enable-extensions = H904
+ignore = D100,D101,D102,D103,D104,D105,D107,A002,A003,G200,G201
+enable-extensions=G
+application-import-names = gnocchi
 
 [testenv:docs]
 basepython = python3


### PR DESCRIPTION
Since hacking is not maintained anymore and depends on an old flake8 version,
replace it with flake8 + extensions.