### PR TITLE
fix doc formatting

### DIFF
--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -190,15 +190,16 @@ can be resampled to a new |granularity|.
 Time-series data can also be grouped by calendar dates beyond a standard day.
 The resulting groupings are tied to the leading date of the group. For example,
 grouping on month returns a monthly aggregate linked to the first of the month.
-Available calendar groups are::
-
-   `Y` - by year.
-   `H` - by half.
-   `Q` - by quarter.
-   `M` - by month.
-   `W` - by week, starting on Sunday.
 
 {{ scenarios['get-measures-resample-calendar']['doc'] }}
+
+Available calendar groups are:
+
+* `Y` – by year
+* `H` – by half
+* `Q` – by quarter
+* `M` – by month
+* `W` – by week, starting on Sunday
 
 .. note::
 


### PR DESCRIPTION
the REST output seems to be clashing with the formatting of previous
element. remove the formatting and move the REST output above.