### PR TITLE
Group measures by resource metadata history

### DIFF
--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -818,6 +818,23 @@ requested |resource| type, and then compute the aggregation:
 
 {{ scenarios['get-aggregates-by-attributes-lookup-groupby']['doc'] }}
 
+Gnocchi will only group by the last attribute's value for each resource.
+Therefore, in cases that the resource's attributes get changed over the
+provided time window, Gnocchi will only display the last attributes' value.
+Below we have an example of a resource that had the `flavor_id` attribute
+changed from `1` to `2` after `2015`.
+
+{{ scenarios['get-aggregates-by-attributes-lookup-groupby-without-history']['doc'] }}
+
+Between the measurements from `2015` and `2099`, the `flavor_id` was changed
+from `1` to `2`, but in the response, it is always `2`. In these cases, if you
+want to get all the attributes' values over the time window, and group each
+measurement by the attribute value the resource has when the measurement was
+collected, you can add the `use_history=true` in the aggregates API request,
+like the following example.
+
+{{ scenarios['get-aggregates-by-attributes-lookup-groupby-with-history']['doc'] }}
+
 List of supported <operations>
 ------------------------------
 

--- a/doc/source/rest.yaml
+++ b/doc/source/rest.yaml
@@ -22,6 +22,20 @@
       ]
     }
 
+- name: create-archive-policy-unrelated
+  request: |
+    POST /v1/archive_policy HTTP/1.1
+    Content-Type: application/json
+
+    {
+      "name": "unrelated",
+      "definition": [
+        {
+          "granularity": "1h"
+        }
+      ]
+    }
+
 - name: create-archive-policy-without-max
   request: |
     POST /v1/archive_policy HTTP/1.1
@@ -888,6 +902,85 @@
       "resource_type": "instance",
       "search": "server_group='my_autoscaling_group'",
       "operations": "(* (aggregate mean (metric cpu.util mean)) 4)"
+    }
+
+
+- name: create-resource-instance-c14fafd8-2e50-4a1a-ac13-319c82fb2f65
+  request: |
+    POST /v1/resource/instance HTTP/1.1
+    Content-Type: application/json
+
+    {
+      "id": "c14fafd8-2e50-4a1a-ac13-319c82fb2f65",
+      "user_id": "BD3A1E52-1C62-44CB-BF04-660BD88CD74D",
+      "project_id": "BD3A1E52-1C62-44CB-BF04-660BD88CD74D",
+      "flavor_id": "1",
+      "image_ref": "http://image",
+      "host": "compute2",
+      "display_name": "myvmc1",
+      "server_group": "my_autoscaling_group",
+      "metrics": {
+        "vm.uptime": {
+          "archive_policy_name": "unrelated"
+        }
+      }
+    }
+
+- name: post-uptime-measures-c14fafd8-2e50-4a1a-ac13-319c82fb2f65
+  request: |
+    POST /v1/resource/instance/c14fafd8-2e50-4a1a-ac13-319c82fb2f65/metric/vm.uptime/measures HTTP/1.1
+    Content-Type: application/json
+
+    [{
+      "timestamp": "2015-03-06T14:00:00",
+      "value": 1
+    },{
+      "timestamp": "2015-03-06T15:00:00",
+      "value": 1
+    }]
+
+- name: update-instance-resource-instance-c14fafd8-2e50-4a1a-ac13-319c82fb2f65
+  request: |
+    PATCH /v1/resource/instance/c14fafd8-2e50-4a1a-ac13-319c82fb2f65 HTTP/1.1
+    Content-Type: application/json
+
+    {
+      "flavor_id": "2"
+    }
+
+- name: post-uptime-measures-updated-c14fafd8-2e50-4a1a-ac13-319c82fb2f65
+  request: |
+    POST /v1/resource/instance/c14fafd8-2e50-4a1a-ac13-319c82fb2f65/metric/vm.uptime/measures HTTP/1.1
+    Content-Type: application/json
+
+    [{
+      "timestamp": "2099-01-01T01:00:00",
+      "value": 1
+    },{
+      "timestamp": "2099-01-01T02:00:00",
+      "value": 1
+    }]
+
+- name: get-aggregates-by-attributes-lookup-groupby-without-history
+  request: |
+    POST /v1/aggregates?groupby=flavor_id HTTP/1.1
+    Content-Type: application/json
+
+    {
+      "resource_type": "instance",
+      "search": "id = 'c14fafd8-2e50-4a1a-ac13-319c82fb2f65'",
+      "operations": "(aggregate mean (metric vm.uptime mean))"
+    }
+
+- name: get-aggregates-by-attributes-lookup-groupby-with-history
+  request: |
+    POST /v1/aggregates?groupby=flavor_id&use_history=true HTTP/1.1
+    Content-Type: application/json
+
+    {
+      "resource_type": "instance",
+      "search": "id = 'c14fafd8-2e50-4a1a-ac13-319c82fb2f65'",
+      "operations": "(aggregate mean (metric vm.uptime mean))"
     }
 
 - name: get-capabilities

