### PR TITLE
Enhance rest api logging

### DIFF
--- a/gnocchi/rest/exceptions.py
+++ b/gnocchi/rest/exceptions.py
@@ -1,0 +1,30 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright © 2016-2020 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+import six
+
+
+class UnableToDecodeBody(Exception):
+    def __init__(self, exception, body):
+        self.reason = six.text_type(exception)
+        self.body = body
+        super(UnableToDecodeBody, self).__init__(body)
+
+    def jsonify(self):
+        return {
+            "cause": "Unable to decode body",
+            "reason": self.reason,
+            "detail": self.body
+        }

--- a/gnocchi/tests/functional/gabbits/resource.yaml
+++ b/gnocchi/tests/functional/gabbits/resource.yaml
@@ -312,10 +312,15 @@ tests:
 
     - name: patch resource no data
       desc: providing no data is an error
+      request_headers:
+        accept: application/json
       PATCH: /v1/resource/generic/75C44741-CC60-4033-804E-2D3098C7D2E9
       status: 400
-      response_strings:
-          - "Unable to decode body:"
+      response_json_paths:
+        $.description:
+          cause: "Unable to decode body"
+          reason: "Expected object or value"
+          detail: []
 
     - name: patch resource bad data
       desc: providing data that is not a dict is an error


### PR DESCRIPTION
To help operators to debug some API errors, was added some logs in warning and debug level to log the responses in Gnocchi rest API.