### PR TITLE
setuptools: Disable auto discovery

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,4 +37,5 @@ setuptools.setup(
     # Remove any local stuff to mimic pbr
     use_scm_version={'local_scheme': lambda v: ""},
     cmdclass=cmdclass,
+    py_modules=[],
 )


### PR DESCRIPTION
The latest release of setuptools 61.0 made a breaking change[1] and
because of this change 'pip install' fails with the following error.

~~
error: Multiple top-level packages discovered in a flat-layout:
['lib', 'spec', 'manifests', 'releasenotes'].
~~

Users that don't set 'packages', 'py_modules', or configuration'
are still likely to observe the auto-discovery behavior, which may
halt the build if the project contains multiple directories and/or
multiple Python files directly under the project root.

To disable auto discovery, one can do below in setup.py

~~
setuptools.setup(..,packages=[],..)
~~

or

~~
setuptools.setup(..,py_modules=[],..)
~~

[1] https://github.com/pypa/setuptools/issues/3197