### PR TITLE
Fix Gnocchi manager upgrade command for File

### DIFF
--- a/gnocchi/incoming/file.py
+++ b/gnocchi/incoming/file.py
@@ -35,17 +35,15 @@ class FileStorage(incoming.IncomingDriver):
         self.basepath = conf.file_basepath
         self.basepath_tmp = os.path.join(self.basepath, 'tmp')
 
-        # We need to make sure that the 'tmp' path exists; otherwise,
-        # we will have an issue when running the method "set_storage_settings"
-        # that created the temporary JSON file under the 'tmp' folder.
-        utils.ensure_paths([self.basepath_tmp])
-
     def __str__(self):
         return "%s: %s" % (self.__class__.__name__, str(self.basepath))
 
     def upgrade(self, num_sacks):
-        super(FileStorage, self).upgrade(num_sacks)
+        # We need to make sure that the 'tmp' path exists; otherwise,
+        # we will have an issue when running the method "set_storage_settings"
+        # that created the temporary JSON file under the 'tmp' folder.
         utils.ensure_paths([self.basepath_tmp])
+        super(FileStorage, self).upgrade(num_sacks)
 
     def _get_storage_sacks(self):
         with open(os.path.join(self.basepath_tmp, self.CFG_PREFIX),

--- a/gnocchi/incoming/file.py
+++ b/gnocchi/incoming/file.py
@@ -35,6 +35,11 @@ class FileStorage(incoming.IncomingDriver):
         self.basepath = conf.file_basepath
         self.basepath_tmp = os.path.join(self.basepath, 'tmp')
 
+        # We need to make sure that the 'tmp' path exists; otherwise,
+        # we will have an issue when running the method "set_storage_settings"
+        # that created the temporary JSON file under the 'tmp' folder.
+        utils.ensure_paths([self.basepath_tmp])
+
     def __str__(self):
         return "%s: %s" % (self.__class__.__name__, str(self.basepath))
 


### PR DESCRIPTION
When running the upgrade command manually, we noticed that the "tmp" folder in the "conf.file_basepath" is not created, which will lead to an error later in the execution flow.