### PR TITLE
Pin protobuf<4.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -78,7 +78,7 @@ ceph_alternative =
     python-rados>=12.2.0 # not available on pypi
 prometheus =
     python-snappy
-    protobuf
+    protobuf<4.0.0
 amqp1:
     python-qpid-proton>=0.17.0
 doc =


### PR DESCRIPTION
The newer release requires us to regenerate the
protos from the remote.proto file.