### PR TITLE
Fix compatibility with MySQL >= 8

### DIFF
--- a/gnocchi/indexer/alembic/versions/04eba72e4f90_rename_ck_started_before_ended.py
+++ b/gnocchi/indexer/alembic/versions/04eba72e4f90_rename_ck_started_before_ended.py
@@ -1,0 +1,55 @@
+# Copyright 2019 The Gnocchi Developers
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+"""rename ck_started_before_ended
+
+Revision ID: 04eba72e4f90
+Revises: 1e1a63d3d186
+Create Date: 2019-10-01 11:19:38.865522
+
+"""
+
+from alembic import op
+from sqlalchemy.engine.reflection import Inspector
+
+# revision identifiers, used by Alembic.
+revision = '04eba72e4f90'
+down_revision = '1e1a63d3d186'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    inspector = Inspector.from_engine(bind)
+
+    for table in ("resource", "resource_history"):
+        existing_cks = [
+            c['name'] for c in inspector.get_check_constraints(table)
+        ]
+        if "ck_started_before_ended" in existing_cks:
+            # Drop non-uniquely named check constraints
+            # for consistency across DB types.
+            op.drop_constraint("ck_started_before_ended",
+                               table,
+                               type_="check")
+
+        new_ck_name = "ck_{}_started_before_ended".format(table)
+        if new_ck_name not in existing_cks:
+            # Re-create check constraint with unique name
+            # if needed
+            op.create_check_constraint(new_ck_name,
+                                       table,
+                                       "started_at <= ended_at")

--- a/gnocchi/indexer/alembic/versions/40c6aae14c3f_ck_started_before_ended.py
+++ b/gnocchi/indexer/alembic/versions/40c6aae14c3f_ck_started_before_ended.py
@@ -31,9 +31,9 @@ from alembic import op
 
 
 def upgrade():
-    op.create_check_constraint("ck_started_before_ended",
+    op.create_check_constraint("ck_resource_started_before_ended",
                                "resource",
                                "started_at <= ended_at")
-    op.create_check_constraint("ck_started_before_ended",
+    op.create_check_constraint("ck_resource_history_started_before_ended",
                                "resource_history",
                                "started_at <= ended_at")

--- a/gnocchi/indexer/sqlalchemy.py
+++ b/gnocchi/indexer/sqlalchemy.py
@@ -880,7 +880,9 @@ class SQLAlchemyIndexer(indexer.IndexerDriver):
 
                 session.flush()
             except exception.DBConstraintError as e:
-                if e.check_name == "ck_started_before_ended":
+                if e.check_name in (
+                        "ck_resource_started_before_ended",
+                        "ck_resource_history_started_before_ended"):
                     raise indexer.ResourceValueError(
                         resource_type, "ended_at", ended_at)
                 raise

--- a/gnocchi/indexer/sqlalchemy_base.py
+++ b/gnocchi/indexer/sqlalchemy_base.py
@@ -221,9 +221,14 @@ class ResourceJsonifier(indexer.Resource):
 class ResourceMixin(ResourceJsonifier):
     @declarative.declared_attr
     def __table_args__(cls):
-        return (sqlalchemy.CheckConstraint('started_at <= ended_at',
-                                           name="ck_started_before_ended"),
-                COMMON_TABLES_ARGS)
+        return (sqlalchemy.CheckConstraint(
+            'started_at <= ended_at',
+            name="ck_{}_started_before_ended".format(
+                cls.__tablename__
+                )
+            ),
+            COMMON_TABLES_ARGS
+        )
 
     @declarative.declared_attr
     def type(cls):


### PR DESCRIPTION
Under newer MySQL versions, check constraints must have unique names.

Drop and re-create the check constraints on the resource and
resource_history tables to ensure that they are uniquely named
for upgrades in existing deployments.

Ensure that check constraints are created with unique names in
new deployments.