### PR TITLE
Fix README include bound

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -2,8 +2,10 @@
 Gnocchi – Metric as a Service
 ==================================
 
+Gnocchi is an open-source time series database.
+
 .. include:: ../../README.rst
-   :start-line: 13
+   :start-after: Gnocchi is an open-source time series database.
 
 Key Features
 ------------


### PR DESCRIPTION
Using a specific string as the magic marker. Repeated as an actual string (on line 5) because '...-after' is actually after that line, not that line and later. Can't seem to use a comment/crossref marker like `.. _doc_include_marker:` and `start-after` that. If the intro README line changes, then the docs build will break, rather than strangely truncating.

If you want to just keep the `start-line` option, it's now 9.