### PR TITLE
Implement default policies in code

### DIFF
--- a/gnocchi/gnocchi-policy-generator.conf
+++ b/gnocchi/gnocchi-policy-generator.conf
@@ -1,0 +1,2 @@
+[DEFAULT]
+namespace = gnocchi

--- a/gnocchi/rest/app.py
+++ b/gnocchi/rest/app.py
@@ -36,6 +36,7 @@ from gnocchi import incoming as gnocchi_incoming
 from gnocchi import indexer as gnocchi_indexer
 from gnocchi import json
 from gnocchi.rest import http_proxy_to_wsgi
+from gnocchi.rest import policies
 from gnocchi import storage as gnocchi_storage
 
 
@@ -52,6 +53,7 @@ class GnocchiHook(pecan.hooks.PecanHook):
         self.backends = {}
         self.conf = conf
         self.policy_enforcer = policy.Enforcer(conf)
+        self.policy_enforcer.register_defaults(policies.list_rules())
         self.auth_helper = driver.DriverManager("gnocchi.rest.auth_helper",
                                                 conf.api.auth_mode,
                                                 invoke_on_load=True).driver

--- a/gnocchi/rest/policies.py
+++ b/gnocchi/rest/policies.py
@@ -1,0 +1,48 @@
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+from oslo_policy import policy
+
+RULE_ADMIN = "role:admin"
+RULE_ADMIN_OR_CREATOR = \
+    'role:admin or user:%(creator)s or project_id:%(created_by_project_id)s'
+RULE_RESOURCE_OWNER = "project_id:%(project_id)s"
+RULE_METRIC_OWNER = "project_id:%(resource.project_id)s"
+RULE_UNPROTECTED = ""
+
+ADMIN_OR_CREATOR_OR_METRIC_OWNER = "rule:admin_or_creator or rule:metric_owner"
+
+rules = [
+    policy.RuleDefault(
+        name="context_is_admin",
+        check_str=RULE_ADMIN
+    ),
+    policy.RuleDefault(
+        name="admin_or_creator",
+        check_str=RULE_ADMIN_OR_CREATOR
+    ),
+    policy.RuleDefault(
+        name="resource_owner",
+        check_str=RULE_RESOURCE_OWNER
+    ),
+    policy.RuleDefault(
+        name="metric_owner",
+        check_str=RULE_METRIC_OWNER
+    )
+]
+
+
+def list_rules():
+    return rules

--- a/gnocchi/rest/policies.py
+++ b/gnocchi/rest/policies.py
@@ -300,7 +300,99 @@ archive_policy_rule_rules = [
     )
 ]
 
+metric_rules = [
+    policy.DocumentedRuleDefault(
+        name="create metric",
+        check_str=RULE_UNPROTECTED,
+        description='Create a new metric',
+        operations=[
+            {
+                'path': '/v1/metric',
+                'method': 'POST'
+            }
+        ]
+    ),
+    policy.DocumentedRuleDefault(
+        name="get metric",
+        check_str=ADMIN_OR_CREATOR_OR_METRIC_OWNER,
+        description='Get a metric',
+        operations=[
+            {
+                'path': '/v1/metric/{metric}',
+                'method': 'GET'
+            }
+        ]
+    ),
+    policy.DocumentedRuleDefault(
+        name="delete metric",
+        check_str=ADMIN_OR_CREATOR,
+        description='Delete a metric',
+        operations=[
+            {
+                'path': '/v1/metric/{metric}',
+                'method': 'DELETE'
+            }
+        ]
+    ),
+    policy.DocumentedRuleDefault(
+        name="list metric",
+        check_str=ADMIN_OR_CREATOR_OR_METRIC_OWNER,
+        description='List all metrics',
+        operations=[
+            {
+                'path': '/v1/metric',
+                'method': 'GET'
+            }
+        ]
+    ),
+    policy.DocumentedRuleDefault(
+        name="search metric",
+        check_str=ADMIN_OR_CREATOR_OR_METRIC_OWNER,
+        description='Search metrics',
+        operations=[
+            {
+                'path': '/v1/search/metric',
+                'method': 'POST'
+            }
+        ]
+    )
+]
+
+measure_rules = [
+    policy.DocumentedRuleDefault(
+        name="post measures",
+        check_str=ADMIN_OR_CREATOR,
+        description='Post measures',
+        operations=[
+            {
+                'path': '/v1/metric/{metric}/measures',
+                'method': 'POST'
+            },
+            {
+                'path': '/v1/batch/metrics/measures',
+                'method': 'POST'
+            },
+            {
+                'path': '/v1/batch/resources/metrics/measures',
+                'method': 'POST'
+            }
+        ]
+    ),
+    policy.DocumentedRuleDefault(
+        name="get measures",
+        check_str=ADMIN_OR_CREATOR_OR_METRIC_OWNER,
+        description='Get measures',
+        operations=[
+            {
+                'path': '/v1/metric/{metric}/measures',
+                'method': 'GET'
+            }
+        ]
+    )
+]
+
 
 def list_rules():
     return rules + resource_rules + resource_type_rules \
