### PR TITLE
Fix yaml deprecation warning

### DIFF
--- a/gnocchi/gendoc.py
+++ b/gnocchi/gendoc.py
@@ -194,7 +194,7 @@ def setup(app):
 
     # TODO(jd) Do not hardcode doc/source
     with open("doc/source/rest.yaml") as f:
-        scenarios = ScenarioList(yaml.load(f))
+        scenarios = ScenarioList(yaml.load(f, Loader=yaml.FullLoader))
 
     test = test_rest.RestTest()
     test.auth_mode = "basic"


### PR DESCRIPTION
YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated,
as the default Loader is unsafe. Please read https://msg.pyyaml.org/load
for full details.

(cherry picked from commit ae022ad4ef3dbf003d704265713fb253b002ec95)