### PR TITLE
Pin down SQL Alchemy to <2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,13 +61,13 @@ keystone =
 mysql =
     pymysql
     oslo.db>=4.29.0
-    sqlalchemy
+    sqlalchemy<2
     sqlalchemy-utils
     alembic>=0.7.6,!=0.8.1,!=0.9.0
 postgresql =
     psycopg2
     oslo.db>=4.29.0
-    sqlalchemy
+    sqlalchemy<2
     sqlalchemy-utils
     alembic>=0.7.6,!=0.8.1,!=0.9.0
 s3 =


### PR DESCRIPTION
Version 2 of SQL Alchemy has been released, and it brings considerable changes to it [1]. The one that is affecting us right away is the philosophy of always using a transaction. That means, for every connection open with the database (DB), there is automatically a transaction opened. This, in turn, breaks the current code structure that we have, where we try to open a transaction every time we get a connection to write or read in the DB. The break happens because the code is trying to open a transaction inside an already existing one (the transaction opened by SQL Alchemy itself).

This whole situation only happens with SQL Alchemy >=2. Therefore, for now, the solution is to pin down its (SQL Alchemy) version until we have a final solution, which is going to have a considerable impact in the transaction management that we currently have.

[1] https://pypi.org/project/SQLAlchemy/2.0.0/