### PR TITLE
Bump ujson>=2.0.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     cotyledon>=1.5.0
     six
     stevedore
-    ujson
+    ujson>=2.0.3
     voluptuous>=0.8.10
     werkzeug
     trollius; python_version < '3.4'


### PR DESCRIPTION
There is a memory leak included in ujson, see
https://github.com/ultrajson/ultrajson/pull/394/commits/92c57b421052b146e4f2dfce9386c7cf13241091