### PR TITLE
Use policy.yaml by default

### DIFF
--- a/gnocchi/cli/api.py
+++ b/gnocchi/cli/api.py
@@ -44,7 +44,7 @@ def prepare_service(conf=None):
         cfg_path = conf.find_file(cfg_path)
     if cfg_path is None or not os.path.exists(cfg_path):
         cfg_path = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                   '..', 'rest', 'policy.json'))
+                                   '..', 'rest', 'policy.yaml'))
     conf.set_default('policy_file', cfg_path, group='oslo_policy')
     return conf
 

--- a/gnocchi/rest/policy.yaml
+++ b/gnocchi/rest/policy.yaml
@@ -1,0 +1,40 @@
+"admin_or_creator": "role:admin or user:%(creator)s or project_id:%(created_by_project_id)s"
+"resource_owner": "project_id:%(project_id)s"
+"metric_owner": "project_id:%(resource.project_id)s"
+
+"get status": "role:admin"
+
+"create resource": ""
+"get resource": "rule:admin_or_creator or rule:resource_owner"
+"update resource": "rule:admin_or_creator"
+"delete resource": "rule:admin_or_creator"
+"delete resources": "rule:admin_or_creator"
+"list resource": "rule:admin_or_creator or rule:resource_owner"
+"search resource": "rule:admin_or_creator or rule:resource_owner"
+
+"create resource type": "role:admin"
+"delete resource type": "role:admin"
+"update resource type": "role:admin"
+"list resource type": ""
+"get resource type": ""
+
+"get archive policy": ""
+"list archive policy": ""
+"create archive policy": "role:admin"
+"update archive policy": "role:admin"
+"delete archive policy": "role:admin"
+
+"create archive policy rule": "role:admin"
+"get archive policy rule": ""
+"list archive policy rule": ""
+"update archive policy rule": "role:admin"
+"delete archive policy rule": "role:admin"
+
+"create metric": ""
+"delete metric": "rule:admin_or_creator"
+"get metric": "rule:admin_or_creator or rule:metric_owner"
+"search metric": "rule:admin_or_creator or rule:metric_owner"
+"list metric": "rule:admin_or_creator or rule:metric_owner"
+
+"get measures": "rule:admin_or_creator or rule:metric_owner"
+"post measures": "rule:admin_or_creator"

--- a/gnocchi/tests/base.py
+++ b/gnocchi/tests/base.py
@@ -315,7 +315,7 @@ class TestCase(BaseTestCase):
                                os.path.join(py_root, 'rest', 'api-paste.ini'),
                                group="api")
         self.conf.set_override('policy_file',
-                               os.path.join(py_root, 'rest', 'policy.json'),
+                               os.path.join(py_root, 'rest', 'policy.yaml'),
                                group="oslo_policy")
 
         # NOTE(jd) This allows to test S3 on AWS

--- a/gnocchi/tests/functional/fixtures.py
+++ b/gnocchi/tests/functional/fixtures.py
@@ -111,7 +111,7 @@ class ConfigFixture(fixture.GabbiFixture):
                           os.path.join(py_root, 'rest', 'api-paste.ini'),
                           group="api")
         conf.set_override('policy_file',
-                          os.path.join(py_root, 'rest', 'policy.json'),
+                          os.path.join(py_root, 'rest', 'policy.yaml'),
                           group="oslo_policy")
 
         # NOTE(sileht): This is not concurrency safe, but only this tests file

--- a/releasenotes/notes/migrate-policy-format-from-json-to-yaml-3287dfaeee6abfa2.yaml
+++ b/releasenotes/notes/migrate-policy-format-from-json-to-yaml-3287dfaeee6abfa2.yaml
@@ -1,0 +1,10 @@
+---
+upgrade:
+  - |
+    Now Gnocchi uses policy.yaml as its default policy file instead of
+    policy.json.
+
+deprecations:
+  - |
+    Default policy.json has been deprecated and will be removed in a future
+    release. Use policy.yaml instead.

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     numpy>=1.9.0
     iso8601
     oslo.config>=3.22.0
-    oslo.policy>=0.3.0
+    oslo.policy>=1.7.0
     oslo.middleware>=3.22.0
     pytimeparse
     pecan>=0.9


### PR DESCRIPTION
Since oslo.policy 3.4.0, support for policy.json has been deprecated in favor of the yaml format [1]

This PR is a backport of the required changes to migrate from policy.json to policy.yaml, so that each distro can consume a version with policy.yaml used by default.

[1] https://docs.openstack.org/releasenotes/oslo.policy/victoria.html#relnotes-3-4-0-stable-victoria
[2] https://governance.openstack.org/tc/goals/selected/wallaby/migrate-policy-format-from-json-to-yaml.html
