### PR TITLE
doc: update reno branches to new eol names

### DIFF
--- a/doc/source/releasenotes/3.0.rst
+++ b/doc/source/releasenotes/3.0.rst
@@ -3,4 +3,4 @@
 ===================================
 
 .. release-notes::
-   :branch: origin/stable/3.0
+   :branch: origin/eol/3.0

--- a/doc/source/releasenotes/3.1.rst
+++ b/doc/source/releasenotes/3.1.rst
@@ -3,4 +3,4 @@
 ===================================
 
 .. release-notes::
-   :branch: origin/stable/3.1
+   :branch: origin/eol/3.1

--- a/doc/source/releasenotes/4.0.rst
+++ b/doc/source/releasenotes/4.0.rst
@@ -3,4 +3,4 @@
 ===================================
 
 .. release-notes::
-   :branch: origin/stable/4.0
+   :branch: origin/eol/4.0

--- a/doc/source/releasenotes/4.1.rst
+++ b/doc/source/releasenotes/4.1.rst
@@ -3,4 +3,4 @@
 ===================================
 
 .. release-notes::
-   :branch: origin/stable/4.1
+   :branch: origin/eol/4.1

--- a/doc/source/releasenotes/4.2.rst
+++ b/doc/source/releasenotes/4.2.rst
@@ -3,4 +3,4 @@
 ===================================
 
 .. release-notes::
-   :branch: origin/stable/4.2
+   :branch: origin/eol/4.2


### PR DESCRIPTION
old stable branches was renamed to eol-<version>
so that needs to be updated.