### PR TITLE
Fix yaml deprecation warning

### DIFF
--- a/gnocchi/gendoc.py
+++ b/gnocchi/gendoc.py
@@ -194,7 +194,7 @@ def setup(app):
 
     # TODO(jd) Do not hardcode doc/source
     with open("doc/source/rest.yaml") as f:
-        scenarios = ScenarioList(yaml.load(f))
+        scenarios = ScenarioList(yaml.load(f, Loader=yaml.FullLoader))
 
     test = test_rest.RestTest()
     test.auth_mode = "basic"

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,6 +87,7 @@ prometheus =
 amqp1:
     python-qpid-proton>=0.17.0
 doc =
+    chardet<4
     sphinx
     sphinx_rtd_theme
     sphinxcontrib-httpdomain

--- a/tox.ini
+++ b/tox.ini
@@ -77,6 +77,8 @@ commands = {toxinidir}/run-upgrade-tests.sh mysql-ceph
 basepython = python3
 deps = hacking>=0.12
 commands = flake8
+allowlist_externals =
+    /usr/bin/flake8
 
 [testenv:py36-cover]
 commands = pifpaf -g GNOCCHI_INDEXER_URL run postgresql -- python setup.py testr --coverage --testr-args="{posargs}"


### PR DESCRIPTION
YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated,
as the default Loader is unsafe. Please read https://msg.pyyaml.org/load
for full details.