### PR TITLE
Accept float values for socket_timeout

### DIFF
--- a/gnocchi/common/redis.py
+++ b/gnocchi/common/redis.py
@@ -65,6 +65,10 @@ CLIENT_INT_ARGS = frozenset([
     'db',
     'health_check_interval',
     'socket_keepalive',
+])
+
+#: Client arguments that are expected to be float convertible.
+CLIENT_FLOAT_ARGS = frozenset([
     'socket_timeout',
 ])
 
@@ -137,6 +141,8 @@ def get_client(conf, scripts=None):
             v = options[a]
         elif a in CLIENT_INT_ARGS:
             v = int(options[a][-1])
+        elif a in CLIENT_FLOAT_ARGS:
+            v = float(options[a][-1])
         else:
             v = options[a][-1]
         kwargs[a] = v


### PR DESCRIPTION
The socket_timeout argument of redis client supports not only integers
but also floats. This allows users to pass float values[1].

[1] https://github.com/redis/redis-py/blob/1b2f408259/redis/connection.py#L1206