### PR TITLE
Use Ceph CLI

### DIFF
--- a/gnocchi/tests/base.py
+++ b/gnocchi/tests/base.py
@@ -347,7 +347,12 @@ class TestCase(BaseTestCase):
                                    'storage')
             self.ceph_pool_name = uuid.uuid4().hex
             with open(os.devnull, 'w') as f:
-                subprocess.call("rados -c %s mkpool %s" % (
+                subprocess.call(("ceph -c %s osd pool create %s "
+                                 "16 16 replicated") % (
+                    os.getenv("CEPH_CONF"), self.ceph_pool_name), shell=True,
+                    stdout=f, stderr=subprocess.STDOUT)
+                subprocess.call(("ceph -c %s osd pool application "
+                                 "enable %s rbd") % (
                     os.getenv("CEPH_CONF"), self.ceph_pool_name), shell=True,
                     stdout=f, stderr=subprocess.STDOUT)
             self.conf.set_override('ceph_pool', self.ceph_pool_name, 'storage')
@@ -380,7 +385,7 @@ class TestCase(BaseTestCase):
 
         if self.conf.storage.driver == 'ceph':
             with open(os.devnull, 'w') as f:
-                ceph_rmpool_command = "rados -c %s rmpool %s %s \
+                ceph_rmpool_command = "ceph -c %s osd pool delete %s %s \
 --yes-i-really-really-mean-it" % (os.getenv("CEPH_CONF"), self.ceph_pool_name,
                                   self.ceph_pool_name)
                 subprocess.call(ceph_rmpool_command, shell=True,

--- a/gnocchi/tests/functional/fixtures.py
+++ b/gnocchi/tests/functional/fixtures.py
@@ -135,12 +135,17 @@ class ConfigFixture(fixture.GabbiFixture):
         elif conf.storage.driver == 'ceph':
             conf.set_override('ceph_conffile', os.getenv("CEPH_CONF"),
                               'storage')
-            pool_name = uuid.uuid4().hex
+            self.ceph_pool_name = uuid.uuid4().hex
             with open(os.devnull, 'w') as f:
-                subprocess.call("rados -c %s mkpool %s" % (
-                    os.getenv("CEPH_CONF"), pool_name), shell=True,
+                subprocess.call(("ceph -c %s osd pool create %s "
+                                 "16 16 replicated") % (
+                    os.getenv("CEPH_CONF"), self.ceph_pool_name), shell=True,
                     stdout=f, stderr=subprocess.STDOUT)
-            conf.set_override('ceph_pool', pool_name, 'storage')
+                subprocess.call(("ceph -c %s osd pool application "
+                                 "enable %s rbd") % (
+                    os.getenv("CEPH_CONF"), self.ceph_pool_name), shell=True,
+                    stdout=f, stderr=subprocess.STDOUT)
+            conf.set_override('ceph_pool', self.ceph_pool_name, 'storage')
         elif conf.storage.driver == "s3":
             conf.set_override('s3_endpoint_url',
                               os.getenv("GNOCCHI_STORAGE_HTTP_URL"),
@@ -237,6 +242,14 @@ class ConfigFixture(fixture.GabbiFixture):
             warnings.filterwarnings('ignore',
                                     module='sqlalchemy.engine.default')
             sqlalchemy_utils.drop_database(self.conf.indexer.url)
+
+        if self.conf.storage.driver == 'ceph':
+            with open(os.devnull, 'w') as f:
+                ceph_rmpool_command = "ceph -c %s osd pool delete %s %s \
+--yes-i-really-really-mean-it" % (os.getenv("CEPH_CONF"), self.ceph_pool_name,
+                                  self.ceph_pool_name)
+                subprocess.call(ceph_rmpool_command, shell=True,
+                                stdout=f, stderr=subprocess.STDOUT)
 
         if self.tmp_dir:
             shutil.rmtree(self.tmp_dir)

--- a/run-func-tests.sh
+++ b/run-func-tests.sh
@@ -29,7 +29,7 @@ for storage in ${GNOCCHI_TEST_STORAGE_DRIVERS}; do
             ceph)
                 eval $(pifpaf -e STORAGE run ceph)
                 check_empty_var STORAGE_URL
-                rados -c $STORAGE_CEPH_CONF mkpool gnocchi
+                ceph -c $STORAGE_CEPH_CONF osd pool create gnocchi 16 16 replicated
                 STORAGE_URL=ceph://$STORAGE_CEPH_CONF
                 ;;
             s3)

--- a/run-upgrade-tests.sh
+++ b/run-upgrade-tests.sh
@@ -78,7 +78,7 @@ trap cleanup EXIT
 
 
 if [ "$STORAGE_DAEMON" == "ceph" ]; then
-    rados -c $STORAGE_CEPH_CONF mkpool gnocchi
+    ceph -c $STORAGE_CEPH_CONF osd pool create gnocchi 16 16 replicated
     STORAGE_URL=ceph://$STORAGE_CEPH_CONF
 else
     STORAGE_URL=file://$GNOCCHI_DATA


### PR DESCRIPTION
Use the Ceph CLI instead of Rados command
in the fixtures.

Also make sure we delete pools when we cleanup
after gabbi runs in stop_fixtures() that was
missing.