### PR TITLE
Revert "tox: use python3.9 for doc jobs"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -133,7 +133,7 @@ enable-extensions = H904
 ignore = E501,E731,W503,W504
 
 [testenv:docs]
-basepython = python3.9
+basepython = python3
 ## This does not work, see: https://github.com/tox-dev/tox/issues/509
 # deps = {[testenv]deps}
 #        .[postgresql,doc]
@@ -146,7 +146,7 @@ commands = doc8 --ignore-path doc/source/rest.rst,doc/source/comparison-table.rs
            pifpaf -g GNOCCHI_INDEXER_URL run postgresql -- python setup.py build_sphinx -W
 
 [testenv:docs-gnocchi-web]
-basepython = python3.9
+basepython = python3
 allowlist_externals =
     /bin/bash
     /bin/rm


### PR DESCRIPTION
The docs build fails because we've hardcoded this so docs is not updated.
See the build log here: https://gnocchi.osci.io/build-logs/gnocchi.log

See what we can do to rectify that, we don't know what version that runs.

This reverts commit cbf138eb4ffde968c168f3cfd8489db26a7a8dbb.