### PR TITLE
Support Python 3.9

### DIFF
--- a/.github/workflows/gnocchi.yml
+++ b/.github/workflows/gnocchi.yml
@@ -109,6 +109,7 @@ jobs:
         python:
           - py36
           - py38
+          - py39
         env:
           - mysql-file
           - mysql-swift
@@ -123,6 +124,10 @@ jobs:
             python: py36
           - env: postgresql-ceph
             python: py36
+          - env: mysql-ceph
+            python: py39
+          - env: postgresql-ceph
+            python: py39
     steps:
       - uses: actions/checkout@v2
       - run: sudo chown -R 1001:1001 $GITHUB_WORKSPACE

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -18,6 +18,12 @@ queue_rules:
     - check-success=test (py38, postgresql-swift)
     - check-success=test (py38, postgresql-s3)
     - check-success=test (py38, postgresql-ceph)
+    - check-success=test (py39, mysql-file)
+    - check-success=test (py39, mysql-swift)
+    - check-success=test (py39, mysql-s3)
+    - check-success=test (py39, postgresql-file)
+    - check-success=test (py39, postgresql-swift)
+    - check-success=test (py39, postgresql-s3)
 
 pull_request_rules:
   - name: automatic merge
@@ -45,6 +51,12 @@ pull_request_rules:
     - check-success=test (py38, postgresql-swift)
     - check-success=test (py38, postgresql-s3)
     - check-success=test (py38, postgresql-ceph)
+    - check-success=test (py39, mysql-file)
+    - check-success=test (py39, mysql-swift)
+    - check-success=test (py39, mysql-s3)
+    - check-success=test (py39, postgresql-file)
+    - check-success=test (py39, postgresql-swift)
+    - check-success=test (py39, postgresql-s3)
 
   - name: automatic merge backports from Mergify
     actions:

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ description = Metric as a Service
 long_description = file: README.rst
 long_description_content_type = text/x-rst
 author = Gnocchi developers
+python_requires = >=3.6
 classifier =
     Intended Audience :: Information Technology
     Intended Audience :: System Administrators
@@ -14,8 +15,10 @@ classifier =
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Topic :: System :: Monitoring
 
 [options]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.4
-envlist = {py36,py38}-{postgresql,mysql}{,-file,-swift,-ceph,-s3},pep8
+envlist = {py36,py38,py39}-{postgresql,mysql}{,-file,-swift,-ceph,-s3},pep8
 skipsdist = True
 
 [testenv]
@@ -54,7 +54,7 @@ commands =
     {toxinidir}/run-tests.sh {posargs}
     {toxinidir}/run-func-tests.sh {posargs}
 
-[testenv:{py36,py38}-postgresql-file-upgrade-from-4.3]
+[testenv:{py36,py38,py39}-postgresql-file-upgrade-from-4.3]
 # We should always recreate since the script upgrade
 # Gnocchi we can't reuse the virtualenv
 recreate = True
@@ -69,7 +69,7 @@ deps =
   xattr!=0.9.4
 commands = {toxinidir}/run-upgrade-tests.sh postgresql-file
 
-[testenv:{py36,py38}-mysql-ceph-upgrade-from-4.3]
+[testenv:{py36,py38,py39}-mysql-ceph-upgrade-from-4.3]
 # We should always recreate since the script upgrade
 # Gnocchi we can't reuse the virtualenv
 recreate = True
@@ -89,7 +89,7 @@ basepython = python3
 deps = hacking>=0.12
 commands = flake8
 
-[testenv:{py36,py38}-cover]
+[testenv:{py36,py38,py39}-cover]
 setenv =
     {[testenv]setenv}
     PYTHON=coverage run --source gnocchi --parallel-mode


### PR DESCRIPTION
This change adds Python 3.9 to supported python versions and adds
test coverage for it. CentOS Stream 9 now uses Python 3.9 by default
so the support is required to run Gnocchi in CentOS Stream 9.

This change also adds a few metadata items to setup.cfg to enforce
usage of Python >= 3.6.

(cherry picked from commit 12e3c9262b02d931f78e1c290c7e7e025d08d08a)