### PR TITLE
docs: use remove sphinx < 1.6 limitation, disable gnocchi.xyz doc job

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ ceph_recommended_lib =
 ceph_alternative_lib =
     python-rados>=12.2.0 # not available on pypi
 doc =
-    sphinx<1.6.0
+    sphinx
     sphinx_rtd_theme
     sphinxcontrib-httpdomain
     PyYAML


### PR DESCRIPTION
This is needed by reno.
docs-gnocchi.xyz job does not work see #953

(cherry picked from commit d8ccb18c465ca7e4118f8acb7c897b0830e8d3e4)