### PR TITLE
Remove unused dependency

### DIFF
--- a/gnocchi/statsd.py
+++ b/gnocchi/statsd.py
@@ -12,13 +12,10 @@
 # implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import itertools
 import uuid
 
-try:
-    import asyncio
-except ImportError:
-    import trollius as asyncio
 import daiquiri
 from oslo_config import cfg
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,6 @@ install_requires =
     ujson
     voluptuous>=0.8.10
     werkzeug
-    trollius; python_version < '3.4'
     tenacity>=5.0.0
     WebOb>=1.4.1
     Paste


### PR DESCRIPTION
The trollius library is required only in Python <= 3.4, but currently Python 3.8 is the minimum supported version.