-        + archive_policy_rules + archive_policy_rule_rules
+        + archive_policy_rules + archive_policy_rule_rules \
+        + metric_rules + measure_rules

--- a/gnocchi/rest/policies.py
+++ b/gnocchi/rest/policies.py
@@ -184,6 +184,123 @@ resource_type_rules = [
     )
 ]
 
+archive_policy_rules = [
+    policy.DocumentedRuleDefault(
+        name="create archive policy",
+        check_str=RULE_ADMIN,
+        description='Create a new archive policy',
+        operations=[
+            {
+                'path': '/v1/archive_policy',
+                'method': 'POST'
+            }
+        ]
+    ),
+    policy.DocumentedRuleDefault(
+        name="get archive policy",
+        check_str=RULE_UNPROTECTED,
+        description='Get an archive policy',
+        operations=[
+            {
+                'path': '/v1/archive_policy/{archive_policy}',
+                'method': 'GET'
+            }
+        ]
+    ),
+    policy.DocumentedRuleDefault(
+        name="update archive policy",
+        check_str=RULE_ADMIN,
+        description='Update an archive policy',
+        operations=[
+            {
+                'path': '/v1/archive_policy/{archive_policy}',
+                'method': 'PATCH'
+            }
+        ]
+    ),
+    policy.DocumentedRuleDefault(
+        name="delete archive policy",
+        check_str=RULE_ADMIN,
+        description='Delete an archive policy',
+        operations=[
+            {
+                'path': '/v1/archive_policy/{archive_policy}',
+                'method': 'DELETE'
+            }
+        ]
+    ),
+    policy.DocumentedRuleDefault(
+        name="list archive policy",
+        check_str=RULE_UNPROTECTED,
+        description='List all archive policies',
+        operations=[
+            {
+                'path': '/v1/archive_policy',
+                'method': 'GET'
+            }
+        ]
+    )
+]
+
+archive_policy_rule_rules = [
+    policy.DocumentedRuleDefault(
+        name="create archive policy rule",
+        check_str=RULE_ADMIN,
+        description='Create a new archive policy rule',
+        operations=[
+            {
+                'path': '/v1/archive_policy_rule',
+                'method': 'POST'
+            }
+        ]
+    ),
+    policy.DocumentedRuleDefault(
+        name="get archive policy rule",
+        check_str=RULE_UNPROTECTED,
+        description='Get an archive policy rule',
+        operations=[
+            {
+                'path': '/v1/archive_policy_rule/{archive_policy_rule}',
+                'method': 'GET'
+            }
+        ]
+    ),
+    policy.DocumentedRuleDefault(
+        name="update archive policy rule",
+        check_str=RULE_ADMIN,
+        description='Update an archive policy rule',
+        operations=[
+            {
+                'path': '/v1/archive_policy_rule/{archive_policy_rule}',
+                'method': 'PATCH'
+            }
+        ]
+    ),
+    policy.DocumentedRuleDefault(
+        name="delete archive policy rule",
+        check_str=RULE_ADMIN,
+        description='Delete an archive policy rule',
+        operations=[
+            {
+                'path': '/v1/archive_policy_rule/{archive_policy_rule}',
+                'method': 'DELETE'
+            }
+        ]
+    ),
+    policy.DocumentedRuleDefault(
+        name="list archive policy rule",
+        check_str=RULE_UNPROTECTED,
+        description='List all archive policy rules',
+        operations=[
+            {
+                'path': '/v1/archive_policy_rule',
+                'method': 'GET'
+            }
+        ]
+    )
+]
+
 
 def list_rules():