--- a/gnocchi/indexer/sqlalchemy_base.py
+++ b/gnocchi/indexer/sqlalchemy_base.py
@@ -202,6 +202,9 @@ class ResourceType(Base, GnocchiBase, resource_type.ResourceType):
 
 
 class ResourceJsonifier(indexer.Resource):
+    def __str__(self):
+        return str(self.jsonify())
+
     def jsonify(self, attrs=None):
         d = dict(self)
         del d['revision']

--- a/gnocchi/tests/functional/gabbits/aggregates-with-resources.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregates-with-resources.yaml
@@ -131,6 +131,52 @@ tests:
     - name: list resources
       GET: /v1/resource/generic
 
+    - name: create resource type instance
+      POST: /v1/resource_type
+      request_headers:
+        # User admin
+        authorization: "basic YWRtaW46"
+      data:
+        name: instance
+        attributes:
+          flavor_id:
+            type: uuid
+      status: 201
+
+    - name: create resource instance
+      POST: /v1/resource/instance
+      data:
+        id: c14fafd8-2e50-4a1a-ac13-319c82fb2f65
+        flavor_id: d7a2b16c-fd00-4a6e-8e2f-086886b0637f
+        metrics:
+          vm.uptime:
+            archive_policy_name: unrelated
+      status: 201
+
+    - name: post uptime measures
+      POST: /v1/resource/instance/c14fafd8-2e50-4a1a-ac13-319c82fb2f65/metric/vm.uptime/measures
+      data:
+        - timestamp: "2015-03-06T14:00:00"
+          value: 1
+        - timestamp: "2015-03-06T15:00:00"
+          value: 1
+      status: 202
+
+    - name: update resource instance
+      PATCH: /v1/resource/instance/c14fafd8-2e50-4a1a-ac13-319c82fb2f65
+      data:
+        flavor_id: ea98441b-2fcb-4bd9-97af-21333f8ddffa
+      status: 200
+
+    - name: post uptime measures updated
+      POST: /v1/resource/generic/c14fafd8-2e50-4a1a-ac13-319c82fb2f65/metric/vm.uptime/measures
+      data:
+        - timestamp: "2099-01-01T01:00:00" # time after the update
+          value: 1
+        - timestamp: "2099-01-01T02:00:00" # time after the update
+          value: 1
+      status: 202
+
     - name: aggregate metric
       POST: /v1/aggregates?details=true
       data:
@@ -323,6 +369,41 @@ tests:
               - ['2015-03-06T14:34:12+00:00', 1.0, 8.0]
         $[0].group:
               id: 2447cd7e-48a6-4c50-a991-6677cc0d00e6
