### PR TITLE
Improve documentation for aggregates API and the `use_history` option

### DIFF
--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -846,7 +846,7 @@ in the aggregates API request, like the following example.
 
 {{ scenarios['get-aggregates-by-attributes-lookup-groupby-with-history']['doc'] }}
 
-When using the `use_history`, the re-agggregation process will not
+When using the `use_history=True`, the re-agggregation process will not
 work as expected, as the values in the timespan that represents the
 granularity being consulted are added together to enable the split into
 different portions according to their participation in the timeframe being

--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -846,7 +846,7 @@ in the aggregates API request, like the following example.
 
 {{ scenarios['get-aggregates-by-attributes-lookup-groupby-with-history']['doc'] }}
 
-When using the `use_history=True`, the re-agggregation process will not
+When using the `use_history=True`, the re-aggregation process will not
 work as expected, as the values in the timespan that represents the
 granularity being consulted are added together to enable the split into
 different portions according to their participation in the timeframe being

--- a/doc/source/rest.j2
+++ b/doc/source/rest.j2
@@ -838,13 +838,20 @@ changed from `1` to `2` after `2015`.
 {{ scenarios['get-aggregates-by-attributes-lookup-groupby-without-history']['doc'] }}
 
 Between the measurements from `2015` and `2099`, the `flavor_id` was changed
-from `1` to `2`, but in the response, it is always `2`. In these cases, if you
-want to get all the attributes' values over the time window, and group each
-measurement by the attribute value the resource has when the measurement was
-collected, you can add the `use_history=true` in the aggregates API request,
-like the following example.
+from `1` to `2`, but in the response, the `flavor_id` is as if it was always
+`2`. In these cases, if you want to get all the attributes' values over the
+time window, and group each measurement by the attribute value the resource
+has when the measurement was collected, you can add the `use_history=true`
+in the aggregates API request, like the following example.
 
 {{ scenarios['get-aggregates-by-attributes-lookup-groupby-with-history']['doc'] }}
+
+When using the `use_history`, the re-agggregation process will not
+work as expected, as the values in the timespan that represents the
+granularity being consulted are added together to enable the split into
+different portions according to their participation in the timeframe being
+consulted. Therefore, if one wants to use the re-aggregation process, he/she
+needs to consider using the `use_history` option as `False`.
 
 List of supported <operations>
 ------------------------------


### PR DESCRIPTION
The `use_history` option for the aggregates API allows one to retrieve the exact attributes of a resource that were present during a given timestamp for a measurement obtained via the aggregates API. However, this API has a downside, which is the inability to execute "re-aggregations" for now. Therefore, if one needs to execute the "re-aggregation" of computed measures, she/he will need to use the aggregates API with the option `use_history` as `False`.

This patch makes that clear for the end users.