### PR TITLE
Limit maximum metrics to be deleted simultaniously

### DIFF
--- a/gnocchi/chef.py
+++ b/gnocchi/chef.py
@@ -49,14 +49,17 @@ class Chef(object):
         self.index = index
         self.storage = storage
 
-    def expunge_metrics(self, sync=False):
+    def expunge_metrics(self, cleanup_batch_size, sync=False):
         """Remove deleted metrics.
 
+        :param cleanup_batch_size: The amount of metrics to delete in one
+                                   run.
         :param sync: If True, then delete everything synchronously and raise
                      on error
         :type sync: bool
         """
-        metrics_to_expunge = self.index.list_metrics(status='delete')
+        metrics_to_expunge = self.index.list_metrics(status='delete',
+                                                     limit=cleanup_batch_size)
         metrics_by_id = {m.id: m for m in metrics_to_expunge}
         for sack, metric_ids in self.incoming.group_metrics_by_sack(
                 metrics_by_id.keys()):

--- a/gnocchi/cli/metricd.py
+++ b/gnocchi/cli/metricd.py
@@ -267,7 +267,7 @@ class MetricJanitor(MetricProcessBase):
             worker_id, conf, conf.metricd.metric_cleanup_delay)
 
     def _run_job(self):
-        self.chef.expunge_metrics()
+        self.chef.expunge_metrics(self.conf.metricd.cleanup_batch_size)
         LOG.debug("Metrics marked for deletion removed from backend")
 
 

--- a/gnocchi/opts.py
+++ b/gnocchi/opts.py
@@ -172,6 +172,11 @@ def list_opts():
                        "value may improve worker utilization but may also "
                        "increase load on coordination backend. Value is "
                        "capped by number of workers globally."),
+            cfg.IntOpt('cleanup_batch_size',
+                       default=10000,
+                       min=1,
+                       help="Number of metrics that should be deleted "
+                       "simultaneously by one janitor."),
         )),
         ("api", (
             cfg.StrOpt('paste_config',

--- a/gnocchi/tests/test_chef.py
+++ b/gnocchi/tests/test_chef.py
@@ -42,7 +42,7 @@ class TestChef(base.TestCase):
         self.trigger_processing()
         __, __, details = self.incoming._build_report(True)
         self.assertNotIn(str(self.metric.id), details)
-        self.chef.expunge_metrics(sync=True)
+        self.chef.expunge_metrics(10000, sync=True)
 
     def test_delete_expunge_metric(self):
         self.incoming.add_measures(self.metric.id, [
@@ -50,6 +50,6 @@ class TestChef(base.TestCase):
         ])
         self.trigger_processing()
         self.index.delete_metric(self.metric.id)
-        self.chef.expunge_metrics(sync=True)
+        self.chef.expunge_metrics(10000, sync=True)
         self.assertRaises(indexer.NoSuchMetric, self.index.delete_metric,
                           self.metric.id)

--- a/releasenotes/notes/configurable_clenaup_batch_size-a785c1aa6ee29058.yaml
+++ b/releasenotes/notes/configurable_clenaup_batch_size-a785c1aa6ee29058.yaml
@@ -1,0 +1,12 @@
+---
+
+features:
+  - |
+    Users can now configure the ``cleanup_batch_size``. This limits the amount of
+    metrics being deleted during a run of the janitor thereby preventing
+    out-of-memory errors.
+upgrade:
+  - |
+    Users having a large amount of metrics being deleted regularly might needs
+    to increase ``cleanup_batch_size`` to a higher value so that the janitor
+    can keep up.


### PR DESCRIPTION
Currently gnocchi-metricd tries to collect all metrics that should be deleted
and deletes them in one big loop. If a large amount of old metrics has
accumulated this will cause high load on the database as it needs to find
and sort all of these rows. It will also cause a high amount of memory usage
for gnocchi-metricd as it needs to also sort all of these rows in memory.

To fix this the amount of rows being deleted in one run is limited to 10000.
This is sufficient to allow gnocchi to cleanup metrics in a fast way under
normal circumstances while still allowing it to catch up if no deletion has
been performed for a while.

Signed-off-by: Felix Huettner <felix.huettner@mail.schwarz>