### PR TITLE
Pin werkzeug<3.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     stevedore
     ujson
     voluptuous>=0.8.10
-    werkzeug
+    werkzeug<3.0.0
     trollius; python_version < '3.4'
     tenacity>=5.0.0
     WebOb>=1.4.1


### PR DESCRIPTION
The http.parse_authorization_header is removed
in >=3.0.0 [1]

[1] https://github.com/pallets/werkzeug/commit/bafffa9fb597156567c1ca80042bfbc842a42284