### PR TITLE
docs: use remove sphinx < 1.6 limitation, disable gnocchi.xyz doc job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
 env:
   - TARGET: pep8
   - TARGET: docs
-  - TARGET: docs-gnocchi.xyz
+  # - TARGET: docs-gnocchi.xyz
 
   - TARGET: py27-mysql-ceph-upgrade-from-4.3
   - TARGET: py37-postgresql-file-upgrade-from-4.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,7 +84,7 @@ prometheus =
 amqp1:
     python-qpid-proton>=0.17.0
 doc =
-    sphinx<1.6.0
+    sphinx
     sphinx_rtd_theme
     sphinxcontrib-httpdomain
     PyYAML


### PR DESCRIPTION
This is needed by reno.
docs-gnocchi.xyz job does not work see #953