### PR TITLE
Fixup rendering on Pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,10 @@ notifications:
     channels:
       - "irc.freenode.org#gnocchi"
 
+before_deploy:
+  # Remove |substitutions| to fix rendering on pypi.
+  - sed -i -e 's/|\([a-zA-Z0-9 ]\+\)|/\1/g' README.rst
+
 deploy:
   provider: pypi
   user: jd


### PR DESCRIPTION
The description of the project is currently not rendered on
Pypi.  Instead, Pypi shows raw rst.  Checking the page with
"readme_renderer" reports "undefined substitutions" for "time
series" and "aggregates".

This patch adds a before_deploy section to .travis.yml that
uses sed to remove matching pairs of pipes from the README.

The resulting README was tested again with the readme renderer.

See Also:
 -   https://pypi.org/project/readme_renderer/
