### PR TITLE
Revert unnecessary bump of oslo.policy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     numpy>=1.9.0
     iso8601
     oslo.config>=3.22.0
-    oslo.policy>=3.11.0
+    oslo.policy>=1.7.0
     oslo.middleware>=3.22.0
     pytimeparse
     pecan>=0.9


### PR DESCRIPTION
This is peuso-cherry-pick of f09b88cf27ecf8ea1f0d316fb5d0113366afb102 .
This change partially reverts a53fcfc3ab60be6e223712d46e050e8740f16c23
and reverts the change of minimum versio nof oslo.policy. The change
depends on the interface available in older versions and that bump
was not really necessary.