### PR TITLE
Fix time format for datetime objects

### DIFF
--- a/gnocchi/json.py
+++ b/gnocchi/json.py
@@ -30,8 +30,7 @@ def to_primitive(obj):
     if isinstance(obj, datetime.datetime):
         return obj.isoformat()
     if isinstance(obj, numpy.datetime64):
-        # Do not include nanoseconds if null
-        return str(obj).rpartition(".000000000")[0] + "+00:00"
+        return numpy.datetime_as_string(obj, unit='s') + "+00:00"
     if isinstance(obj, numpy.timedelta64):
         return obj / numpy.timedelta64(1, 's')
     if isinstance(obj, datetime.timedelta):


### PR DESCRIPTION
The date manipulation in Gnocchi to generate the response  is quite odd, which is causing some weird outputs if the nanoseconds part of the string has some value different from .000000000; this patch is changing that to a better approach.

This was extract from https://github.com/gnocchixyz/gnocchi/pull/1307#discussion_r1330867035