### PR TITLE
Adjust metric not found exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ cover
 .coverage
 dist
 upgrade/
+
+# Ignore the IDE files
+.idea

--- a/gnocchi/indexer/__init__.py
+++ b/gnocchi/indexer/__init__.py
@@ -135,7 +135,7 @@ class NoSuchMetric(IndexerException):
 
     def jsonify(self):
         return {
-            "cause": "Metrics not found",
+            "cause": "Metric not found",
             "detail": self.metric,
         }
 

--- a/gnocchi/rest/aggregates/api.py
+++ b/gnocchi/rest/aggregates/api.py
@@ -507,7 +507,7 @@ class AggregatesController(rest.RestController):
                         references, resources, start, stop, groupby)
 
             except indexer.NoSuchMetric as e:
-                api.abort(404, e)
+                api.abort(404, six.text_type(e))
             except indexer.IndexerException as e:
                 api.abort(400, six.text_type(e))
             except Exception as e:
@@ -515,9 +515,10 @@ class AggregatesController(rest.RestController):
                 raise e
 
             if not results:
-                api.abort(
-                    404,
-                    indexer.NoSuchMetric(set((m for (m, a) in references))))
+                all_metrics_not_found = list(set((m for (m, a) in references)))
+                all_metrics_not_found.sort()
+                api.abort(404, six.text_type(
+                    indexer.NoSuchMetric(all_metrics_not_found)))
             return results
 
         else:
@@ -603,7 +604,10 @@ class AggregatesController(rest.RestController):
             ])
 
         if not references:
-            raise indexer.NoSuchMetric(set((m for (m, a) in metric_wildcards)))
+            all_metrics_not_found = list(
+                set((m for (m, a) in metric_wildcards)))
+            all_metrics_not_found.sort()
+            raise indexer.NoSuchMetric(all_metrics_not_found)
 
         response = {
             "measures": get_measures_or_abort(

--- a/gnocchi/tests/functional/gabbits/aggregates-with-resources.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregates-with-resources.yaml
@@ -487,10 +487,7 @@ tests:
       status: 404
       response_json_paths:
         $.code: 404
-        $.description.cause: "Metrics not found"
-        $.description.detail.`sorted`:
-          - foobar
-          - notexists
+        $.description: "Metric ['foobar', 'notexists'] does not exist"
 
     - name: not matching metrics in any group
       POST: /v1/aggregates?groupby=id
@@ -505,10 +502,7 @@ tests:
       status: 404
       response_json_paths:
         $.code: 404
-        $.description.cause: "Metrics not found"
-        $.description.detail.`sorted`:
-          - foobar
-          - notexists
+        $.description: "Metric ['foobar', 'notexists'] does not exist"
 
     - name: invalid groupby attribute
       POST: /v1/aggregates?groupby=unit


### PR DESCRIPTION
Following the discussion on [1], Gnocchi was not properly handling the metric not found exceptions, which in turn causes a problem with Gnocchi client.

The exceptions were being rendered as a JSON, and not a string inside the description field. This PR fixes that.
The problem seems to have been caused by: https://github.com/gnocchixyz/gnocchi/commit/455c1b9b60942230028a6012a674c83816afd6ef

P.S. There are some other situations that the response is a JSON inside the description attribute. I would prefer as is and fix the issue in the Client. However, I see that this would break the backward compatibility.

[1] https://github.com/gnocchixyz/python-gnocchiclient/pull/133#discussion_r1084311700