### PR TITLE
Optimize Gnocchi aggregates API

### DIFF
--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -838,19 +838,13 @@ changed from `1` to `2` after `2015`.
 {{ scenarios['get-aggregates-by-attributes-lookup-groupby-without-history']['doc'] }}
 
 Between the measurements from `2015` and `2099`, the `flavor_id` was changed
-from `1` to `2`, but in the response, the `flavor_id` is as if it was always
-`2`. In these cases, if you want to get all the attributes' values over the
-time window, and group each measurement by the attribute value the resource
-has when the measurement was collected, you can add the `use_history=true`
-in the aggregates API request, like the following example.
+from `1` to `2`, but in the response, it is always `2`. In these cases, if you
+want to get all the attributes' values over the time window, and group each
+measurement by the attribute value the resource has when the measurement was
+collected, you can add the `use_history=true` in the aggregates API request,
+like the following example.
 
 {{ scenarios['get-aggregates-by-attributes-lookup-groupby-with-history']['doc'] }}
-
-When using the `use_history`, the re-agggregation process will not
-work as expected, as the values in the timespan that represents the
-granularity being consulted are added together. Therefore, if one
-wants to use the re-aggregation process, he/she needs to consider
-using the `use_history` option as `False`.
 
 List of supported <operations>
 ------------------------------

--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -838,13 +838,19 @@ changed from `1` to `2` after `2015`.
 {{ scenarios['get-aggregates-by-attributes-lookup-groupby-without-history']['doc'] }}
 
 Between the measurements from `2015` and `2099`, the `flavor_id` was changed
-from `1` to `2`, but in the response, it is always `2`. In these cases, if you
-want to get all the attributes' values over the time window, and group each
-measurement by the attribute value the resource has when the measurement was
-collected, you can add the `use_history=true` in the aggregates API request,
-like the following example.
+from `1` to `2`, but in the response, the `flavor_id` is as if it was always
+`2`. In these cases, if you want to get all the attributes' values over the
+time window, and group each measurement by the attribute value the resource
+has when the measurement was collected, you can add the `use_history=true`
+in the aggregates API request, like the following example.
 
 {{ scenarios['get-aggregates-by-attributes-lookup-groupby-with-history']['doc'] }}
+
+When using the `use_history`, the re-agggregation process will not
+work as expected, as the values in the timespan that represents the
+granularity being consulted are added together. Therefore, if one
+wants to use the re-aggregation process, he/she needs to consider
+using the `use_history` option as `False`.
 
 List of supported <operations>
 ------------------------------

--- a/doc/source/rest.yaml
+++ b/doc/source/rest.yaml
@@ -591,6 +591,7 @@
       "image_ref": "http://image",
       "host": "compute1",
       "display_name": "myvm2",
+      "started_at": "2014-10-06T14:00:02.000000",
       "server_group": "my_autoscaling_group",
       "metrics": {"cpu.util": "{{ scenarios['create-metric']['response'].json['id'] }}"}
     }
@@ -608,6 +609,7 @@
       "image_ref": "http://image",
       "host": "compute2",
       "display_name": "myvm3",
+      "started_at": "2014-10-06T14:00:02.000000",
       "server_group": "my_autoscaling_group",
       "metrics": {"cpu.util": {"archive_policy_name": "{{ scenarios['create-archive-policy']['response'].json['name'] }}"}}
     }

--- a/gnocchi/indexer/sqlalchemy.py
+++ b/gnocchi/indexer/sqlalchemy.py
@@ -1120,7 +1120,10 @@ class SQLAlchemyIndexer(indexer.IndexerDriver):
                     attribute_filters_to_use[value_index] = value_sanitized
 
         elif is_value_dict:
-            for key, value in attribute_filter:
+            all_keys = list(attribute_filter.keys())
+            for key in all_keys:
+                value = attribute_filter.get(key)
+
                 # The value is a leaf when it is not of type dict of list.
                 is_value_leaf = not (isinstance(
                     value, dict) or isinstance(value, list))

--- a/gnocchi/indexer/sqlalchemy.py
+++ b/gnocchi/indexer/sqlalchemy.py
@@ -1120,10 +1120,7 @@ class SQLAlchemyIndexer(indexer.IndexerDriver):
                     attribute_filters_to_use[value_index] = value_sanitized
 
         elif is_value_dict:
