### PR TITLE
Reduce the number of required reviewers

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,17 +7,6 @@ pull_request_rules:
         strict: true
     conditions:
     - label!=work-in-progress
-    - '#approved-reviews-by>=2'
-    - status-success=continuous-integration/travis-ci/pr
-  - name: merge backport to stable with one review
-    actions:
-      merge:
-        method: rebase
-        rebase_fallback: merge
-        strict: true
-    conditions:
-    - base~=^stable/.*
-    - label!=work-in-progress
     - '#approved-reviews-by>=1'
     - status-success=continuous-integration/travis-ci/pr
   - name: automatic merge backports from Mergify


### PR DESCRIPTION
With the low activity going on, it might be hard to get two reviews.