### PR TITLE
Drop upgrade jobs from 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ env:
   - TARGET: pep8
   - TARGET: docs
 
-  - TARGET: py36-mysql-ceph-upgrade-from-4.2
-  - TARGET: py36-postgresql-file-upgrade-from-4.2
-
   - TARGET: py36-mysql
   - TARGET: py36-postgresql
   - TARGET: py36-postgresql


### PR DESCRIPTION
We won't maintain CI for 4.2 so we won't
test upgrade.