### PR TITLE
CI: Use Python 3.11 for tox

### DIFF
--- a/images/Dockerfile.ci
+++ b/images/Dockerfile.ci
@@ -60,7 +60,7 @@ RUN locale-gen $LANG
 
 #NOTE(sileht): Upgrade python dev tools
 RUN python3 -m pip install -U pip tox virtualenv
-RUN python3.6 -m pip install -U pip tox virtualenv
+RUN python3.11 -m pip install -U pip tox virtualenv
 
 RUN npm install s3rver@3.7.0 --global
 


### PR DESCRIPTION
Recent versions of tox do not support Python 3.6.
