### PR TITLE
Fix gnocchi build with latest setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,13 @@ classifier =
 [options]
 packages =
     gnocchi
+    gnocchi.cli
+    gnocchi.common
+    gnocchi.incoming
+    gnocchi.indexer
+    gnocchi.rest
+    gnocchi.storage
+    gnocchi.tests 
 
 include_package_data = true
 

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ else:
 
 # Can't use six in this file it's too early in the bootstrap process
 PY3 = sys.version_info >= (3,)
+SETUPTOOLS_VER = setuptools.__version__
 
 
 class local_install_scripts(install_scripts.install_scripts):
@@ -63,7 +64,10 @@ class local_install_scripts(install_scripts.install_scripts):
         # replaced by the correct interpreter. We do the same here.
         bs_cmd = self.get_finalized_command('build_scripts')
         executable = getattr(bs_cmd, 'executable', easy_install.sys_executable)
-        script = easy_install.get_script_header("", executable) + SCRIPT_TMPL
+        if not SETUPTOOLS_VER.startswith('68'):
+            script = easy_install.get_script_header("", executable) + SCRIPT_TMPL
+        else:
+            script = easy_install.ScriptWriter.get_header("", executable) + SCRIPT_TMPL
         if PY3:
             script = script.encode('ascii')
         self.write_script("gnocchi-api", script, 'b')
@@ -74,7 +78,10 @@ class local_develop(develop.develop):
         develop.develop.install_wrapper_scripts(self, dist)
         if self.exclude_scripts:
             return
-        script = easy_install.get_script_header("") + SCRIPT_TMPL
+        if not SETUPTOOLS_VER.startswith('68'):
+            script = easy_install.get_script_header("") + SCRIPT_TMPL
+        else:
+            script = easy_install.ScriptWriter.get_header("") + SCRIPT_TMPL
         if PY3:
             script = script.encode('ascii')
         self.write_script("gnocchi-api", script, 'b')


### PR DESCRIPTION
Setuptools removed deprecated APIs in easy_install: get_script_args, get_script_header and get_writer. The direct usage of easy_install has been deprecated since v58.3.0, and the warnings regarding these APIs predate that version.

This patch fix this issue by replacing direct easy_install call easy_install.get_script_header() with
easy_install.ScriptWriter.get_header().

Build error:

AttributeError: module 'setuptools.command.easy_install' has no attribute 'get_script_header'

Fixes gnocchixyz/gnocchi#1304