### PR TITLE
Drop cradox

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -54,12 +54,7 @@ be created for example with:
 
 
 Gnocchi leverages some *librados* features (omap, async, operation context)
-available in the Python binding only since *python-rados* >= 12.2.0. To handle
-this, Gnocchi uses *cradox* python library which has exactly the same API but
-works with Ceph >= 0.80.0.
-
-If Ceph and python-rados are >= 12.2.0, the cradox Python library becomes
-optional but is still recommended.
+available in the Ceph Python binding only since *python-rados* >= 12.2.0.
 
 
 Configuration

--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -307,9 +307,8 @@ class TimeSerie(object):
 
     @staticmethod
     def _compress(payload):
-        # FIXME(jd) lz4 > 0.9.2 returns bytearray instead of bytes. But Cradox
-        # does not accept bytearray but only bytes, so make sure that we have a
-        # byte type returned.
+        # FIXME(jd) lz4 > 0.9.2 returns bytearray instead of bytes but we need
+        # a byte type returned.
         return memoryview(lz4.block.compress(payload)).tobytes()
 
 

--- a/gnocchi/common/ceph.py
+++ b/gnocchi/common/ceph.py
@@ -19,15 +19,10 @@ import daiquiri
 
 LOG = daiquiri.getLogger(__name__)
 
-
-for RADOS_MODULE_NAME in ('rados', 'cradox'):
-    try:
-        rados = __import__(RADOS_MODULE_NAME)
-    except ImportError:
-        pass
-    else:
-        break
-else:
+RADOS_MODULE_NAME = 'rados'
+try:
+    rados = __import__(RADOS_MODULE_NAME)
+except ImportError:
     RADOS_MODULE_NAME = None
     rados = None
 
@@ -48,12 +43,12 @@ def create_rados_connection(conf):
         options['client_mount_timeout'] = conf.ceph_timeout
 
     if not rados:
-        raise ImportError("No module named 'rados' nor 'cradox'")
+        raise ImportError("No module named 'rados'")
 
     if not hasattr(rados, 'OmapIterator'):
         raise ImportError("Your rados python module does not support "
-                          "omap feature. Install 'cradox' (recommended) "
-                          "or upgrade 'python-rados' >= 9.1.0 ")
+                          "omap feature. Install or upgrade "
+                          "'python-rados' >= 9.1.0 ")
 
     LOG.info("Ceph storage backend use '%s' python library",
              RADOS_MODULE_NAME)

--- a/releasenotes/notes/remove-cradox-support-aa0e5f7546484bed.yaml
+++ b/releasenotes/notes/remove-cradox-support-aa0e5f7546484bed.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    Cradox is no longer maintained or supported, please use the python rados
+    module that can be installation from your distributions package manager.

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,7 +77,7 @@ redis =
 swift =
     python-swiftclient>=3.1.0
 ceph =
-    cradox>=2.0.0
+    # No deps - need rados dist package
 ceph_alternative =
     python-rados>=12.2.0 # not available on pypi
 prometheus =


### PR DESCRIPTION
This backports three changes to drop cradox completely in the 4.3 series as it blocks adding Python 3.9 support since it depends on an older version of Cython.