-    return rules + resource_rules + resource_type_rules
+    return rules + resource_rules + resource_type_rules \
+        + archive_policy_rules + archive_policy_rule_rules

--- a/gnocchi/rest/policies.py
+++ b/gnocchi/rest/policies.py
@@ -22,6 +22,9 @@ RULE_RESOURCE_OWNER = "project_id:%(project_id)s"
 RULE_METRIC_OWNER = "project_id:%(resource.project_id)s"
 RULE_UNPROTECTED = ""
 
+ADMIN_OR_CREATOR = "rule:admin_or_creator"
+ADMIN_OR_CREATOR_OR_RESOURCE_OWNER = \
+    "rule:admin_or_creator or rule:resource_owner"
 ADMIN_OR_CREATOR_OR_METRIC_OWNER = "rule:admin_or_creator or rule:metric_owner"
 
 rules = [
@@ -43,6 +46,144 @@ rules = [
     )
 ]
 
+resource_rules = [
+    policy.DocumentedRuleDefault(
+        name="create resource",
+        check_str=RULE_UNPROTECTED,
+        description='Create a new resource.',
+        operations=[
+            {
+                'path': '/v1/resource/{resource_type}',
+                'method': 'POST'
+            }
+        ]
+    ),
+    policy.DocumentedRuleDefault(
+        name="get resource",
+        check_str=ADMIN_OR_CREATOR_OR_RESOURCE_OWNER,
+        description='Get a resource.',
+        operations=[
+            {
+                'path': '/v1/resource/{resource_type}/{resource_id}',
+                'method': 'GET'
+            }
+        ]
+    ),
+    policy.DocumentedRuleDefault(
+        name="update resource",
+        check_str=ADMIN_OR_CREATOR,
+        description='Update a resource.',
+        operations=[
+            {
+                'path': '/v1/resource/{resource_type}/{resource_id}',
+                'method': 'PATCH'
+            }
+        ]
+    ),
+    policy.DocumentedRuleDefault(
+        name="delete resource",
+        check_str=ADMIN_OR_CREATOR,
+        description='Delete a resource.',
+        operations=[
+            {
+                'path': '/v1/resource/{resource_type}/{resource_id}',
+                'method': 'DELETE'
+            }
+        ]
+    ),
+    policy.DocumentedRuleDefault(
+        name="delete resources",
+        check_str=ADMIN_OR_CREATOR,
+        description='Delete multiple resources.',
+        operations=[
+            {
+                'path': '/v1/resource/{resource_type}',
+                'method': 'DELETE'
+            }
+        ]
+    ),
+    policy.DocumentedRuleDefault(
+        name="list resource",
+        check_str=ADMIN_OR_CREATOR_OR_RESOURCE_OWNER,
+        description='List all resources.',
+        operations=[
+            {
+                'path': '/v1/resource/{resource_type}',
+                'method': 'GET'
+            }
+        ]
+    ),
+    policy.DocumentedRuleDefault(
+        name="search resource",
+        check_str=ADMIN_OR_CREATOR_OR_RESOURCE_OWNER,
+        description='Search resources.',
+        operations=[
+            {
+                'path': '/v1/search/resources/{resource_type}',
+                'method': 'POST'
+            }
+        ]
+    )
+]
+
+resource_type_rules = [
+    policy.DocumentedRuleDefault(
+        name="create resource type",
+        check_str=RULE_ADMIN,
+        description='Create a new resource type.',
+        operations=[
+            {
+                'path': '/v1/resource_type',
+                'method': 'POST'
+            }
+        ]
+    ),
+    policy.DocumentedRuleDefault(
+        name="get resource type",
+        check_str=RULE_UNPROTECTED,
+        description='Get a resource type.',
+        operations=[
+            {
+                'path': '/v1/resource_type/{resource_type}',
+                'method': 'GET'
+            }
+        ]
+    ),
+    policy.DocumentedRuleDefault(
+        name="update resource type",
+        check_str=RULE_ADMIN,
+        description='Update a resource type.',
+        operations=[
+            {
+                'path': '/v1/resource_type/{resource_type}',
+                'method': 'PATCH'
+            }
+        ]
+    ),
+    policy.DocumentedRuleDefault(
+        name="delete resource type",
+        check_str=RULE_ADMIN,
+        description='Delete a resource type.',
+        operations=[
+            {
+                'path': '/v1/resource_type/{resource_type}',
+                'method': 'DELETE'
+            }
+        ]
+    ),
+    policy.DocumentedRuleDefault(
+        name="list resource type",
+        check_str=RULE_UNPROTECTED,
+        description='List all resource types.',
+        operations=[
+            {
+                'path': '/v1/resource_type',
+                'method': 'GET'
+            }
+        ]
+    )
+]
+
 
 def list_rules():