-            all_keys = list(attribute_filter.keys())
-            for key in all_keys:
-                value = attribute_filter.get(key)
-
+            for key, value in attribute_filter:
                 # The value is a leaf when it is not of type dict of list.
                 is_value_leaf = not (isinstance(
                     value, dict) or isinstance(value, list))

--- a/gnocchi/rest/aggregates/api.py
+++ b/gnocchi/rest/aggregates/api.py
@@ -211,18 +211,21 @@ class MeasureGroup(object):
         self.measures.append(measure)
 
     def join_sequential_groups(self, group):
-        group.sort(key=lambda key: key['revision_start'])
+        group.sort(key=lambda key: key['search_start'])
         new_group = []
         last_it = None
         for it in group:
-            if last_it and it['revision_start'] == last_it['revision_end']:
-                last_it['revision_end'] = it['revision_end']
+            if last_it and it['search_start'] == last_it['search_start']:
+                last_it['search_en'] = it['search_en']
                 continue
 
             last_it = it
             new_group.append(it)
 
         return new_group
+
+    def __str__(self):
+        return "Group keys [%s]." % self.group_key
 
     def sum_groups_same_time_values(self):
         to_remove = []
@@ -303,10 +306,17 @@ class Grouper(object):
 
     def get_grouped_measures(self):
         resources = self.retrieve_resources_history()
-        self.grouped_response = self.get_measures(self.group(resources))
+        groups_to_process_metrics = self.group(resources)
+        LOG.debug("Groups [%s] to process metrics of resources [%s].",
+                  groups_to_process_metrics, resources)
+
+        self.grouped_response = self.get_measures(groups_to_process_metrics)
+        LOG.debug("Response grouped [%s] for resources [%s].",
+                  self.grouped_response, resources)
+
         response = self.format_response()
-        LOG.debug("[ Resources History: %s ]", resources)
-        LOG.debug("[ Response: %s ]", response)
+        LOG.debug("Response to be used after group by process and formatting: "
+                  "[%s]", response)
         return response
 
     def group(self, to_group):
@@ -332,30 +342,38 @@ class Grouper(object):
         return grouped
 
     def truncate_resource_time_window(self, value, is_first=False):
+        LOG.debug("Truncating timewindow for object [%s] is_first [%s].",
+                  value, is_first)
+
+        value['search_start'] = value['revision_start']
+        value['search_end'] = value['revision_end']
+
         if is_first:
-            value['revision_start'] = self.start
+            value['search_start'] = self.start
         elif self.start:
-            if value['revision_start']:
-                revision_start = numpy.datetime64(value['revision_start'])
-                value['revision_start'] = max(revision_start, self.start)
+            if value['search_start']:
+                search_start = numpy.datetime64(value['search_start'])
+                value['search_start'] = max(search_start, self.start)
             else:
-                value['revision_start'] = self.start
+                value['search_start'] = self.start
 
         if self.end:
-            if value['revision_end']:
-                revision_end = numpy.datetime64(value['revision_end'])
-                value['revision_end'] = min(revision_end, self.end)
+            if value['search_end']:
+                search_end = numpy.datetime64(value['search_end'])
+                value['search_end'] = min(search_end, self.end)
             else:
-                value['revision_end'] = self.end
+                value['search_end'] = self.end
+
+        LOG.debug("Timewindow of object [%s] after truncating.", value)
 
     def get_measures(self, groups):
         for group in groups:
             date_map = self.get_date_map(group)
             for resource in group.resources:
-                start = numpy.datetime64(resource['revision_start']) \
-                    if resource['revision_start'] else None
-                stop = numpy.datetime64(resource['revision_end']) \
-                    if resource['revision_end'] else None
+                start = numpy.datetime64(resource['search_start']) \
+                    if resource['search_start'] else None
+                stop = numpy.datetime64(resource['search_end']) \
+                    if resource['search_end'] else None
 
                 LOG.debug("[ Collecting measures from %s to %s ]",
                           start, stop)
@@ -365,9 +383,26 @@ class Grouper(object):
                         [resource], self.references, self.body["operations"],
                         start, stop, self.granularity, self.needed_overlap,
                         self.fill, details=self.details)
+
+                    LOG.debug(
+                        "[%s] measure found for resource [%s], operations "
+                        "[%s], start [%s], stop [%s], granularity [%s], "
+                        "need_overlap [%s], fill [%s], details [%s], and "
+                        "references [%s].", measure, resource,
+                        self.body["operations"], start, stop, self.granularity,
+                        self.needed_overlap, self.fill, self.details,
+                        self.references)
+
                     group.add_measures(measure, date_map, start, stop,
                                        self.details)
