### PR TITLE
ci: dont run actions on push and dont hardcode default branch

### DIFF
--- a/.github/workflows/gnocchi.yml
+++ b/.github/workflows/gnocchi.yml
@@ -1,8 +1,6 @@
 name: Gnocchi
 
-on:
-  pull_request:
-    branches: [master]
+on: pull_request
 
 # NOTE(tobias-urdin): If you change any jobs make sure to modify
 # the Mergify.io config in .mergify.yml to include the jobs!

--- a/.github/workflows/gnocchi.yml
+++ b/.github/workflows/gnocchi.yml
@@ -1,8 +1,6 @@
 name: Gnocchi
 
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
 


### PR DESCRIPTION
Only run the actions on PR and not
on push because that runs the actions
when a PR is merged.

Dont hardcode the default branch to master
since it actions will use the same ref/commit
that it's going to test when loading workflows.

Removing the default branch makes it easier to
just backport later.