### PR TITLE
Handle invalid values for getting all metrics.

### DIFF
--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -651,7 +651,10 @@ class MetricsController(rest.RestController):
     @classmethod
     @pecan.expose('json')
     def get_all(cls, **kwargs):
-        filtering = cls.MetricListSchema(kwargs)
+        try:
+            filtering = cls.MetricListSchema(kwargs)
+        except voluptuous.Error as e:
+            abort(400, "Invalid input: %s" % e)
 
         # Compat with old user/project API
         provided_user_id = filtering.pop('user_id', None)


### PR DESCRIPTION
The patch resolves 500 server error
when user sends request with invalid values, e.g.
metric?query=KoZlthVNGjXDeWPaEgRPyGjDKvqwHHZJmI
Patch fixes issue 1196.

Change-Id: Ib87bdd5f942b2642f460e7e97e2d71be3f3dce37