-                except indexer.NoSuchMetric:
+                except indexer.NoSuchMetric as e:
+                    LOG.debug("No measure found for resource [%s], operations "
+                              "[%s], start [%s], stop [%s], granularity [%s], "
+                              "need_overlap [%s], fill [%s], details [%s], "
+                              "and references [%s]. Error: [%s].", resource,
+                              self.body["operations"], start, stop,
+                              self.granularity, self.needed_overlap,
+                              self.fill, self.details, self.references, e)
                     continue
 
         self.truncate_measures()
@@ -375,10 +410,29 @@ class Grouper(object):
         return groups
 
     def get_date_map(self, group):
-        if 'id' in group.group_key:
-            return self.measures_date_map.setdefault(group.group_key['id'], {})
+        """This method returns the map used to control the groupby elements.
+
+        If the entry does not exist, an empty map is returned. The rest of the
+        code handles/works by adding entries to the map returned by this method
+        """
+        data_map_key = ""
+        all_keys = list(group.group_key.keys())
+        if not all_keys:
+            LOG.error("A group without keys for [%s] should not be possible.",
+                      group)
 
         return self.measures_date_map
+        all_keys.sort()
+        for key in all_keys:
+            data_map_key += "%s=%s," % (key, group.group_key[key])
+
+        data_map_key = data_map_key[0:len(data_map_key) - 1]
+
+        date_map_to_return = self.measures_date_map.setdefault(data_map_key, {})
+        LOG.debug("Date map [%s] found for key [%s].",
+                  date_map_to_return, data_map_key)
+
+        return date_map_to_return
 
     def sum_sequential_group_metrics(self, groups):
         for group in groups:
@@ -394,16 +448,14 @@ class Grouper(object):
                 self.truncate_measure(measure)
 
     def truncate_measure(self, measures_list):
-        if measures_list and len(measures_list) == 1:
+        if not measures_list:
             return
-        measures_sum = 0
-        for measure in measures_list[:-1]:
-            measure_new_val = (measure.value *
-                               measure.usage_coefficient)
-            measures_sum += measure_new_val
+
+        for measure in measures_list:
+            measure_new_val = (measure.value * measure.usage_coefficient)
+            LOG.debug('Trucating measure [%s] value to [%s].',
+                      measure.__dict__, measure_new_val)
             measure.value = measure_new_val
-        last_measure = measures_list[-1]
-        last_measure.value = abs(measures_sum - last_measure.value)
 
     def format_response(self):
         measures_list = []
@@ -422,6 +474,9 @@ class Grouper(object):
 
             if aggregated:
                 measures_list.append(measures)
+            else:
+                LOG.debug("No measure found in measures [%s] of group [%s].",
+                          group.measures, group)
 
         return measures_list
 
@@ -457,6 +512,12 @@ class AggregatesController(rest.RestController):
         start, stop, granularity, needed_overlap, fill = api.validate_qs(
             start, stop, granularity, needed_overlap, fill)
 
+        if start:
+            start = numpy.datetime64(start)
+
+        if stop:
+            stop = numpy.datetime64(stop)
+
         body = api.deserialize_and_validate(self.FetchSchema)
 
         references = extract_references(body["operations"])
@@ -467,6 +528,61 @@ class AggregatesController(rest.RestController):
 
         if "resource_type" in body:
             attr_filter = body["search"]
+
+            time_range_filters = []
+
+            # When we apply the filters in the query, we need to bear in mind
+            # that for the queries where use_history=False, we do not have the
+            # revision_end as we do not care about revisions.
+            # The revision_start exists in the resource history. Therefore,
+            # we can leave its use there as well, with use_history=True or not.
+            if stop:
+                # We use the stop filter as the start value, since we want
+                # everything that started until the end of the time range.
+                time_range_filters.append({"or": [
+                    {"<": {'started_at': stop}},
+                    {"<": {'revision_start': stop}}
+                ]})
+
+            if start:
+                # We want all elements/resources that exist after the start of
+                # the time range or that were deleted after the start of the
+                # time range.
+                time_range_filters.append(
+                    {
+                        "or": [
+                            {">=": {'ended_at': start}},
+                            {"=": {'ended_at': None}},
+                            {">=": {'revision_end': start}},
+                            {"=": {'revision_end': None}}
+                        ]
+                    } if use_history else {
+                        "or": [
+                            {">=": {'ended_at': start}},
+                            {"=": {'ended_at': None}},
+                        ]
+                    })
+            if not (start and stop):
+                LOG.warning("No stop and start filtering provided. Therefore, "
+                            "we will use a query that is going to manipulate "
+                            "all dataset. This can be quite costly!")
+
+            if time_range_filters:
+                if len(time_range_filters) > 1:
+                    time_range_filters = {
+                        "and": time_range_filters
+                    }
+                else:
+                    time_range_filters = time_range_filters[0]
+
+                if attr_filter:
+                    attr_filter = {"and": [time_range_filters, attr_filter]}
+                else:
+                    attr_filter = time_range_filters
+
+            LOG.debug("Filters to be used in the search query: [%s].",
+                      attr_filter)
+
             policy_filter = (
                 pecan.request.auth_helper.get_resource_policy_filter(
                     pecan.request, "search resource", body["resource_type"]))
