### PR TITLE
Use health_check_interval

### DIFF
--- a/gnocchi/common/redis.py
+++ b/gnocchi/common/redis.py
@@ -36,6 +36,7 @@ SEP = b':'
 CLIENT_ARGS = frozenset([
     'db',
     'encoding',
+    'health_check_interval',
     'retry_on_timeout',
     'socket_keepalive',
     'socket_timeout',
@@ -62,6 +63,7 @@ CLIENT_BOOL_ARGS = frozenset([
 #: Client arguments that are expected to be int convertible.
 CLIENT_INT_ARGS = frozenset([
     'db',
+    'health_check_interval',
     'socket_keepalive',
     'socket_timeout',
 ])

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ s3 =
     boto3
     botocore>=1.5
 redis =
-    redis >= 3.2.0 # MIT
+    redis >= 3.3.0 # MIT
     hiredis
 swift =
     python-swiftclient>=3.1.0


### PR DESCRIPTION
which was introduced in redis_py >= 3.3. It helps with keeping
connections alive and to prevent  ServerConnection errors.