### PR TITLE
Fix incomplete switch to policy.yaml

### DIFF
--- a/gnocchi/cli/api.py
+++ b/gnocchi/cli/api.py
@@ -37,7 +37,7 @@ def prepare_service(conf=None):
         conf = cfg.ConfigOpts()
 
     opts.set_defaults()
-    policy_opts.set_defaults(conf)
+    policy_opts.set_defaults(conf, 'policy.yaml')
     conf = service.prepare_service(conf=conf)
     cfg_path = conf.oslo_policy.policy_file
     if not os.path.isabs(cfg_path):

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     numpy>=1.9.0
     iso8601
     oslo.config>=3.22.0
-    oslo.policy>=3.5.0
+    oslo.policy>=3.11.0
     oslo.middleware>=3.22.0
     pytimeparse
     pecan>=0.9


### PR DESCRIPTION
Commit 0d610f6dcdfa4cb95e6832aff5054da247052a10 was supposed to switch
default policy file from policy.json to policy.yaml but that change
was incomplete and still the old policy.json is searched first.

This change fixes it and ensures policy.yaml is loaded first.