### PR TITLE
Concurrency issues when multiple patches happen for the same resources

### DIFF
--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -1073,16 +1073,11 @@ class ResourceController(rest.RestController):
             etag_set_headers(resource)
             return resource
 
-        for k, v in six.iteritems(body):
-            if k != 'metrics' and getattr(resource, k) != v:
-                create_revision = True
-                break
-        else:
-            if 'metrics' not in body:
-                # No need to go further, we assume the db resource
-                # doesn't change between the get and update
-                return resource
-            create_revision = False
+        create_revision = utils.is_resource_revision_needed(resource, body)
+        if not create_revision and 'metrics' not in body:
+            # No need to go further, we assume the db resource
+            # doesn't change between the get and update
+            return resource
 
         try:
             resource = pecan.request.indexer.update_resource(

--- a/gnocchi/utils.py
+++ b/gnocchi/utils.py
@@ -351,3 +351,18 @@ class _retry_on_exception_and_log(tenacity.retry_if_exception_type):
 def retry_on_exception_and_log(msg):
     return tenacity.Retrying(
         wait=wait_exponential, retry=_retry_on_exception_and_log(msg)).wraps
+
+
+def is_resource_revision_needed(resource, request_attributes):
+    for k, v in six.iteritems(request_attributes):
+        if not hasattr(resource, k):
+            continue
+
+        database_attribute = getattr(resource, k)
+        if k != 'metrics' and database_attribute != v:
+            LOG.debug("Generating a new revision for resource [%s] "
+                      "because the attribute key [%s] with its value [%s] "
+                      "is different from the one found in the database [%s]"
+                      ".", resource, k, v, database_attribute)
+            return True
+    return False


### PR DESCRIPTION
An issue was found when Ceilometer notification is stopped, and samples accumulate in the RabbitMQ. These samples might contain the same set of attributes that would trigger one revision. However, due to a concurrency issue, when Ceilometer notification is started back again, all of them are processed in almost the same moment, and then pushed back to Gnocchi API. Then, in Gnocchi API the detection to see if the resource needs a revision is executed outside of a semaphore control (e.g. read/write transaction with the DB with a table being locked). Therefore, the code detects that a revision is needed, and generated multiple revisions, which have the same content but different revision start and end.

This patches aims to resolve that situation. The solution adopted is to check again in the transaction (when the lock was acquired), before the revision is created, if the revision is really needed. It it is not needed, a log entry is generated and we stop the processing by returnign the resource data.