### PR TITLE
Add oslo.policy.enforcer entry point

### DIFF
--- a/gnocchi/rest/app.py
+++ b/gnocchi/rest/app.py
@@ -21,7 +21,6 @@ import uuid
 
 import daiquiri
 from oslo_middleware import cors
-from oslo_policy import policy
 from paste import deploy
 import pecan
 from pecan import jsonify
@@ -52,8 +51,7 @@ class GnocchiHook(pecan.hooks.PecanHook):
     def __init__(self, conf):
         self.backends = {}
         self.conf = conf
-        self.policy_enforcer = policy.Enforcer(conf)
-        self.policy_enforcer.register_defaults(policies.list_rules())
+        self.policy_enforcer = policies.init(conf)
         self.auth_helper = driver.DriverManager("gnocchi.rest.auth_helper",
                                                 conf.api.auth_mode,
                                                 invoke_on_load=True).driver

--- a/gnocchi/rest/policies.py
+++ b/gnocchi/rest/policies.py
@@ -13,6 +13,7 @@
 #    under the License.
 
 
+from oslo_config import cfg
 from oslo_policy import policy
 
 ADMIN = "role:admin"
@@ -412,3 +413,16 @@ def list_rules():
         + resource_rules + resource_type_rules \
         + archive_policy_rules + archive_policy_rule_rules \
         + metric_rules + measure_rules
+
+
+def init(conf):
+    policy_enforcer = policy.Enforcer(conf)
+    policy_enforcer.register_defaults(list_rules())
+    return policy_enforcer
+
+
+def get_enforcer():
+    # This method is used by oslopolicy CLI scripts in order to generate policy
+    # files from overrides on disk and defaults in code.
+    cfg.CONF([], project='gnocchi')
+    return init(cfg.CONF)

--- a/setup.cfg
+++ b/setup.cfg
@@ -160,6 +160,9 @@ oslo.config.opts.defaults =
 oslo.policy.policies =
     gnocchi = gnocchi.rest.policies:list_rules
 
+oslo.policy.enforcer =
+    gnocchi = gnocchi.rest.policies:get_enforcer
+
 [build_sphinx]
 all_files = 1
 build-dir = doc/build


### PR DESCRIPTION
this will allow various oslo.policy scripts like
`oslopolicy-policy-generator` to work with Gnocchi.

Fixes: #1291