### PR TITLE
releasenote: add note about python 3.6 and 3.11

### DIFF
--- a/releasenotes/notes/py36-support-removed-6d90f20b486e8441.yaml
+++ b/releasenotes/notes/py36-support-removed-6d90f20b486e8441.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Added support for Python 3.11
+upgrade:
+  - |
+    Removed support for Python 3.6, the supported version is now
+    Python 3.8 or higher.


### PR DESCRIPTION
Python 3.6 support is removed and Python 3.11
support is added. Minimum Python version is 3.8
or higher.