### PR TITLE
dynamic aggregates - metric not found

### DIFF
--- a/gnocchi/rest/aggregates/api.py
+++ b/gnocchi/rest/aggregates/api.py
@@ -251,7 +251,7 @@ class AggregatesController(rest.RestController):
                         resources, references, body["operations"], start, stop,
                         granularity, needed_overlap, fill, details=details)
                 except indexer.NoSuchMetric as e:
-                    api.abort(400, e)
+                    api.abort(404, e)
 
             def groupper(r):
                 return tuple((attr, r[attr]) for attr in groupby)
@@ -270,7 +270,7 @@ class AggregatesController(rest.RestController):
                     pass
             if not results:
                 api.abort(
-                    400,
+                    404,
                     indexer.NoSuchMetric(set((m for (m, a) in references))))
             return results
 

--- a/gnocchi/tests/functional/gabbits/aggregates-with-resources.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregates-with-resources.yaml
@@ -403,9 +403,9 @@ tests:
         resource_type: generic
         search: "user_id = 'A50F549C-1F1C-4888-A71A-2C5473CCCEC1'"
         operations: "(aggregate mean (metric (notexists mean) (foobar mean)))"
-      status: 400
+      status: 404
       response_json_paths:
-        $.code: 400
+        $.code: 404
         $.description.cause: "Metrics not found"
         $.description.detail.`sorted`:
           - foobar
@@ -421,9 +421,9 @@ tests:
         resource_type: generic
         search: "user_id = 'A50F549C-1F1C-4888-A71A-2C5473CCCEC1'"
         operations: "(aggregate mean (metric (notexists mean) (foobar mean)))"
-      status: 400
+      status: 404
       response_json_paths:
-        $.code: 400
+        $.code: 404
         $.description.cause: "Metrics not found"
         $.description.detail.`sorted`:
           - foobar

--- a/releasenotes/notes/aggregates-no-metric-9be5a8894bad09ee.yaml
+++ b/releasenotes/notes/aggregates-no-metric-9be5a8894bad09ee.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    The Dynamic Aggregates API now returns a 404 response when metrics are
+    not found rather than a 400 response.  This allows differentiation between
+    an invalid request to the API vs a lack of metric data due to resources
+    not yet being present and is inline with the deprecated metric aggregate
+    API behaviour.


### PR DESCRIPTION
Return a 404 (metric not found) rather than 400 (bad request) when
metrics associated with a dynamic aggregate are not found.