+
+    - name: aggregate metric with groupby on flavor_id aggregates API
+      POST: /v1/aggregates?groupby=flavor_id
+      data:
+        resource_type: instance
+        search: "id = 'c14fafd8-2e50-4a1a-ac13-319c82fb2f65'"
+        operations: "(aggregate mean (metric vm.uptime mean))"
+      response_json_paths:
+        $.`len`: 1
+        $[0].measures.measures.aggregated:
+              - ['2015-03-06T14:00:00+00:00', 5.0, 1.0]
+              - ['2015-03-06T15:00:00+00:00', 5.0, 1.0]
+              - ['2099-01-01T01:00:00+00:00', 5.0, 1.0]
+              - ['2099-01-01T02:00:00+00:00', 5.0, 1.0]
+        $[0].group:
+              flavor_id: ea98441b-2fcb-4bd9-97af-21333f8ddffa
+
+    - name: aggregate metric with groupby on flavor_id aggregates API with history
+      POST: /v1/aggregates?groupby=flavor_id&use_history=true
+      data:
+        resource_type: instance
+        search: "id = 'c14fafd8-2e50-4a1a-ac13-319c82fb2f65'"
+        operations: "(aggregate mean (metric vm.uptime mean))"
+      response_json_paths:
+        $.`len`: 2
+        $[0].measures.measures.aggregated:
+              - ['2015-03-06T14:00:00+00:00', 5.0, 1.0]
+              - ['2015-03-06T15:00:00+00:00', 5.0, 1.0]
+        $[0].group:
+              flavor_id: d7a2b16c-fd00-4a6e-8e2f-086886b0637f
+        $[1].measures.measures.aggregated:
+              - ['2099-01-01T01:00:00+00:00', 5.0, 1.0]
+              - ['2099-01-01T02:00:00+00:00', 5.0, 1.0]
+        $[1].group:
+              flavor_id: ea98441b-2fcb-4bd9-97af-21333f8ddffa
 
     - name: aggregate and drop infinity from divide by zero
       POST: /v1/aggregates?details=true

