### PR TITLE
carbonara: fix __float__ warning in SplitKey

### DIFF
--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -548,7 +548,10 @@ class SplitKey(object):
         return str(float(self))
 
     def __float__(self):
-        return datetime64_to_epoch(self.key)
+        f = datetime64_to_epoch(self.key)
+        if isinstance(f, numpy.float64):
+            return f.item()
+        return f
 
     def __repr__(self):
         return "<%s: %s / %s>" % (self.__class__.__name__,


### PR DESCRIPTION
```
DeprecationWarning: SplitKey.__float__ returned non-float (type numpy.float64)
```