### PR TITLE
Fix issue with None value attributes

### DIFF
--- a/gnocchi/rest/aggregates/api.py
+++ b/gnocchi/rest/aggregates/api.py
@@ -316,7 +316,7 @@ class Grouper(object):
         for value in to_group:
             self.truncate_resource_time_window(value, is_first=is_first)
             is_first = False
-        to_group.sort(key=lambda x: tuple((attr, x[attr])
+        to_group.sort(key=lambda x: tuple((attr, str(x[attr] or ''))
                                           for attr in self.groups))
         grouped_values = \
             itertools.groupby(

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,13 +58,13 @@ keystone =
 mysql =
     pymysql
     oslo.db>=4.29.0
-    sqlalchemy
+    sqlalchemy<2
     sqlalchemy-utils
     alembic>=0.7.6,!=0.8.1,!=0.9.0
 postgresql =
     psycopg2
     oslo.db>=4.29.0
-    sqlalchemy
+    sqlalchemy<2
     sqlalchemy-utils
     alembic>=0.7.6,!=0.8.1,!=0.9.0
 s3 =


### PR DESCRIPTION
With Python 3, the ``sort`` function is not handling `None` values. Therefore, when we handle resources with values as ``None`` an exception happens. This patch fixes such situations.