-    return rules
+    return rules + resource_rules + resource_type_rules

--- a/gnocchi/rest/policies.py
+++ b/gnocchi/rest/policies.py
@@ -46,6 +46,20 @@ rules = [
     )
 ]
 
+status_rules = [
+    policy.DocumentedRuleDefault(
+        name="get status",
+        check_str=RULE_ADMIN,
+        description='Get status of Gnocchi service.',
+        operations=[
+            {
+                'path': '/v1/status',
+                'method': 'GET'
+            }
+        ]
+    )
+]
+
 resource_rules = [
     policy.DocumentedRuleDefault(
         name="create resource",
@@ -393,6 +407,7 @@ measure_rules = [
 
 
 def list_rules():
-    return rules + resource_rules + resource_type_rules \
+    return rules + status_rules \
+        + resource_rules + resource_type_rules \
         + archive_policy_rules + archive_policy_rule_rules \
         + metric_rules + measure_rules

--- a/gnocchi/rest/policy.json
+++ b/gnocchi/rest/policy.json
@@ -1,20 +1,6 @@
 {
     "get status": "role:admin",
 
-    "create resource": "",
-    "get resource": "rule:admin_or_creator or rule:resource_owner",
-    "update resource": "rule:admin_or_creator",
-    "delete resource": "rule:admin_or_creator",
-    "delete resources": "rule:admin_or_creator",
-    "list resource": "rule:admin_or_creator or rule:resource_owner",
-    "search resource": "rule:admin_or_creator or rule:resource_owner",
-
-    "create resource type": "role:admin",
-    "delete resource type": "role:admin",
-    "update resource type": "role:admin",
-    "list resource type": "",
-    "get resource type": "",
-
     "get archive policy": "",
     "list archive policy": "",
     "create archive policy": "role:admin",

--- a/gnocchi/rest/policy.json
+++ b/gnocchi/rest/policy.json
@@ -1,18 +1,6 @@
 {
     "get status": "role:admin",
 
-    "get archive policy": "",
-    "list archive policy": "",
-    "create archive policy": "role:admin",
-    "update archive policy": "role:admin",
-    "delete archive policy": "role:admin",
-
-    "create archive policy rule": "role:admin",
-    "get archive policy rule": "",
-    "list archive policy rule": "",
-    "update archive policy rule": "role:admin",
-    "delete archive policy rule": "role:admin",
-
     "create metric": "",
     "delete metric": "rule:admin_or_creator",
     "get metric": "rule:admin_or_creator or rule:metric_owner",

--- a/gnocchi/rest/policy.json
+++ b/gnocchi/rest/policy.json
@@ -1,12 +1,3 @@
 {
     "get status": "role:admin",
-
-    "create metric": "",
-    "delete metric": "rule:admin_or_creator",
-    "get metric": "rule:admin_or_creator or rule:metric_owner",
-    "search metric": "rule:admin_or_creator or rule:metric_owner",
-    "list metric": "rule:admin_or_creator or rule:metric_owner",
-
-    "get measures":  "rule:admin_or_creator or rule:metric_owner",
-    "post measures":  "rule:admin_or_creator"
 }

--- a/gnocchi/rest/policy.json
+++ b/gnocchi/rest/policy.json
@@ -1,3 +1,1 @@
-{
-    "get status": "role:admin",
-}
+{}

--- a/gnocchi/rest/policy.json
+++ b/gnocchi/rest/policy.json
@@ -1,8 +1,4 @@
 {
-    "admin_or_creator": "role:admin or user:%(creator)s or project_id:%(created_by_project_id)s",
-    "resource_owner": "project_id:%(project_id)s",
-    "metric_owner": "project_id:%(resource.project_id)s",
-
     "get status": "role:admin",
 
     "create resource": "",

--- a/gnocchi/rest/policy.yaml
+++ b/gnocchi/rest/policy.yaml
@@ -1,17 +1,5 @@
 "get status": "role:admin"
 
-"get archive policy": ""
-"list archive policy": ""
-"create archive policy": "role:admin"
-"update archive policy": "role:admin"
-"delete archive policy": "role:admin"
-
-"create archive policy rule": "role:admin"
-"get archive policy rule": ""
-"list archive policy rule": ""
-"update archive policy rule": "role:admin"
-"delete archive policy rule": "role:admin"
-
 "create metric": ""
 "delete metric": "rule:admin_or_creator"
 "get metric": "rule:admin_or_creator or rule:metric_owner"

--- a/gnocchi/rest/policy.yaml
+++ b/gnocchi/rest/policy.yaml
@@ -1,19 +1,5 @@
 "get status": "role:admin"
 
-"create resource": ""
-"get resource": "rule:admin_or_creator or rule:resource_owner"
-"update resource": "rule:admin_or_creator"
-"delete resource": "rule:admin_or_creator"
-"delete resources": "rule:admin_or_creator"
-"list resource": "rule:admin_or_creator or rule:resource_owner"
-"search resource": "rule:admin_or_creator or rule:resource_owner"
-
-"create resource type": "role:admin"
-"delete resource type": "role:admin"
-"update resource type": "role:admin"
-"list resource type": ""
-"get resource type": ""
-
 "get archive policy": ""
 "list archive policy": ""
 "create archive policy": "role:admin"

--- a/gnocchi/rest/policy.yaml
+++ b/gnocchi/rest/policy.yaml
@@ -1,1 +1,0 @@
-"get status": "role:admin"

--- a/gnocchi/rest/policy.yaml
+++ b/gnocchi/rest/policy.yaml
@@ -1,10 +1,1 @@
 "get status": "role:admin"
-
-"create metric": ""
-"delete metric": "rule:admin_or_creator"
-"get metric": "rule:admin_or_creator or rule:metric_owner"
-"search metric": "rule:admin_or_creator or rule:metric_owner"
-"list metric": "rule:admin_or_creator or rule:metric_owner"
-
-"get measures": "rule:admin_or_creator or rule:metric_owner"
-"post measures": "rule:admin_or_creator"

--- a/gnocchi/rest/policy.yaml
+++ b/gnocchi/rest/policy.yaml
@@ -1,7 +1,3 @@
-"admin_or_creator": "role:admin or user:%(creator)s or project_id:%(created_by_project_id)s"
-"resource_owner": "project_id:%(project_id)s"
-"metric_owner": "project_id:%(resource.project_id)s"
-
 "get status": "role:admin"
 
 "create resource": ""

--- a/releasenotes/notes/policy-in-code-2ded688177f2dc19.yaml
+++ b/releasenotes/notes/policy-in-code-2ded688177f2dc19.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Now all default policies are implemented in code, and the default policy
+    rules are no longer required in policy configuration.

--- a/setup.cfg
+++ b/setup.cfg
@@ -161,6 +161,9 @@ oslo.config.opts =
 oslo.config.opts.defaults =
     gnocchi = gnocchi.opts:set_defaults
 
+oslo.policy.policies =
+    gnocchi = gnocchi.rest.policies:list_rules
+
 [build_sphinx]
 all_files = 1
 build-dir = doc/build


### PR DESCRIPTION
This change implements default policies in code. With this change, operators no longer need to define the default policy rules in policy configuration file(policy.yaml) unless they need any customized rules.