### PR TITLE
redis: Fix types of some options

### DIFF
--- a/gnocchi/common/redis.py
+++ b/gnocchi/common/redis.py
@@ -55,19 +55,19 @@ CLIENT_LIST_ARGS = frozenset([
 #: Client arguments that are expected to be boolean convertible.
 CLIENT_BOOL_ARGS = frozenset([
     'retry_on_timeout',
+    'socket_keepalive',
     'ssl',
 ])
 
 #: Client arguments that are expected to be int convertible.
 CLIENT_INT_ARGS = frozenset([
     'db',
-    'health_check_interval',
-    'socket_keepalive',
 ])
 
 #: Client arguments that are expected to be float convertible.
 CLIENT_FLOAT_ARGS = frozenset([
     'socket_timeout',
+    'health_check_interval',
 ])
 
 OPTS = [


### PR DESCRIPTION
The socket_keepalive option in RedisClient is not an integer but a boolean. Also the healthcheck_interval option can accept not only integers but also float values. This fixes the types to parse these options accordingly.

Note this change still keeps support for socket_keepalive=1 or socket_keepalive=0 , but would remove support for the other integer values such as 2 or -1.