### PR TITLE
Revert "Pin oslo.policy<=3.4.0"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -84,6 +84,7 @@ prometheus =
 amqp1:
     python-qpid-proton>=0.17.0
 doc =
+    chardet<4
     sphinx
     sphinx_rtd_theme
     sphinxcontrib-httpdomain

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,10 +27,7 @@ install_requires =
     numpy>=1.9.0
     iso8601
     oslo.config>=3.22.0
-    # TODO(tobias-urdin): oslo.policy >= 3.5.0 requires
-    # PyYAML>=5.1 which something we use blocks. Need
-    # to fix this to support Ubuntu Focal later.
-    oslo.policy>=0.3.0,<=3.4.0
+    oslo.policy>=0.3.0
     oslo.middleware>=3.22.0
     pytimeparse
     pecan>=0.9


### PR DESCRIPTION
It broke e.g ceilometer/aodh on devstack.
This reverts commit a2d84f5b1b0555ad83b14e931d9bd7065f2f7b6a.

I acknowledge, this is controversial, see 
https://github.com/gnocchixyz/gnocchi/commit/a2d84f5b1b0555ad83b14e931d9bd7065f2f7b6a#comments
for discussion

Resolves: https://github.com/gnocchixyz/gnocchi/issues/1095