### PR TITLE
fix travis deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,14 +67,15 @@ notifications:
       - "irc.freenode.org#gnocchi"
 
 before_deploy:
-  # Remove |substitutions| to fix rendering on pypi.
-  - sed -i -e 's/|\([a-zA-Z0-9 ]\+\)|/\1/g' README.rst
+  - pip install --user --upgrade pip
+  - pip install --user --upgrade six
 
 deploy:
   provider: pypi
   user: jd
   password:
     secure: c+Ccx3SHCWepiy0PUxDJ7XO9r3aNYnHjkzxF5c/kjV8QaCJayAJEgXJnBKhvjroqwgn7JPUgpD6QdSWdB4FqjbZYQ3I3oHOO1YL0vYYa8wHG5HuMsMp4J8qvzgs3QNQDECPI1mXsPevn3VMfGszUN+6BQrHB3FbZsTtOmE+Kmgok5NCT+obsfEhVea/UOD0XFUkVW9VJhPjQ2ytvYvFIc46/73GQf2Er/5DCa/4GGDEBSD++bDJgp3kQj438xslCAFeZWDwGsa+cTc43PI0Y0+E144ySVY7QyVbZ1B66a1BGWVrXJuM+gW/eIBCMN1FJXmD7CDdPa22azKI8dfMF7qaH3Oiv3cVovPWpubOvhTUHUFwG8+W7Fx+zUKktCWiLer/fZvEd3W8tcgby2kNOdcUfKfDB2ImZJ+P694/OJ4jJ8T5TQerruNoP2OstzcBMon77Ry0XawXR15SZd4JhbqhSi+h7XV6EYmct1UN4zoysA7fx/cWHcBxdnm2G6R0gzmOiiGUd74ptU8lZ3IlEP6EZckK/OZOdy1I8EQeUe7aiTooXZDAn07iPkDZliYRr2e36ij/xjtWCe1AjCksn/xdKfHOKJv5UVob495DU2GuNObe01ewXzexcnldjfp9Sb8SVEFuhHx6IvH5OC+vAq+BVYu2jwvMcVfXi3VSOkB4=
+  skip_existing: true
   on:
     all_branches: true
     tags: true


### PR DESCRIPTION
- force upgrade of six
- remove README.rst cleanup as it's been done permanently (and i didn't
realise this line existed when i did it)
- add skip_existing[1]. each ENV runs the deploy so travis tries to
upload multiple times and fails on each ENV except for the first

[1] https://docs.travis-ci.com/user/deployment/pypi/#upload-artifacts-only-once