### PR TITLE
try forcing newer version of six on to travis image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,10 @@ notifications:
     channels:
       - "irc.freenode.org#gnocchi"
 
+before_deploy:
+  - pip install --user --upgrade pip
+  - pip install --user --upgrade six
+
 deploy:
   provider: pypi
   user: jd


### PR DESCRIPTION
it's not installing correct version when it installs twine during
deploy