### PR TITLE
Mark Python 3.6 as supported

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifier =
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
     Topic :: System :: Monitoring
 
 [options]


### PR DESCRIPTION
Python 3.6 is used in CI and tested.

(cherry picked from commit 0270c728574fd36e101db5e24b625a123784c9db)