### PR TITLE
deps: set numpy>=1.14.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ packages =
 include_package_data = true
 
 install_requires =
-    numpy>=1.9.0
+    numpy>=1.14.0
     iso8601
     oslo.config>=3.22.0
     oslo.policy>=3.5.0


### PR DESCRIPTION
The copy kwarg on astype() was not introduced until 1.14.0 and we are using that in multiple places.