### PR TITLE
New CI fixes

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,17 +1,9 @@
-pull_request_rules:
-  - name: automatic merge
-    actions:
-      merge:
-        method: rebase
-        rebase_fallback: merge
+queue_rules:
+  - name: default
     conditions:
-    - label!=work-in-progress
-    - '#approved-reviews-by>=1'
     - check-success=doc (docs)
     - check-success=doc (docs-gnocchi-web)
-
     - check-success=check (pep8)
-
     - check-success=test (py36, postgresql-file-upgrade-from-4.3)
     - check-success=test (py36, mysql-file)
     - check-success=test (py36, mysql-swift)
@@ -19,7 +11,36 @@ pull_request_rules:
     - check-success=test (py36, postgresql-file)
     - check-success=test (py36, postgresql-swift)
     - check-success=test (py36, postgresql-s3)
+    - check-success=test (py38, mysql-ceph-upgrade-from-4.3)
+    - check-success=test (py38, postgresql-file-upgrade-from-4.3)
+    - check-success=test (py38, mysql-file)
+    - check-success=test (py38, mysql-swift)
+    - check-success=test (py38, mysql-s3)
+    - check-success=test (py38, mysql-ceph)
+    - check-success=test (py38, postgresql-file)
+    - check-success=test (py38, postgresql-swift)
+    - check-success=test (py38, postgresql-s3)
+    - check-success=test (py38, postgresql-ceph)
 
+pull_request_rules:
+  - name: automatic merge
+    actions:
+      queue:
+        method: merge
+        name: default
+    conditions:
+    - label!=work-in-progress
+    - '#approved-reviews-by>=1'
+    - check-success=doc (docs)
+    - check-success=doc (docs-gnocchi-web)
+    - check-success=check (pep8)
+    - check-success=test (py36, postgresql-file-upgrade-from-4.3)
+    - check-success=test (py36, mysql-file)
+    - check-success=test (py36, mysql-swift)
+    - check-success=test (py36, mysql-s3)
+    - check-success=test (py36, postgresql-file)
+    - check-success=test (py36, postgresql-swift)
+    - check-success=test (py36, postgresql-s3)
     - check-success=test (py38, mysql-ceph-upgrade-from-4.3)
     - check-success=test (py38, postgresql-file-upgrade-from-4.3)
     - check-success=test (py38, mysql-file)
@@ -33,9 +54,9 @@ pull_request_rules:
 
   - name: automatic merge backports from Mergify
     actions:
-      merge:
-        method: rebase
-        rebase_fallback: merge
+      queue:
+        method: merge
+        name: default
     conditions:
     - base~=^stable/.*
     - label!=work-in-progress

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,7 +4,6 @@ pull_request_rules:
       merge:
         method: rebase
         rebase_fallback: merge
-        strict: true
     conditions:
     - label!=work-in-progress
     - '#approved-reviews-by>=1'
@@ -37,7 +36,6 @@ pull_request_rules:
       merge:
         method: rebase
         rebase_fallback: merge
-        strict: true
     conditions:
     - base~=^stable/.*
     - label!=work-in-progress

--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -1296,7 +1296,7 @@ class QueryStringSearchAttrFilter(object):
     @classmethod
     def _parsed_query2dict(cls, parsed_query):
         result = None
-        while parsed_query:
+        while len(parsed_query.asList()):
             part = parsed_query.pop()
             if part in cls.binary_operator:
                 result = {part: {parsed_query.pop(): result}}

--- a/gnocchi/tests/functional/gabbits/aggregates-with-metric-ids.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregates-with-metric-ids.yaml
@@ -645,7 +645,7 @@ tests:
         $.code: 400
         $.description.cause: "Invalid operations"
         $.description.reason: "/^Fail to parse the operations string/"
-        $.description.detail: '/^Expected "\)", found end of text  \(at char 15\), \(line:1, col:16\)/'
+        $.description.detail: /^Expected \'\)\', found end of text  \(at char 15\), \(line:1, col:16\)/
 
     - name: get invalid metric operations
       POST: /v1/aggregates


### PR DESCRIPTION
This contains new CI fixes.

* pyparsing >= 3.0.0 changed behavior of ``__bool__`` on pyparsing.ParseResult class
* Update asserRegex for gabbi tests where pyparsing changed the output
* Update mergify config to remove the ``strict`` key in the ``merge`` dict