### PR TITLE
Dismiss reviews after pushing a new commit

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -23,8 +23,7 @@ pull_request_rules:
   - name: dismiss reviews on additional commit
     actions:
       dismiss_reviews: {}
-    contitions:
-    - .*
+    conditions: []
 
 # Backports to stable branches
   - actions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -20,6 +20,11 @@ pull_request_rules:
     - label!=work-in-progress
     - author=mergify[bot]
     - status-success=Travis CI - Pull Request
+  - name: dismiss reviews on additional commit
+    actions:
+      dismiss_reviews: {}
+    contitions:
+    - .*
 
 # Backports to stable branches
   - actions:


### PR DESCRIPTION
to prevent accidental merges of non-reviewed
changes.

Related: https://github.com/Mergifyio/mergify-engine/issues/1860