@@ -496,6 +612,9 @@ class AggregatesController(rest.RestController):
                     results = self.get_measures_grouping_with_history(
                         attr_filter, body, details, fill, granularity, groupby,
                         needed_overlap, references, sorts, start, stop)
+
+                    LOG.debug("Response of aggregates call with history: "
+                              "[%s] for body parameters [%s].", results, body)
                 else:
                     resources = pecan.request.indexer.list_resources(
                         body["resource_type"],
@@ -504,6 +623,13 @@ class AggregatesController(rest.RestController):
                     results = self.get_measures_grouping(
                         body, details, fill, granularity, needed_overlap,
                         references, resources, start, stop, groupby)
+
+                    LOG.debug(
+                        "Resources found [%s] with query filter [%s].",
+                        [{'original_resource_id': r.original_resource_id,
+                          'started_at': r.started_at,
+                          'ended_at': r.ended_at} for r in resources or []],
+                        attr_filter)
 
             except indexer.NoSuchMetric as e:
                 api.abort(404, str(e))
@@ -567,6 +693,11 @@ class AggregatesController(rest.RestController):
 
         results = []
         for key, resources in itertools.groupby(resources, groupper):
+            resources = list(resources)
+
+            LOG.debug("Executing collection of metrics for group [%s] and "
+                      "resources [%s].", key, resources)
+
             try:
                 results.append({
                     "group": dict(key),

--- a/gnocchi/rest/aggregates/api.py
+++ b/gnocchi/rest/aggregates/api.py
@@ -426,10 +426,10 @@ class Grouper(object):
         data_map_key = ""
         all_keys = list(group.group_key.keys())
         if not all_keys:
-            LOG.error("A group without keys for [%s] should not be possible.",
+            LOG.error("A group without keys [%s] should not be possible.",
                       group)
 
-        return self.measures_date_map
+            return self.measures_date_map
         all_keys.sort()
         for key in all_keys:
             data_map_key += "%s=%s," % (key, group.group_key[key])

--- a/gnocchi/rest/aggregates/api.py
+++ b/gnocchi/rest/aggregates/api.py
@@ -216,7 +216,7 @@ class MeasureGroup(object):
         last_it = None
         for it in group:
             if last_it and it['search_start'] == last_it['search_start']:
-                last_it['search_en'] = it['search_en']
+                last_it['search_end'] = it['search_end']
                 continue
 
             last_it = it

--- a/gnocchi/rest/aggregates/api.py
+++ b/gnocchi/rest/aggregates/api.py
@@ -320,9 +320,17 @@ class Grouper(object):
         return response
 
     def group(self, to_group):
-        to_group.sort(key=lambda g: g['revision_start'])
+        to_group.sort(key=lambda g: (g['original_resource_id'],
+                                     g['revision_start']))
+
         is_first = True
+        last_processed_resource_id = None
         for value in to_group:
+            resource_id = value['original_resource_id']
+            if resource_id != last_processed_resource_id:
+                last_processed_resource_id = resource_id
+                is_first = True
+
             self.truncate_resource_time_window(value, is_first=is_first)
             is_first = False
         to_group.sort(key=lambda x: tuple((attr, str(x[attr] or ''))

--- a/gnocchi/tests/functional/gabbits/aggregation.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregation.yaml
@@ -331,6 +331,7 @@ tests:
     - name: post a resource
       POST: /v1/resource/generic
       data:
+          started_at: "2015-03-06T14:30:00.000000"
           id: bcd3441c-b5aa-4d1b-af9a-5a72322bb269
           metrics:
             agg_meter:
@@ -340,6 +341,7 @@ tests:
     - name: post another resource
       POST: /v1/resource/generic
       data:
+          started_at: "2015-03-06T14:30:00.000000"
           id: 1b0a8345-b279-4cb8-bd7a-2cb83193624f
           metrics:
             agg_meter:

--- a/gnocchi/tests/test_aggregates.py
+++ b/gnocchi/tests/test_aggregates.py
@@ -72,18 +72,21 @@ class TestGrouper(base.BaseTestCase):
 
         self.test_resource_1 = {
             'uuid': '30b51786-944f-427b-85df-ce5f462e58a4',
+            'original_resource_id': '30b51786-944f-427b-85df-ce5f462e58a4',
             'revision_start': self.start - datetime.timedelta(hours=10),
             'revision_end': self.start - datetime.timedelta(hours=9),
             "attribute1": "a", "attribute2": "a", "attribute3": "a"
         }
         self.test_resource_2 = {
             'uuid': '17002c42-2f30-45fb-b1f1-eb33f7345e89',
+            'original_resource_id': '17002c42-2f30-45fb-b1f1-eb33f7345e89',
             'revision_start': self.start - datetime.timedelta(hours=7),
             'revision_end': self.start - datetime.timedelta(hours=5),
             "attribute1": None, "attribute2": "b", "attribute3": "b"
         }
         self.test_resource_3 = {
             'uuid': '8f6be3bb-d5ee-4d01-986b-c034386637b0',
+            'original_resource_id': '8f6be3bb-d5ee-4d01-986b-c034386637b0',
             'revision_start': self.start - datetime.timedelta(hours=2),
             'revision_end': self.start - datetime.timedelta(hours=1),
             "attribute1": "c", "attribute2": None, "attribute3": None

--- a/gnocchi/tests/test_measures_grouper.py
+++ b/gnocchi/tests/test_measures_grouper.py
@@ -86,16 +86,27 @@ class TestScenario(object):
     def validate_scenario(self):
         all_groups = list(map(lambda o: o['group'], self.expected_output))
         all_response_groups = list(map(lambda r: r['group'], self.result))
-        assert all_groups == all_response_groups
+        self.execute_assert(all_groups, all_response_groups)
         for r in self.result:
             for out in self.expected_output:
                 if out['group'] == r['group']:
                     for date, val in out['measures'].items():
                         aggregated = r['measures']['measures']['aggregated']
-                        assert len(aggregated) == len(out['measures'])
+                        self.execute_assert(
+                            len(aggregated), len(out['measures']))
                         for dat, gran, value in aggregated:
                             if str(dat) == date:
-                                assert val == value
+                                message = "Expected [%s], but got [%s]. " \
+                                          "Parameters expected_output [%s] " \
+                                          "and result[%s]." % (
+                                              val, value, self.expected_output,
+                                              self.result)
+                                self.execute_assert(val, value, message)
+
+    def execute_assert(self, expected, received, message=None):
+        if not message:
+            message = "Expected [%s], but got [%s]." % (expected, received)
+        assert expected == received, message
 
     def create_test_scenario(self):
         scenario = self.test_input
@@ -337,7 +348,7 @@ class TestGroupMeasuresWithHistory(base.BaseTestCase):
             {
                 'group': {'flavor_name': '4gb-mem'},
                 'measures': {
-                    '2020-03-10T10:00:00.000000': 16.666666666666686
+                    '2020-03-10T10:00:00.000000': 16.666666666666664
                 }
             }
         ]

--- a/gnocchi/tests/test_measures_grouper.py
+++ b/gnocchi/tests/test_measures_grouper.py
@@ -33,6 +33,7 @@ class Resource(object):
         self.display_name = display_name
         self.revision_start = revision_start
         self.revision_end = None
+        self.original_resource_id = str(hash(id))
 
 
 class ResourceHistory(object):


### PR DESCRIPTION
Gnocchi aggregates API can present slowness with time, due to the growing number of resources and revisions in large scale OpenStack Cloud environments. This happens due to the situation where Gnocchi does not apply filters in the MySQL queries in the resource tables. I mean, start/stop filters are not applied, and others as well, which makes Gnocchi to manipulate all dataset in the MySQL database and then the filtering is executed in Python.

To cope with that situation, we are proposing an optimization to improve the query executed by Gnocchi in MySQL, and apply the filtering right away; thus, the dataset manipulated by MySQL will be drastically reduced. After applying the patch, we noticed a reduction of 5-6 folds in the response time for the Gnocchi aggregates API.