### PR TITLE
deps: cap sphinx<7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -88,7 +88,8 @@ amqp1:
     python-qpid-proton>=0.17.0
 doc =
     chardet<4
-    sphinx
+    # TODO(tobias-urdin): sphinx 7.0 removed support for setuptools
+    sphinx<7
     sphinx_rtd_theme
     sphinxcontrib-httpdomain
     PyYAML


### PR DESCRIPTION
the 7.0 version removed support for setuptools
with the removal of the setup_command module.