### PR TITLE
Mark Python 3.6 as supported

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ classifier =
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
     Topic :: System :: Monitoring
 
 [options]


### PR DESCRIPTION
Python 3.6 is used in CI and tested.