--- a/gnocchi/tests/test_measures_grouper.py
+++ b/gnocchi/tests/test_measures_grouper.py
@@ -1,0 +1,395 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import datetime
+import numpy
+
+from gnocchi.rest.aggregates.api import Grouper
+from gnocchi.tests import base
+from unittest import mock
+
+
+RETRIEVE_RESOURCES_HISTORY = \
+    "gnocchi.rest.aggregates.api.Grouper.retrieve_resources_history"
+API_AGGREGATE = \
+    "gnocchi.rest.aggregates.api.AggregatesController._get_measures_by_name"
+
+
+class Resource(object):
+    def __init__(self, id, flavor_name, host, display_name,
+                 revision_start=datetime.datetime(2020, 3, 10, 10, 0, 0, 0)):
+        self.id = id
+        self.flavor_name = flavor_name
+        self.host = host
+        self.display_name = display_name
+        self.revision_start = revision_start
+        self.revision_end = None
+
+
+class ResourceHistory(object):
+    def __init__(self, resources):
+        self.resources = resources
+        self.history = list(resources)
+
+    def update_resource(self, date, update, id):
+        resource = list(filter(lambda r: r.id == id, self.resources))[0]
+        new_resource = Resource(resource.id, resource.flavor_name,
+                                resource.host, resource.display_name, date)
+
+        for k, v in update.items():
+            new_resource.__setattr__(k, v)
+        self.history.append(new_resource)
+
+    def get_history_as_dict(self):
+        self.history.sort(key=lambda r: r.revision_start)
+        ids = set(map(lambda h: h.id, self.history))
+        for id in ids:
+            resources_with_id = [h for h in self.history if h.id == id]
+            for i, resource in enumerate(resources_with_id[:-1]):
+                resource.revision_end = resources_with_id[i + 1].revision_start
+
+        return list(map(lambda x: x.__dict__, self.history))
+
+
+class TestScenario(object):
+
+    @mock.patch(RETRIEVE_RESOURCES_HISTORY)
+    @mock.patch(API_AGGREGATE)
+    def __init__(self, mock_measure, mock_history, test_input,
+                 expected_output):
+        self.test_input = test_input
+        self.expected_output = expected_output
+        self.result = None
+        self.grouper = Grouper(test_input['test_group_by'],
+                               test_input['test_start'],
+                               test_input['test_end'],
+                               {'operations': 'operation'},
+                               None, None, None, None, None,
+                               None, None)
+        history = self.create_test_scenario()
+        mock_history.side_effect = history.get_history_as_dict
+        mock_measure.side_effect = get_metric
+        self.execute()
+
+    def execute(self):
+        self.result = self.grouper.get_grouped_measures()
+
+    def validate_scenario(self):
+        all_groups = list(map(lambda o: o['group'], self.expected_output))
+        all_response_groups = list(map(lambda r: r['group'], self.result))
+        assert all_groups == all_response_groups
+        for r in self.result:
+            for out in self.expected_output:
+                if out['group'] == r['group']:
+                    for date, val in out['measures'].items():
+                        aggregated = r['measures']['measures']['aggregated']
+                        assert len(aggregated) == len(out['measures'])
+                        for dat, gran, value in aggregated:
+                            if str(dat) == date:
+                                assert val == value
+
+    def create_test_scenario(self):
+        scenario = self.test_input
+        resource_history = ResourceHistory(scenario['resource'])
+        for update in scenario['updates']:
+            resource_history.update_resource(update['event_time'],
+                                             update['event_update'],
+                                             update['id'])
+
+        return resource_history
+
+
+def get_metric(*args, **kwargs):
+    start = args[3]
+    end = args[4]
+    if not end:
+        end = numpy.datetime64('2020-03-10T12:00:00Z')
+    ts = (start - numpy.datetime64(
+        '1970-01-01T00:00:00Z')) / numpy.timedelta64(1, 's')
+    current = numpy.datetime64(
+        datetime.datetime.utcfromtimestamp(ts - (ts % 3600)))
+    to_return = []
+    while current < end:
+        to_return.append((
+            current,
+            numpy.timedelta64(3600000000000, 'ns'),
+            100
+        ))
+        current += numpy.timedelta64(3600, 's')
+
+    return {'measures': {'aggregated': to_return}}
+
+
+class TestGroupMeasuresWithHistory(base.BaseTestCase):
+
+    def test_group_measures_changing_over_two_hours_with_more_than_one_resource(self):
+        test_input = {
+            'test_start': datetime.datetime(2020, 3, 10, 10, 0, 0, 0),
+            'test_end': datetime.datetime(2020, 3, 10, 12, 0, 0, 0),
+            'test_group_by': ['flavor_name', 'id'],
+            'resource': [Resource(id=1, flavor_name="1gb-mem", host="192.168.0.1",
+                                  display_name="My_VM",
+                                  revision_start=datetime.datetime(
+                                      2020, 3, 10, 9, 0, 0, 0)),
+                         Resource(id=2, flavor_name="1gb-mem", host="192.168.0.1",
+                                  display_name="My_VM",
+                                  revision_start=datetime.datetime(
+                                      2020, 3, 10, 8, 0, 0, 0))
+                         ],
+            'updates': [
+                {
+                    'id': 1,
+                    'event_time': datetime.datetime(2020, 3, 10, 10, 30, 0, 0),
+                    'event_update': {'flavor_name': "2gb-mem"}
+                },
+                {
+                    'id': 1,
+                    'event_time': datetime.datetime(2020, 3, 10, 11, 30, 0, 0),
+                    'event_update': {'flavor_name': "1gb-mem"}
+                },
+                {
+                    'id': 2,
+                    'event_time': datetime.datetime(2020, 3, 10, 11, 0, 0, 0),
+                    'event_update': {'flavor_name': "2gb-mem"}
+                },
+            ]
+        }
+        expected_output = [
+            {
+                'group': {'flavor_name': '1gb-mem', 'id': 1},
+                'measures': {
+                    '2020-03-10T10:00:00.000000': 50,
+                    '2020-03-10T11:00:00.000000': 50
+                }
+            },
+            {
+                'group': {'flavor_name': '1gb-mem', 'id': 2},
+                'measures': {
+                    '2020-03-10T10:00:00.000000': 100
+                }
+            },
+            {
+                'group': {'flavor_name': '2gb-mem', 'id': 1},
+                'measures': {
+                    '2020-03-10T10:00:00.000000': 50,
+                    '2020-03-10T11:00:00.000000': 50
+                }
+            },
+            {
+                'group': {'flavor_name': '2gb-mem', 'id': 2},
+                'measures': {
+                    '2020-03-10T11:00:00.000000': 100
+                }
+            },
+        ]
+        scenario = TestScenario(test_input=test_input,
+                                expected_output=expected_output)
+        scenario.validate_scenario()
+
+    def test_group_measures_changing_over_two_hours(self):
+        test_input = {
+            'test_start': datetime.datetime(2020, 3, 10, 10, 0, 0, 0),
+            'test_end': datetime.datetime(2020, 3, 10, 12, 0, 0, 0),
+            'test_group_by': ['flavor_name'],
+            'resource': [Resource(id=1, flavor_name="1gb-mem", host="192.168.0.1",
+                                  display_name="My_VM")],
+            'updates': [
+                {
+                    'id': 1,
+                    'event_time': datetime.datetime(2020, 3, 10, 10, 30, 0, 0),
+                    'event_update': {'flavor_name': "2gb-mem"}
+                },
+                {
+                    'id': 1,
+                    'event_time': datetime.datetime(2020, 3, 10, 11, 30, 0, 0),
+                    'event_update': {'flavor_name': "1gb-mem"}
+                }
+            ]
+        }
+        expected_output = [
+            {
+                'group': {'flavor_name': '1gb-mem'},
+                'measures': {
+                    '2020-03-10T10:00:00.000000': 50,
+                    '2020-03-10T11:00:00.000000': 50
+                }
+            },
+            {
+                'group': {'flavor_name': '2gb-mem'},
+                'measures': {
+                    '2020-03-10T10:00:00.000000': 50,
+                    '2020-03-10T11:00:00.000000': 50
+                }
+            }
+        ]
+        scenario = TestScenario(test_input=test_input,
+                                expected_output=expected_output)
+        scenario.validate_scenario()
+
+    def test_group_measures_changing_flavors_in_a_hour(self):
+        test_input = {
+            'test_start': datetime.datetime(2020, 3, 10, 10, 0, 0, 0),
+            'test_end': datetime.datetime(2020, 3, 10, 12, 0, 0, 0),
+            'test_group_by': ['flavor_name'],
+            'resource': [Resource(id=1, flavor_name="1gb-mem", host="192.168.0.1",
+                                  display_name="My_VM")],
+            'updates': [
+                {
+                    'id': 1,
+                    'event_time': datetime.datetime(2020, 3, 10, 10, 30, 0, 0),
+                    'event_update': {'flavor_name': "2gb-mem"}
+                },
+                {
+                    'id': 1,
+                    'event_time': datetime.datetime(2020, 3, 10, 10, 45, 0, 0),
+                    'event_update': {'flavor_name': "1gb-mem"}
+                }
+            ]
+        }
+        expected_output = [
+            {
+                'group': {'flavor_name': '1gb-mem'},
+                'measures': {
+                    '2020-03-10T10:00:00.000000': 75,
+                    '2020-03-10T11:00:00.000000': 100
+                }
+            },
+            {
+                'group': {'flavor_name': '2gb-mem'},
+                'measures': {
+                    '2020-03-10T10:00:00.000000': 25
+                }
+            }
+        ]
+        scenario = TestScenario(test_input=test_input,
+                                expected_output=expected_output)
+        scenario.validate_scenario()
+
+    def test_group_measures_many_flavors_changes_in_a_hour(self):
+        test_input = {
+            'test_start': datetime.datetime(2020, 3, 10, 10, 0, 0, 0),
+            'test_end': datetime.datetime(2020, 3, 10, 12, 0, 0, 0),
+            'test_group_by': ['flavor_name'],
+            'resource': [Resource(id=1, flavor_name="1gb-mem", host="192.168.0.1",
+                                  display_name="My_VM")],
+            'updates': [
+                {
+                    'id': 1,
+                    'event_time': datetime.datetime(2020, 3, 10, 10, 10, 0, 0),
+                    'event_update': {'flavor_name': "2gb-mem"}
+                },
+                {
+                    'id': 1,
+                    'event_time': datetime.datetime(2020, 3, 10, 10, 20, 0, 0),
+                    'event_update': {'flavor_name': "3gb-mem"}
+                },
+                {
+                    'id': 1,
+                    'event_time': datetime.datetime(2020, 3, 10, 10, 30, 0, 0),
+                    'event_update': {'flavor_name': "4gb-mem"}
+                },
+                {
+                    'id': 1,
+                    'event_time': datetime.datetime(2020, 3, 10, 10, 40, 0, 0),
+                    'event_update': {'flavor_name': "1gb-mem"}
+                },
+                {
+                    'id': 1,
+                    'event_time': datetime.datetime(2020, 3, 10, 10, 45, 0, 0),
+                    'event_update': {'flavor_name': "2gb-mem"}
+                },
+                {
+                    'id': 1,
+                    'event_time': datetime.datetime(2020, 3, 10, 10, 55, 0, 0),
+                    'event_update': {'flavor_name': "3gb-mem"}
+                }
+            ]
+        }
+        expected_output = [
+            {
+                'group': {'flavor_name': '1gb-mem'},
+                'measures': {
+                    '2020-03-10T10:00:00.000000': 24.999999999999996
+                }
+            },
+            {
+                'group': {'flavor_name': '2gb-mem'},
+                'measures': {
+                    '2020-03-10T10:00:00.000000': 33.33333333333333
+                }
+            },
+            {
+                'group': {'flavor_name': '3gb-mem'},
+                'measures': {
+                    '2020-03-10T10:00:00.000000': 24.999999999999996,
+                    '2020-03-10T11:00:00.000000': 100,
+                }
+            },
+            {
+                'group': {'flavor_name': '4gb-mem'},
+                'measures': {
+                    '2020-03-10T10:00:00.000000': 16.666666666666686
+                }
+            }
+        ]
+        scenario = TestScenario(test_input=test_input,
+                                expected_output=expected_output)
+        scenario.validate_scenario()
+
+    def test_group_measures_multiple_metadata_changed(self):
+        test_input = {
+            'test_start': datetime.datetime(2020, 3, 10, 10, 0, 0, 0),
+            'test_end': datetime.datetime(2020, 3, 10, 12, 0, 0, 0),
+            'test_group_by': ['flavor_name', 'display_name'],
+            'resource': [Resource(id=1, flavor_name="1gb-mem", host="192.168.0.1",
+                                  display_name="My_VM")],
+            'updates': [
+                {
+                    'id': 1,
+                    'event_time': datetime.datetime(2020, 3, 10, 10, 30, 0, 0),
+                    'event_update': {'flavor_name': "2gb-mem"}
+                },
+                {
+                    'id': 1,
+                    'event_time': datetime.datetime(2020, 3, 10, 10, 45, 0, 0),
+                    'event_update': {'display_name': "Not_My_VM",
+                                     'flavor_name': "2gb-mem"}
+                }
+            ]
+        }
+        expected_output = [
+            {
+                'group': {'flavor_name': '1gb-mem',
+                          'display_name': 'My_VM'},
+                'measures': {
+                    '2020-03-10T10:00:00.000000': 50
+                }
+            },
+            {
+                'group': {'flavor_name': '2gb-mem',
+                          'display_name': 'My_VM'},
+                'measures': {
+                    '2020-03-10T10:00:00.000000': 25
+                }
+            },
+            {
+                'group': {'flavor_name': '2gb-mem',
+                          'display_name': 'Not_My_VM'},
+                'measures': {
+                    '2020-03-10T10:00:00.000000': 25,
+                    '2020-03-10T11:00:00.000000': 100,
+                }
+            }
+        ]
+        scenario = TestScenario(test_input=test_input,
+                                expected_output=expected_output)
+        scenario.validate_scenario()


