### PR TITLE
Policy in code requires oslo.policy >= 3.5.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     numpy>=1.9.0
     iso8601
     oslo.config>=3.22.0
-    oslo.policy>=0.3.0
+    oslo.policy>=3.5.0
     oslo.middleware>=3.22.0
     pytimeparse
     pecan>=0.9


### PR DESCRIPTION
and thus we should bump the requirement.