### PR TITLE
Allow using specific CA certificates file

### DIFF
--- a/gnocchi/common/redis.py
+++ b/gnocchi/common/redis.py
@@ -43,6 +43,7 @@ CLIENT_ARGS = frozenset([
     'ssl',
     'ssl_certfile',
     'ssl_keyfile',
+    'ssl_ca_certs',
     'sentinel',
     'sentinel_fallback',
 ])

--- a/releasenotes/notes/redis-ssl_ca_certs-c4908e78360a31fb.yaml
+++ b/releasenotes/notes/redis-ssl_ca_certs-c4908e78360a31fb.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Now the ``redis_url`` parameter supports the ``ssl_ca_certs`` query
+    parameter which can be used to customize path to CA certificates file.


### PR DESCRIPTION
This change allows configuring ssl_ca_certs argument of redis client using the query parameter, so that users can use a specific CA certificates file instead of system global repository.