### PR DESCRIPTION
Problem description
===============

When we are aggregating measures using Gnocchi, we can group the measures by resource's metadata. However, Gnocchi does not group the measures taking into account the resource's metadata history; so if some resource's metadata changed recently, it will be grouped using only the last metadata value. 

Imagine the following situation:

I have a metric with metadata called "name", so I take a resource that is monitored by this metric and I change the resource's name from "test" to "test1" at 14:45:00. Then I call the Gnocchi's Aggregation API with an interval from 11 to 17 hours grouping by "name" and it returns this:

| group                  | name       | timestamp                    | granularity | value               |
|------------------------|------------|------------------------------|-------------|---------------------|
| name: test1 | aggregated | 2020\-03\-26T11:00:00\+00:00 | 3600\.0     | 101 |
| name: test1 | aggregated | 2020\-03\-26T12:00:00\+00:00 | 3600\.0     | 104 |
| name: test1 | aggregated | 2020\-03\-26T13:00:00\+00:00 | 3600\.0     | 98  |
| name: test1 | aggregated | 2020\-03\-26T14:00:00\+00:00 | 3600\.0     | 100  |
| name: test1 | aggregated | 2020\-03\-26T15:00:00\+00:00 | 3600\.0     | 97  |
| name: test1 | aggregated | 2020\-03\-26T16:00:00\+00:00 | 3600\.0     | 109 |

