### PR TITLE
Allow rate:XXX aggregations

### DIFF
--- a/gnocchi/rest/aggregates/operations.py
+++ b/gnocchi/rest/aggregates/operations.py
@@ -36,6 +36,19 @@ AGG_MAP = {
 }
 
 
+def rated_agg(agg):
+    def _inner_rated_agg(values, axis):
+        values = AGG_MAP[agg](values, axis)
+        values = numpy.diff(values)
+        return values
+
+    return _inner_rated_agg
+
+
+for agg in list(AGG_MAP):
+    AGG_MAP["rate:%s" % agg] = rated_agg(agg)
+
+
 # TODO(sileht): expose all operators in capability API
 binary_operators = {
     u"=": numpy.equal,
@@ -204,6 +217,8 @@ def handle_aggregate(agg, granularity, timestamps, values, is_aggregated,
     if values.shape[1] != 1:
         raise RuntimeError("Unexpected resulting aggregated array shape: %s" %
                            values)
+    if agg.startswith("rate:"):
+        timestamps = timestamps[1:]
     return (granularity, timestamps, values, True)
 
 
@@ -223,6 +238,8 @@ def handle_rolling(agg, granularity, timestamps, values, is_aggregated,
     strides = values.strides + (values.strides[-1],)
     new_values = AGG_MAP[agg](as_strided(values, shape=shape, strides=strides),
                               axis=-1)
+    if agg.startswith("rate:"):
+        timestamps = timestamps[1:]
     return granularity, timestamps, new_values.T, is_aggregated
 
 

--- a/gnocchi/tests/functional/gabbits/aggregates-with-metric-ids.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregates-with-metric-ids.yaml
@@ -319,7 +319,6 @@ tests:
           - ["2015-03-06T14:35:12+00:00", 1.0, 7.5]
           - ["2015-03-06T14:35:15+00:00", 1.0, 12.5]
 
-
     - name: get one metric
       POST: /v1/aggregates?details=true
       data:
@@ -336,6 +335,40 @@ tests:
           - ["2015-03-06T14:34:15+00:00", 1.0, -16.0]
           - ["2015-03-06T14:35:12+00:00", 1.0, 9.0]
           - ["2015-03-06T14:35:15+00:00", 1.0, 11.0]
+
+    - name: get aggregates mean
+      POST: /v1/aggregates
+      data:
+        operations:
+          - aggregate
+          - mean
+          - ["metric", ["$HISTORY['create metric1'].$RESPONSE['$.id']", "mean"], ["$HISTORY['create metric2'].$RESPONSE['$.id']", "mean"]]
+      response_json_paths:
+        $.measures.aggregated:
+          - ["2015-03-06T14:33:00+00:00", 60.0, 22.55]
+          - ["2015-03-06T14:34:00+00:00", 60.0, 1.25]
+          - ["2015-03-06T14:35:00+00:00", 60.0, 11.25]
+          - ["2015-03-06T14:33:57+00:00", 1.0, 22.55]
+          - ["2015-03-06T14:34:12+00:00", 1.0, 8.0]
+          - ["2015-03-06T14:34:15+00:00", 1.0, -5.5]
+          - ["2015-03-06T14:35:12+00:00", 1.0, 9.5]
+          - ["2015-03-06T14:35:15+00:00", 1.0, 13.0]
+
+    - name: get aggregates rate:mean
+      POST: /v1/aggregates
+      data:
+        operations:
+          - aggregate
+          - rate:mean
+          - ["metric", ["$HISTORY['create metric1'].$RESPONSE['$.id']", "mean"], ["$HISTORY['create metric2'].$RESPONSE['$.id']", "mean"]]
+      response_json_paths:
+        $.measures.aggregated:
+          - ["2015-03-06T14:34:00+00:00", 60.0, -21.30]
+          - ["2015-03-06T14:35:00+00:00", 60.0, 10.0]
+          - ["2015-03-06T14:34:12+00:00", 1.0, -14.55]
+          - ["2015-03-06T14:34:15+00:00", 1.0, -13.5]
+          - ["2015-03-06T14:35:12+00:00", 1.0, 15.0]
+          - ["2015-03-06T14:35:15+00:00", 1.0, 3.5]
 
     - name: get aggregates one metric
       POST: /v1/aggregates?details=true


### PR DESCRIPTION
Old aggregate API was allowing rate:XXX format for rateofchange
aggregation.

This change restores it since we use the new internal API.

Closes: #1016