### PR TITLE
Support later versions of tenacity

### DIFF
--- a/gnocchi/utils.py
+++ b/gnocchi/utils.py
@@ -348,10 +348,10 @@ class _retry_on_exception_and_log(tenacity.retry_if_exception_type):
         super(_retry_on_exception_and_log, self).__init__()
         self.msg = msg
 
-    def __call__(self, attempt):
-        if attempt.failed:
-            LOG.error(self.msg, exc_info=attempt.exception())
-        return super(_retry_on_exception_and_log, self).__call__(attempt)
+    def __call__(self, retry_state):
+        if retry_state.outcome.failed:
+            LOG.error(self.msg, exc_info=retry_state.outcome.exception())
+        return super(_retry_on_exception_and_log, self).__call__(retry_state)
 
 
 def retry_on_exception_and_log(msg):

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     voluptuous>=0.8.10
     werkzeug
     trollius; python_version < '3.4'
-    tenacity>=4.6.0,<7.0.0
+    tenacity>=4.6.0
     WebOb>=1.4.1
     Paste
     PasteDeploy

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     voluptuous>=0.8.10
     werkzeug
     trollius; python_version < '3.4'
-    tenacity>=4.6.0
+    tenacity>=5.0.0
     WebOb>=1.4.1
     Paste
     PasteDeploy


### PR DESCRIPTION
This adds support for later version of the
tenacity library and unpins the dependency.

This depends on the tooz [1] change or it
will fail.

[1] https://review.opendev.org/c/openstack/tooz/+/829412