### PR TITLE
Update tests error messages to be compatible with voluptuous 0.14.0

### DIFF
--- a/gnocchi/tests/functional/gabbits/search.yaml
+++ b/gnocchi/tests/functional/gabbits/search.yaml
@@ -53,7 +53,7 @@ tests:
       status: 400
       response_json_paths:
         $.description.cause: "Invalid input"
-        $.description.reason: "/^extra keys not allowed @ data/"
+        $.description.reason: "value must not be one of ['id'] @ data['like']['id']"
         $.description.detail: ["like", "id"]
 
     - name: search like list id
@@ -67,7 +67,7 @@ tests:
       status: 400
       response_json_paths:
         $.description.cause: "Invalid input"
-        $.description.reason: "/^extra keys not allowed @ data/"
+        $.description.reason: "value must not be one of ['id'] @ data['like']['id']"
         $.description.detail: ["like", "id"]
 
     - name: search invalid ne value

--- a/gnocchi/tests/test_rest.py
+++ b/gnocchi/tests/test_rest.py
@@ -1882,7 +1882,7 @@ class GenericResourceTest(RestTest):
         result_description = result.json['description']
         self.assertEqual("Invalid input", result_description['cause'])
         self.assertIn(
-            "extra keys not allowed @ data[", result_description['reason']
+            "not a valid value @ data['wrongoperator']", result_description['reason']
         )
 
 


### PR DESCRIPTION
The commit https://github.com/alecthomas/voluptuous/commit/41bc53df12c078a2fc9ea586a280605c53db5ea1, which was introduced in version 0.14.0 of voluptuous library, improves the error messages for invalid keys. 

To make Gnocchi tests compatible with this new version, we need to update some error messages validation to use the newest error messages from voluptuous parser.