### PR TITLE
Fix Python 3.8, SQLAlchemy 1.4 and MySQL 8

### DIFF
--- a/gnocchi/amqp1d.py
+++ b/gnocchi/amqp1d.py
@@ -64,14 +64,17 @@ class BatchProcessor(object):
         for host_id, measures_by_names in six.iteritems(self._measures):
             resource = resources[host_id]
 
-            names = set(measures_by_names.keys())
+            mbn_keys = measures_by_names.keys()
+            names = (set(mbn_keys) if len(mbn_keys)
+                     else set())
+
             for name in names:
                 if name not in archive_policies:
                     archive_policies[name] = (
                         self.indexer.get_archive_policy_for_metric(name))
             known_metrics = self.indexer.list_metrics(attribute_filter={
                 "and": [{"=": {"resource_id": resource.id}},
-                        {"in": {"name": names}}]
+                        {"in": {"name": list(names)}}]
             })
             known_names = set((m.name for m in known_metrics))
             already_exists_names = []

--- a/gnocchi/amqp1d.py
+++ b/gnocchi/amqp1d.py
@@ -64,10 +64,7 @@ class BatchProcessor(object):
         for host_id, measures_by_names in six.iteritems(self._measures):
             resource = resources[host_id]
 
-            mbn_keys = measures_by_names.keys()
-            names = (set(mbn_keys) if len(mbn_keys)
-                     else set())
-
+            names = set(measures_by_names.keys())
             for name in names:
                 if name not in archive_policies:
                     archive_policies[name] = (

--- a/gnocchi/indexer/sqlalchemy_base.py
+++ b/gnocchi/indexer/sqlalchemy_base.py
@@ -51,13 +51,17 @@ class ArchivePolicyDefinitionType(sqlalchemy_utils.JSONType):
     def process_result_value(self, value, dialect):
         values = super(ArchivePolicyDefinitionType,
                        self).process_result_value(value, dialect)
+        if values is None:
+            return []
         return [archive_policy.ArchivePolicyItem(**v) for v in values]
 
 
 class SetType(sqlalchemy_utils.JSONType):
     def process_result_value(self, value, dialect):
-        return set(super(SetType,
-                         self).process_result_value(value, dialect))
+        values = super(SetType, self).process_result_value(value, dialect)
+        if values is None:
+            return set()
+        return set(values)
 
 
 class ArchivePolicy(Base, GnocchiBase, archive_policy.ArchivePolicy):

--- a/gnocchi/rest/auth_helper.py
+++ b/gnocchi/rest/auth_helper.py
@@ -119,7 +119,7 @@ class BasicAuthHelper(object):
     @staticmethod
     def get_current_user(request):
         hdr = request.headers.get("Authorization")
-        auth_hdr = (hdr.decode('utf-8') if type(hdr) == bytes
+        auth_hdr = (hdr.decode('utf-8') if isinstance(hdr, bytes)
                     else hdr)
         auth = werkzeug.http.parse_authorization_header(auth_hdr)
         if auth is None:

--- a/gnocchi/rest/auth_helper.py
+++ b/gnocchi/rest/auth_helper.py
@@ -118,8 +118,10 @@ class KeystoneAuthHelper(object):
 class BasicAuthHelper(object):
     @staticmethod
     def get_current_user(request):
-        auth = werkzeug.http.parse_authorization_header(
-            request.headers.get("Authorization"))
+        hdr = request.headers.get("Authorization")
+        auth_hdr = (hdr.decode('utf-8') if type(hdr) == bytes
+                    else hdr)
+        auth = werkzeug.http.parse_authorization_header(auth_hdr)
         if auth is None:
             api.abort(401)
         return auth.username

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,13 +57,13 @@ keystone =
 mysql =
     pymysql
     oslo.db>=4.29.0
-    sqlalchemy<1.4.0
+    sqlalchemy
     sqlalchemy-utils
     alembic>=0.7.6,!=0.8.1,!=0.9.0
 postgresql =
     psycopg2
     oslo.db>=4.29.0
-    sqlalchemy<1.4.0
+    sqlalchemy
     sqlalchemy-utils
     alembic>=0.7.6,!=0.8.1,!=0.9.0
 s3 =

--- a/tox.ini
+++ b/tox.ini
@@ -91,7 +91,8 @@ commands = pifpaf -g GNOCCHI_INDEXER_URL run postgresql -- python setup.py testr
 exclude = .tox,.eggs,doc,gnocchi/rest/prometheus/remote_pb2.py,gnocchi/indexer/alembic/versions/
 show-source = true
 enable-extensions = H904
-ignore = E501,E731,W503,W504
+# TODO(tobias-urdin): Remove H216 when we use unittest.mock
+ignore = E501,E731,W503,W504,H216
 
 [testenv:docs]
 basepython = python3


### PR DESCRIPTION
This PR fixes multiple issues.

- [x] Fix new flake8 lint issues that breaks CI (ignore H216 that enforces usage of builtin unittest.mock instead of mock)
- [x] Fix Python3.8 support by utf-8 decoding bytes to strings in Authorization header
- [x] Fix SQLAlchemy 1.4 support by not trying to modify immutable URL, use query(Model) when performing delete()
- [x] Fix MySQL 8 migration by modifying old revision to drop constraints before dropping any column
- [x] Unpin SQLALchemy completely