### PR TITLE
Change URL to gnocchi.osci.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
 env:
   - TARGET: pep8
   - TARGET: docs
-  - TARGET: docs-gnocchi.xyz
+  - TARGET: docs-gnocchi-web
 
   - TARGET: py27-mysql-ceph-upgrade-from-4.3
   - TARGET: py37-postgresql-file-upgrade-from-4.3
@@ -38,7 +38,7 @@ before_script:
           ;;
       esac ;
       case $TARGET in
-        docs-gnocchi.xyz)
+        docs-gnocchi-web)
           git branch -a | sed -n "/\/HEAD /d; /\/master$/d; s,remotes/origin/,,p;" | xargs -i git branch {} origin/{} ;
           git branch -D master;
           git checkout -b master;

--- a/README.rst
+++ b/README.rst
@@ -31,4 +31,4 @@ query time.
 Because Gnocchi computes all the aggregations at ingestion, getting the data
 back is extremely fast, as it just needs to read back the pre-computed results.
 
-You can read the full documentation online at http://gnocchi.xyz.
+You can read the full documentation online at http://gnocchi.osci.io.

--- a/doc/source/client.rst
+++ b/doc/source/client.rst
@@ -24,6 +24,6 @@ It can be installed using *go get*::
 
 This package provides the Go SDK only. You can read the `godoc reference`_.
 
-.. _full documentation online: http://gnocchi.xyz/gnocchiclient
+.. _full documentation online: http://gnocchi.osci.io/gnocchiclient
 .. _Gophercloud: https://github.com/gophercloud
 .. _godoc reference: https://godoc.org/github.com/gophercloud/utils

--- a/gnocchi/gendoc.py
+++ b/gnocchi/gendoc.py
@@ -175,7 +175,7 @@ def setup(app):
     if _RUN:
         return
 
-    # NOTE(sileht): On gnocchi.xyz, we build a multiversion of the docs
+    # NOTE(sileht): On gnocchi.osci.io, we build a multiversion of the docs
     # all versions are built with the master gnocchi.gendoc sphinx extension.
     # So the hack here run an other python script to generate the rest.rst
     # file of old version of the module.

--- a/gnocchi/tests/functional_live/gabbits/search-resource.yaml
+++ b/gnocchi/tests/functional_live/gabbits/search-resource.yaml
@@ -1,6 +1,6 @@
 #
 # Tests to confirm resources are searchable. Run against a live setup.
-# URL: http://gnocchi.xyz/rest.html#searching-for-resources
+# URL: http://gnocchi.osci.io/rest.html#searching-for-resources
 #
 # Instance-ResourceID-1: a64ca14f-bc7c-45b0-aa85-42cd2179e1e2
 # Instance-ResourceID-2: 7ccccfa0-92ce-4225-80ca-3ac9cb122d6a

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,10 @@
 [metadata]
 name = gnocchi
-url = http://gnocchi.xyz
+url = http://gnocchi.osci.io
 description = Metric as a Service
 long_description = file: README.rst
 long_description_content_type = text/x-rst
 author = Gnocchi developers
-author_email = invalid@gnocchi.xyz
 classifier =
     Intended Audience :: Information Technology
     Intended Audience :: System Administrators

--- a/tox.ini
+++ b/tox.ini
@@ -98,7 +98,7 @@ setenv = GNOCCHI_TEST_DEBUG=1
 commands = doc8 --ignore-path doc/source/rest.rst,doc/source/comparison-table.rst doc/source
            pifpaf -g GNOCCHI_INDEXER_URL run postgresql -- python setup.py build_sphinx -W
 
-[testenv:docs-gnocchi.xyz]
+[testenv:docs-gnocchi-web]
 basepython = python2.7
 whitelist_externals = bash rm
 setenv = GNOCCHI_STORAGE_DEPS=file


### PR DESCRIPTION
This is the current hosting platform now that the name has expired.