### PR TITLE
Drop use of setuptools extension

### DIFF
--- a/bin/gnocchi-api
+++ b/bin/gnocchi-api
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
-# Copyright (c) 2014 eNovance
-#
+#!/usr/bin/env python3
+
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -13,19 +12,10 @@
 # implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import sys
+from gnocchi.cli import api
 
-import setuptools
-
-cmdclass = {}
-
-try:
-    from sphinx import setup_command
-    cmdclass['build_sphinx'] = setup_command.BuildDoc
-except ImportError:
-    pass
-
-
-setuptools.setup(
-    cmdclass=cmdclass,
-    py_modules=[],
-)
+if __name__ == '__main__':
+    sys.exit(api.api())
+else:
+    application = api.wsgi()

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,9 @@ packages =
 
 include_package_data = true
 
+scripts =
+    bin/gnocchi-api
+
 install_requires =
     numpy>=1.14.0
     iso8601


### PR DESCRIPTION
We were wrapping easy_install's `install_scripts` and `develop` methods to generate a custom WSGI script. This was a replacement of functionality previously provided by PBR. Unfortunately easy_install is deprecated for removal at a future date and we don't yet have a modern equivalent in pip [1]. As such, we need a migration plan for this and it seems like the old school `scripts` option is probably it. The main downside of this is that the shebang isn't updated accordingly, which means this won't work very well in virtualenvs, but I'm hoping that the use of `/usr/bin/env` will allow us to work around this. At least in local testing, it seems like this is the case:

```
❯ virtualenv .venv
❯ pip install .
❯ cat .venv/bin/gnocchi-api | head -1
#!/gnocchi/.venv/bin/python
```

**EDIT**: this also seems to work just fine with wheels:

```
❯ python -m build -w .
❯ pushd dist
❯ unzip gnocchi-*.whl
❯ cat gnocchi-*.data/scripts/gnocchi-api | head -1
#!python
❯ popd
❯ virtualenv .venv
❯ pip install dist/gnocchi-*.whl
❯ cat .venv/bin/gnocchi-api | head -1
#!/gnocchi/.venv/bin/python
```

[1] https://discuss.python.org/t/adding-support-for-wsgi-scripts-entrypoint/30905

Signed-off-by: Stephen Finucane <stephenfin@redhat.com>
