### PR TITLE
Update code for breaking change in werkzeug

### DIFF
--- a/gnocchi/rest/auth_helper.py
+++ b/gnocchi/rest/auth_helper.py
@@ -121,7 +121,12 @@ class BasicAuthHelper(object):
         hdr = request.headers.get("Authorization")
         auth_hdr = (hdr.decode('utf-8') if isinstance(hdr, bytes)
                     else hdr)
-        auth = werkzeug.http.parse_authorization_header(auth_hdr)
+
+        try:
+            auth = werkzeug.http.parse_authorization_header(auth_hdr)
+        except AttributeError:
+            auth = werkzeug.datastructures.Authorization.from_header(auth_hdr)
+
         if auth is None:
             api.abort(401)
         return auth.username

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     stevedore
     ujson
     voluptuous>=0.8.10
-    werkzeug<3.0.0
+    werkzeug
     trollius; python_version < '3.4'
     tenacity>=5.0.0
     WebOb>=1.4.1


### PR DESCRIPTION
`parse_authorization_header` was removed here: https://github.com/pallets/werkzeug/commit/bafffa9fb597156567c1ca80042bfbc842a42284.