### PR TITLE
Set GNOCCHI_TEST_DEBUG

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ skip_install = True
 sitepackages = True
 passenv = LANG GNOCCHI_TEST_* AWS_*
 setenv =
+    GNOCCHI_TEST_DEBUG=1
     GNOCCHI_TEST_STORAGE_DRIVER=file
     GNOCCHI_TEST_INDEXER_DRIVER=postgresql
     GNOCCHI_TEST_STORAGE_DRIVERS=file swift ceph s3 redis


### PR DESCRIPTION
Test enabling debug logging for jobs
to see if we can make the Travis CI
limit.