### PR TITLE
minor cleanup

### DIFF
--- a/gnocchi/rest/aggregates/processor.py
+++ b/gnocchi/rest/aggregates/processor.py
@@ -152,10 +152,10 @@ def aggregated(refs_and_timeseries, operations, from_timestamp=None,
     is_aggregated = False
     result = {}
     for sampling in sorted(series, reverse=True):
-        combine = numpy.concatenate(series[sampling])
         # np.unique sorts results for us
-        times, indices = numpy.unique(combine['timestamps'],
-                                      return_inverse=True)
+        times, indices = numpy.unique(
+            numpy.concatenate([i['timestamps'] for i in series[sampling]]),
+            return_inverse=True)
 
         # create nd-array (unique series x unique times) and fill
         filler = (numpy.NaN if fill in [None, 'null', 'dropna']

--- a/gnocchi/tests/functional/gabbits/aggregates-with-metric-ids.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregates-with-metric-ids.yaml
@@ -645,7 +645,7 @@ tests:
         $.code: 400
         $.description.cause: "Invalid operations"
         $.description.reason: "/^Fail to parse the operations string/"
-        $.description.detail: "Expected \")\" (at char 15), (line:1, col:16)"
+        $.description.detail: '/^Expected "\)", found end of text  \(at char 15\), \(line:1, col:16\)/'
 
     - name: get invalid metric operations
       POST: /v1/aggregates


### PR DESCRIPTION
- don't create a new array when getting unique times across series
- create a common sum function instead of making a sum timeseries and
ripping out just the values.