Here we have a problem. For the system consuming Gnocchi API, it will look like the resource has the same attributes in all of the timestamps, when that is not true. This can have a negative impact on billing systems that rely on Gnocchi as the time series database (e.g. CloudKitty).

Proposal
=======

I propose to allow users to specify if they want or not to group their measurements taking into account the resource's metadata history; if they want, they can just add a "use_history=true" parameter in their API request and Gnocchi will do it for them. If users do not specify the "use_history" in the API, the following property will be used instead.

```property
[api]
group_measures_using_history = True/False
```

If the property or the query parameter are not defined, the "use_history" value assumes False (for backward compatibility). The new response expected with this proposal using the same situation listed in `Problem description` will be (using group_measures_using_history=true):

| group                  | name       | timestamp                    | granularity | value               |
|------------------------|------------|------------------------------|-------------|---------------------|
| name: test  | aggregated | 2020\-03\-26T11:00:00\+00:00 | 3600\.0     | 101 |
| name: test  | aggregated | 2020\-03\-26T12:00:00\+00:00 | 3600\.0     | 104 |
| name: test  | aggregated | 2020\-03\-26T13:00:00\+00:00 | 3600\.0     | 98  |
| name: test  | aggregated | 2020\-03\-26T14:00:00\+00:00 | 3600\.0     | 75  |
| name: test1 | aggregated | 2020\-03\-26T14:00:00\+00:00 | 3600\.0     | 25  |
| name: test1 | aggregated | 2020\-03\-26T15:00:00\+00:00 | 3600\.0     | 97  |
| name: test1 | aggregated | 2020\-03\-26T16:00:00\+00:00 | 3600\.0     | 109 |

As you can see, there are 2 entries at 14:00; it happens because the resource's name was changed at 14:45, that is equivalent to 75% of the granularity window (that is 1 hour), so the measure named "test" will take 75% of the total measurement of the granularity window, and the measure named "test1" will take the remaining 25% of the measurement value.