### PR TITLE
Use policy.yaml in tests

### DIFF
--- a/gnocchi/tests/base.py
+++ b/gnocchi/tests/base.py
@@ -315,7 +315,7 @@ class TestCase(BaseTestCase):
                                os.path.join(py_root, 'rest', 'api-paste.ini'),
                                group="api")
         self.conf.set_override('policy_file',
-                               os.path.join(py_root, 'rest', 'policy.json'),
+                               os.path.join(py_root, 'rest', 'policy.yaml'),
                                group="oslo_policy")
 
         # NOTE(jd) This allows to test S3 on AWS

--- a/gnocchi/tests/functional/fixtures.py
+++ b/gnocchi/tests/functional/fixtures.py
@@ -111,7 +111,7 @@ class ConfigFixture(fixture.GabbiFixture):
                           os.path.join(py_root, 'rest', 'api-paste.ini'),
                           group="api")
         conf.set_override('policy_file',
-                          os.path.join(py_root, 'rest', 'policy.json'),
+                          os.path.join(py_root, 'rest', 'policy.yaml'),
                           group="oslo_policy")
 
         # NOTE(sileht): This is not concurrency safe, but only this tests file


### PR DESCRIPTION
This change replaces the usage of policy.json by policy.yaml in test
codes, because Gnocchi service now uses policy.yaml by default.