### PR TITLE
DNM: Test setting SQLALCHEMY_WARN_20

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ skip_install = True
 sitepackages = True
 passenv = LANG GNOCCHI_TEST_* AWS_*
 setenv =
+    SQLALCHEMY_WARN_20=1
     GNOCCHI_TEST_STORAGE_DRIVER=file
     GNOCCHI_TEST_INDEXER_DRIVER=postgresql
     GNOCCHI_TEST_STORAGE_DRIVERS=file swift ceph s3 redis


### PR DESCRIPTION
To see if we are missing anything if SQLAlchemy 2.0
arrives.