### PR TITLE
redis_url should be secret

### DIFF
--- a/gnocchi/common/redis.py
+++ b/gnocchi/common/redis.py
@@ -70,6 +70,7 @@ CLIENT_INT_ARGS = frozenset([
 
 OPTS = [
     cfg.StrOpt('redis_url',
+               secret=True,
                default='redis://localhost:6379/',
                help="""Redis URL
 


### PR DESCRIPTION
The redis_url option can contain password string in case authentication is enabled in Redis, thus its value should be hidden in log output.