### PR TITLE
Remove the use of the future module

### DIFF
--- a/gnocchi/common/redis.py
+++ b/gnocchi/common/redis.py
@@ -14,8 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from __future__ import absolute_import
-
 from oslo_config import cfg
 from urllib import parse
 

--- a/gnocchi/gendoc.py
+++ b/gnocchi/gendoc.py
@@ -14,7 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from __future__ import absolute_import
 import io
 import json
 import os

--- a/gnocchi/indexer/sqlalchemy.py
+++ b/gnocchi/indexer/sqlalchemy.py
@@ -13,7 +13,7 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from __future__ import absolute_import
+
 import datetime
 import itertools
 import operator

--- a/gnocchi/indexer/sqlalchemy_base.py
+++ b/gnocchi/indexer/sqlalchemy_base.py
@@ -14,7 +14,6 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from __future__ import absolute_import
 
 from oslo_db.sqlalchemy import models
 import sqlalchemy

--- a/gnocchi/indexer/sqlalchemy_extension.py
+++ b/gnocchi/indexer/sqlalchemy_extension.py
@@ -12,8 +12,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from __future__ import absolute_import
-
 import sqlalchemy
 import sqlalchemy_utils
 

--- a/gnocchi/indexer/sqlalchemy_types.py
+++ b/gnocchi/indexer/sqlalchemy_types.py
@@ -14,7 +14,6 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-from __future__ import absolute_import
 
 import calendar
 import datetime

--- a/gnocchi/tests/functional/fixtures.py
+++ b/gnocchi/tests/functional/fixtures.py
@@ -14,8 +14,6 @@
 # under the License.
 """Fixtures for use with gabbi tests."""
 
-from __future__ import absolute_import
-
 import logging
 import os
 import shutil

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,6 @@ install_requires =
     oslo.middleware>=3.22.0
     pytimeparse
     pecan>=0.9
-    futures; python_version < '3'
     jsonpatch
     cotyledon>=1.5.0
     stevedore


### PR DESCRIPTION
This module is buggy with Python 3.11 and 3.12, and is being actively removed from distributions (like Debian and Ubuntu). The absolute_import things are remaining of the past, in the Python 2.7 age. Let's get rid of them and remove future from setup.cfg.