### PR TITLE
Pin sqlalchemy and tenacity

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     voluptuous>=0.8.10
     werkzeug
     trollius; python_version < '3.4'
-    tenacity>=4.6.0
+    tenacity>=4.6.0,<7.0.0
     WebOb>=1.4.1
     Paste
     PasteDeploy
@@ -58,13 +58,13 @@ keystone =
 mysql =
     pymysql
     oslo.db>=4.29.0
-    sqlalchemy
+    sqlalchemy<1.4.0
     sqlalchemy-utils
     alembic>=0.7.6,!=0.8.1,!=0.9.0
 postgresql =
     psycopg2
     oslo.db>=4.29.0
-    sqlalchemy
+    sqlalchemy<1.4.0
     sqlalchemy-utils
     alembic>=0.7.6,!=0.8.1,!=0.9.0
 s3 =


### PR DESCRIPTION
tenacity has a dropped backwards compatible changes for
version 7.0.0 and sqlalchemy in 1.4 causes an issue
with sqlalchemy_utils.