### PR TITLE
Add minimum requirement for sqlalchemy to 1.4.24

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,13 +63,13 @@ keystone =
 mysql =
     pymysql
     oslo.db>=4.29.0
-    sqlalchemy<2
+    sqlalchemy>=1.4.24,<2
     sqlalchemy-utils
     alembic>=0.7.6,!=0.8.1,!=0.9.0
 postgresql =
     psycopg2
     oslo.db>=4.29.0
-    sqlalchemy<2
+    sqlalchemy>=1.4.24,<2
     sqlalchemy-utils
     alembic>=0.7.6,!=0.8.1,!=0.9.0
 s3 =


### PR DESCRIPTION
Some of the recent sqlalchemy 2 changes used features that were added in 1.4.24 sqlalchemy (session.scalar) [1]. This change fixes the issue with gnocchi-upgrade built with wrong constraints.

1. https://docs.sqlalchemy.org/en/20/changelog/changelog_14.html#change-e619b9bd2796d7e0b948631fac5b01e9

(cherry picked from commit 680ac01512935f7c7bef3e99bd42963c949d6229)