### PR TITLE
dnm: Test broken job (readme for info)

### DIFF
--- a/.github/workflows/gnocchi.yml
+++ b/.github/workflows/gnocchi.yml
@@ -112,8 +112,6 @@ jobs:
           - py38
           - py39
         env:
-          - mysql-ceph-upgrade-from-4.4
-          - postgresql-file-upgrade-from-4.4
           - mysql-file
           - mysql-swift
           - mysql-s3
@@ -123,14 +121,10 @@ jobs:
           - postgresql-s3
           - postgresql-ceph
         exclude:
-          - env: mysql-ceph-upgrade-from-4.4
-            python: py36
           - env: mysql-ceph
             python: py36
           - env: postgresql-ceph
             python: py36
-          - env: mysql-ceph-upgrade-from-4.4
-            python: py39
           - env: mysql-ceph
             python: py39
           - env: postgresql-ceph

--- a/images/Dockerfile.ci
+++ b/images/Dockerfile.ci
@@ -37,8 +37,19 @@ RUN apt-get update -y && apt-get install -qy \
         libsnappy-dev \
         libprotobuf-dev \
 # For redis
-        redis-server \
-        && rm -rf /var/lib/apt/lists/*
+        redis-server
+
+# TODO(tobias-urdin): Downgrade MySQL to a version that works. Report this
+# bug to Ubuntu packaging.
+ENV MYSQL_VERSION=8.0.19-0ubuntu5
+RUN apt-get install -qy --allow-downgrades mysql-client=$MYSQL_VERSION \
+        mysql-client-8.0=$MYSQL_VERSION \
+        mysql-server=$MYSQL_VERSION \
+        mysql-server-8.0=$MYSQL_VERSION \
+        mysql-client-core-8.0=$MYSQL_VERSION \
+        mysql-server-core-8.0=$MYSQL_VERSION
+
+RUN rm -rf /var/lib/apt/lists/*
 
 #NOTE(sileht): really no utf-8 in 2017 !?
 ENV LANG en_US.UTF-8

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     Paste
     PasteDeploy
     daiquiri
-    pyparsing>=2.2.0
+    pyparsing>=2.2.0,<3.1.0
     lz4>=0.9.0
     tooz>=1.38
     cachetools

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,8 @@ class local_install_scripts(install_scripts.install_scripts):
         # replaced by the correct interpreter. We do the same here.
         bs_cmd = self.get_finalized_command('build_scripts')
         executable = getattr(bs_cmd, 'executable', easy_install.sys_executable)
-        script = easy_install.get_script_header("", executable) + SCRIPT_TMPL
+        script = easy_install.ScriptWriter.get_header(
+            "", executable) + SCRIPT_TMPL
         if PY3:
             script = script.encode('ascii')
         self.write_script("gnocchi-api", script, 'b')
@@ -74,7 +75,7 @@ class local_develop(develop.develop):
         develop.develop.install_wrapper_scripts(self, dist)
         if self.exclude_scripts:
             return
-        script = easy_install.get_script_header("") + SCRIPT_TMPL
+        script = easy_install.ScriptWriter.get_header("") + SCRIPT_TMPL
         if PY3:
             script = script.encode('ascii')
         self.write_script("gnocchi-api", script, 'b')

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,6 @@ setenv =
 # coordination driver in functional tests (--coordination-driver is passed to
 # pifpaf)
 deps =
-   -e
    .[test,redis,prometheus,amqp1,{env:GNOCCHI_STORAGE_DEPS:},{env:GNOCCHI_INDEXER_DEPS:}]
    {env:GNOCCHI_TEST_TARBALLS:}
    # TODO(tobias-urdin): Remove this pin and use pifpaf directly instead when this is
@@ -127,7 +126,6 @@ basepython = python3
 #        .[postgresql,doc]
 # setenv = GNOCCHI_STORAGE_DEPS=file
 deps =
-    -e
     .[test,file,postgresql,doc]
     doc8
 setenv = GNOCCHI_TEST_DEBUG=1


### PR DESCRIPTION
do not merge!

this tests the jobs excluding the upgrade jobs.

there is currently a bug somewhere in the db layer relating to sqlalchemy that makes it not returns the rows in the database when doing the select() function call for the resource history

- so it successfully inserts the db rows in the database https://github.com/gnocchixyz/gnocchi/blob/a2eea07f76091b0b00f3fc195ff3ce388c5d2b21/gnocchi/indexer/sqlalchemy.py#L948
- but the code here https://github.com/gnocchixyz/gnocchi/blob/a2eea07f76091b0b00f3fc195ff3ce388c5d2b21/gnocchi/indexer/sqlalchemy.py#L1086 does not return those history records so the gabbit tests fail

also the gnocchi code base is not yet prepared for sqlalchemy 2.0 upgrade, if anybody wants to help with that as well that's appreciated, the workflow would be:
- add a sqlalchemy 2.0 job that is not voting
- enable all warnings for sqlalchemy 2.0 changes
- work them through one by one and don't break <2.0 support