### PR TITLE
Revert unnecessary bump of oslo.policy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     numpy>=1.9.0
     iso8601
     oslo.config>=3.22.0
-    oslo.policy>=3.11.0
+    oslo.policy>=3.5.0
     oslo.middleware>=3.22.0
     pytimeparse
     pecan>=0.9


### PR DESCRIPTION
This partially reverts 87ef6cd26e0bb0e60ce680057f4f4380d3da7e67 and
reverts the change of minimum version of oslo.policy. The change
depends on the interface available in older versions and that bump
was not really necessary.