### PR TITLE
Run upgrade testing from git

### DIFF
--- a/run-upgrade-tests.sh
+++ b/run-upgrade-tests.sh
@@ -13,7 +13,8 @@ fi
 
 export GNOCCHI_DATA=$(mktemp -d -t gnocchi.XXXX)
 
-old_version=$(pip freeze | sed -n '/gnocchi==/s/.*==\(.*\)/\1/p')
+echo "* Installing Gnocchi from ${GNOCCHI_VERSION_FROM}"
+pip install -q --force-reinstall git+https://github.com/gnocchixyz/gnocchi.git@${GNOCCHI_VERSION_FROM}#egg=gnocchi[${GNOCCHI_VARIANT}]
 
 RESOURCE_IDS=(
     "5a301761-aaaa-46e2-8900-8b4f6fe6675a"
@@ -93,7 +94,7 @@ dump_data $GNOCCHI_DATA/old
 pifpaf_stop
 
 new_version=$(python setup.py --version)
-echo "* Upgrading Gnocchi from $old_version to $new_version"
+echo "* Upgrading Gnocchi from $GNOCCHI_VERSION_FROM to $new_version"
 pip install -v -U .[${GNOCCHI_VARIANT}]
 
 eval $(pifpaf run gnocchi --indexer-url $INDEXER_URL --storage-url $STORAGE_URL)
@@ -106,7 +107,7 @@ gnocchi resource delete $GNOCCHI_STATSD_RESOURCE_ID
 
 dump_data $GNOCCHI_DATA/new
 
-echo "* Checking output difference between Gnocchi $old_version and $new_version"
+echo "* Checking output difference between Gnocchi $GNOCCHI_VERSION_FROM and $new_version"
 # This asserts we find the new measures in the old ones. Gnocchi > 4.1 will
 # store less points because it uses the timespan and not the points of the
 # archive policy

--- a/tox.ini
+++ b/tox.ini
@@ -55,9 +55,11 @@ commands =
 # We should always recreate since the script upgrade
 # Gnocchi we can't reuse the virtualenv
 recreate = True
-setenv = GNOCCHI_VARIANT=test,postgresql,file
-deps = gnocchi[{env:GNOCCHI_VARIANT}]>=4.3,<4.4
-  pifpaf[gnocchi]>=0.13
+setenv =
+  GNOCCHI_VERSION_FROM=stable/4.3
+  GNOCCHI_VARIANT=test,postgresql,file
+deps =
+  pifpaf>=0.13
   gnocchiclient>=2.8.0,!=7.0.7
   xattr!=0.9.4
 commands = {toxinidir}/run-upgrade-tests.sh postgresql-file
@@ -66,10 +68,12 @@ commands = {toxinidir}/run-upgrade-tests.sh postgresql-file
 # We should always recreate since the script upgrade
 # Gnocchi we can't reuse the virtualenv
 recreate = True
-setenv = GNOCCHI_VARIANT=test,mysql,ceph,ceph_recommended_lib
-deps = gnocchi[{env:GNOCCHI_VARIANT}]>=4.3,<4.4
+setenv =
+  GNOCCHI_VERSION_FROM=stable/4.3
+  GNOCCHI_VARIANT=test,mysql,ceph,ceph_recommended_lib
+deps =
   gnocchiclient>=2.8.0,!=7.0.7
-  pifpaf[ceph,gnocchi]>=0.13
+  pifpaf[ceph]>=0.13
   xattr!=0.9.4
 commands = {toxinidir}/run-upgrade-tests.sh mysql-ceph
 


### PR DESCRIPTION
Don't upgrade between released versions but use tags
or branches instead. When dependencies breaks it's
easier to get jobs passing without having to release
instantly.