### PR TITLE
ci: update actions to newest versions

### DIFF
--- a/.github/workflows/gnocchi-ci-image.yml
+++ b/.github/workflows/gnocchi-ci-image.yml
@@ -11,10 +11,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: docker/login-action@v1
+      - uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/gnocchi.yml
+++ b/.github/workflows/gnocchi.yml
@@ -23,7 +23,7 @@ jobs:
           - docs
           - docs-gnocchi-web
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - run: sudo chown -R 1001:1001 $GITHUB_WORKSPACE
@@ -34,7 +34,7 @@ jobs:
             ci_image:
               - 'images/Dockerfile.ci'
               - 'images/entrypoint.sh.ci'
-      - uses: docker/login-action@v1
+      - uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -68,7 +68,7 @@ jobs:
           - build
           - pep8
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: sudo chown -R 1001:1001 $GITHUB_WORKSPACE
       - uses: dorny/paths-filter@v2
         id: changes
@@ -77,7 +77,7 @@ jobs:
             ci_image:
               - 'images/Dockerfile.ci'
               - 'images/entrypoint.sh.ci'
-      - uses: docker/login-action@v1
+      - uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -137,7 +137,7 @@ jobs:
           - env: postgresql-ceph
             python: py311
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: sudo chown -R 1001:1001 $GITHUB_WORKSPACE
       - uses: dorny/paths-filter@v2
         id: changes
@@ -146,7 +146,7 @@ jobs:
             ci_image:
               - 'images/Dockerfile.ci'
               - 'images/entrypoint.sh.ci'
-      - uses: docker/login-action@v1
+      - uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
Try to silence all the warnings about node12 and
save-state being removed.