### PR TITLE
Fix `passenv` declaration in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,10 @@ skipsdist = True
 [testenv]
 skip_install = True
 sitepackages = True
-passenv = LANG GNOCCHI_TEST_* AWS_*
+passenv =
+    LANG
+    GNOCCHI_TEST_*
+    AWS_*
 setenv =
     GNOCCHI_TEST_STORAGE_DRIVER=file
     GNOCCHI_TEST_INDEXER_DRIVER=postgresql


### PR DESCRIPTION
While running the tests locally with the latest tox I was getting the following error message:
```
pep8: failed with pass_env values cannot contain whitespace, use comma to have multiple values in a single line, invalid values found 'LANG GNOCCHI_TEST_* AWS_*'
  pep8: FAIL code 1 (0.00 seconds)
  evaluation failed :( (0.09 seconds)

```

That error is happening because of the passenv declaration. This patch is proposing a fix for that.