### PR TITLE
Set json template for DELETE requests

### DIFF
--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -279,7 +279,7 @@ class ArchivePolicyController(rest.RestController):
         except indexer.UnsupportedArchivePolicyChange as e:
             abort(400, six.text_type(e))
 
-    @pecan.expose()
+    @pecan.expose('json')
     def delete(self):
         # NOTE(jd) I don't think there's any point in fetching and passing the
         # archive policy here, as the rule is probably checking the actual role
@@ -407,7 +407,7 @@ class ArchivePolicyRuleController(rest.RestController):
         except indexer.UnsupportedArchivePolicyRuleChange as e:
             abort(400, six.text_type(e))
 
-    @pecan.expose()
+    @pecan.expose('json')
     def delete(self):
         # NOTE(jd) I don't think there's any point in fetching and passing the
         # archive policy rule here, as the rule is probably checking the actual
@@ -527,7 +527,7 @@ class MetricController(rest.RestController):
         except storage.MetricDoesNotExist:
             return []
 
-    @pecan.expose()
+    @pecan.expose('json')
     def delete(self):
         self.enforce_metric("delete metric")
         try:
@@ -919,7 +919,7 @@ class ResourceTypeController(rest.RestController):
         except indexer.NoSuchResourceType as e:
                 abort(400, six.text_type(e))
 
-    @pecan.expose()
+    @pecan.expose('json')
     def delete(self):
         try:
             pecan.request.indexer.get_resource_type(self._name)
@@ -1048,7 +1048,7 @@ class ResourceController(rest.RestController):
         etag_set_headers(resource)
         return resource
 
-    @pecan.expose()
+    @pecan.expose('json')
     def delete(self):
         resource = pecan.request.indexer.get_resource(
             self._resource_type, self.id)

--- a/gnocchi/tests/test_rest.py
+++ b/gnocchi/tests/test_rest.py
@@ -389,7 +389,8 @@ class MetricTest(RestTest):
                                     params={"archive_policy_name": "medium"})
         metric = json.loads(result.text)
         with self.app.use_another_user():
-            self.app.delete("/v1/metric/" + metric['id'], status=403)
+            r = self.app.delete("/v1/metric/" + metric['id'], status=403)
+            self.assertEqual("text/plain", r.content_type)
 
     def test_add_measure_with_another_user(self):
         result = self.app.post_json("/v1/metric",
@@ -976,18 +977,20 @@ class ResourceTest(RestTest):
         self.attributes['metrics'] = {'foo': {'archive_policy_name': "high"}}
         self.app.post_json("/v1/resource/" + self.resource_type,
                            params=self.attributes)
-        self.app.delete("/v1/resource/"
-                        + self.resource_type
-                        + "/"
-                        + self.attributes['id']
-                        + "/metric/foo",
-                        status=204)
-        self.app.delete("/v1/resource/"
-                        + self.resource_type
-                        + "/"
-                        + self.attributes['id']
-                        + "/metric/foo/measures",
-                        status=404)
+        r = self.app.delete("/v1/resource/"
+                            + self.resource_type
+                            + "/"
+                            + self.attributes['id']
+                            + "/metric/foo",
+                            status=204)
+        self.assertEqual(None, r.content_type)
+        r = self.app.delete("/v1/resource/"
+                            + self.resource_type
+                            + "/"
+                            + self.attributes['id']
+                            + "/metric/foo/measures",
+                            status=404)
+        self.assertEqual("text/plain", r.content_type)
 
     def test_get_resource_unknown_named_metric(self):
         self.app.post_json("/v1/resource/" + self.resource_type,
@@ -1246,9 +1249,10 @@ class ResourceTest(RestTest):
         self.app.get("/v1/resource/" + self.resource_type + "/"
                      + self.attributes['id'],
                      status=200)
-        self.app.delete("/v1/resource/" + self.resource_type + "/"
-                        + self.attributes['id'],
-                        status=204)
+        r = self.app.delete("/v1/resource/" + self.resource_type + "/"
+                            + self.attributes['id'],
+                            status=204)
+        self.assertEqual(None, r.content_type)
         self.app.get("/v1/resource/" + self.resource_type + "/"
                      + self.attributes['id'],
                      status=404)
@@ -1267,9 +1271,10 @@ class ResourceTest(RestTest):
         self.app.get("/v1/resource/" + self.resource_type + "/"
                      + self.attributes['id'],
                      status=200)
-        self.app.delete("/v1/resource/" + self.resource_type + "/"
-                        + self.attributes['id'],
-                        status=204)
+        r = self.app.delete("/v1/resource/" + self.resource_type + "/"
+                            + self.attributes['id'],
+                            status=204)
+        self.assertEqual(None, r.content_type)
         self.app.get("/v1/resource/" + self.resource_type + "/"
                      + self.attributes['id'],
                      status=404)
@@ -1280,14 +1285,16 @@ class ResourceTest(RestTest):
         self.app.post_json("/v1/resource/" + self.resource_type,
                            params=self.attributes)
         with self.app.use_another_user():
-            self.app.delete("/v1/resource/" + self.resource_type + "/"
-                            + self.attributes['id'],
-                            status=403)
+            r = self.app.delete("/v1/resource/" + self.resource_type + "/"
+                                + self.attributes['id'],
+                                status=403)
+            self.assertEqual("text/plain", r.content_type)
 
     def test_delete_resource_non_existent(self):
         result = self.app.delete("/v1/resource/" + self.resource_type + "/"
                                  + self.attributes['id'],
                                  status=404)
+        self.assertEqual("text/plain", result.content_type)
         self.assertIn(
             "Resource %s does not exist" % self.attributes['id'],
             result.text)

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,10 @@ install_requires =
     numpy>=1.9.0
     iso8601
     oslo.config>=3.22.0
-    oslo.policy>=0.3.0
+    # TODO(tobias-urdin): oslo.policy >= 3.5.0 requires
+    # PyYAML>=5.1 which something we use blocks. Need
+    # to fix this to support Ubuntu Focal later.
+    oslo.policy>=0.3.0,<=3.4.0
     oslo.middleware>=3.22.0
     pytimeparse
     pecan>=0.9


### PR DESCRIPTION
We hardcode the content-type on all DELETE requests
otherwise Pecan will throw NotAcceptable errors when
doing requests to the APIs without any content-type set
and will default to text/html.