### PR TITLE
redis: Add username

### DIFF
--- a/gnocchi/common/redis.py
+++ b/gnocchi/common/redis.py
@@ -78,7 +78,7 @@ OPTS = [
 
   For example::
 
-    redis://[:password]@localhost:6379?db=0
+    redis://[username:password]@localhost:6379?db=0
 
   We proxy some options to the redis client (used to configure the redis client
   internals so that it works as you expect/want it to):  `%s`
@@ -128,6 +128,8 @@ def get_client(conf, scripts=None):
         if not parsed_url.path:
             raise ValueError("Expected socket path in parsed urls path")
         kwargs['unix_socket_path'] = parsed_url.path
+    if parsed_url.username:
+        kwargs['username'] = parsed_url.username
     if parsed_url.password:
         kwargs['password'] = parsed_url.password
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,7 +72,7 @@ s3 =
     boto3
     botocore>=1.5
 redis =
-    redis >= 3.3.0 # MIT
+    redis >= 3.4.0 # MIT
     hiredis
 swift =
     python-swiftclient>=3.1.0


### PR DESCRIPTION
Redis introduced ACL feature in 4.0.0, and this feature is supported by redis-py since 3.4.0[1]. When ACL is enabled, authentication requires username in addition to password.

[1] https://github.com/redis/redis-py/commit/8df8cd54d135380ad8b3b8807a67a3e6915b0b49