### PR TITLE
Clean raw data metrics that do not receive measures

### DIFF
--- a/gnocchi/chef.py
+++ b/gnocchi/chef.py
@@ -17,6 +17,7 @@
 import hashlib
 
 import daiquiri
+import random
 
 from gnocchi import carbonara
 from gnocchi import indexer
@@ -80,7 +81,10 @@ class Chef(object):
 
         sack_by_metric = self.group_metrics_by_sack(metrics_to_clean)
 
-        for sack in sack_by_metric.keys():
+        # We randomize the list to reduce the chances of lock collision.
+        all_sacks = list(sack_by_metric.keys())
+        random.shuffle(all_sacks)
+        for sack in all_sacks:
             LOG.debug("Executing the raw data cleanup for sack [%s].",
                       sack)
             try:

--- a/gnocchi/cli/api.py
+++ b/gnocchi/cli/api.py
@@ -38,6 +38,7 @@ def prepare_service(conf=None):
 
     opts.set_defaults()
     policy_opts.set_defaults(conf, 'policy.yaml')
+
     conf = service.prepare_service(conf=conf)
     return conf
 

--- a/gnocchi/incoming/file.py
+++ b/gnocchi/incoming/file.py
@@ -197,9 +197,15 @@ class FileStorage(incoming.IncomingDriver):
                 sack, metric_id)
             processed_files[metric_id] = files
             m = self._make_measures_array()
+
+            count = 0
+            total_files = len(files)
             for f in files:
+                count = count + 1
                 abspath = self._build_measure_path(metric_id, f)
                 with open(abspath, "rb") as e:
+                    LOG.debug("(%s/%s) Reading metric file [%s].",
+                              count, total_files, abspath)
                     m = numpy.concatenate((
                         m, self._unserialize_measures(f, e.read())))
             measures[metric_id] = m

--- a/gnocchi/indexer/__init__.py
+++ b/gnocchi/indexer/__init__.py
@@ -74,12 +74,13 @@ class Resource(object):
 
 class Metric(object):
     def __init__(self, id, archive_policy, creator=None,
-                 name=None, resource_id=None):
+                 name=None, resource_id=None, needs_raw_data_truncation=False):
         self.id = id
         self.archive_policy = archive_policy
         self.creator = creator
         self.name = name
         self.resource_id = resource_id
+        self.needs_raw_data_truncation = needs_raw_data_truncation
 
     def __repr__(self):
         return '<%s %s>' % (self.__class__.__name__, self.id)
@@ -88,12 +89,13 @@ class Metric(object):
         return str(self.id)
 
     def __eq__(self, other):
-        return (isinstance(other, Metric)
-                and self.id == other.id
+        return (isinstance(other, Metric) and self.id == other.id
                 and self.archive_policy == other.archive_policy
                 and self.creator == other.creator
                 and self.name == other.name
-                and self.resource_id == other.resource_id)
+                and self.resource_id == other.resource_id
+                and self.needs_raw_data_truncation ==
+                other.needs_raw_data_truncation)
 
     __hash__ = object.__hash__
 
@@ -436,6 +438,15 @@ class IndexerDriver(object):
 
     @staticmethod
     def delete_metric(id):
+        raise exceptions.NotImplementedError
+
+    @staticmethod
+    def update_backwindow_changed_for_metrics_archive_policy(
+            archive_policy_name):
+        raise exceptions.NotImplementedError
+
+    @staticmethod
+    def update_needs_raw_data_truncation(metric_id):
         raise exceptions.NotImplementedError
 
     @staticmethod

--- a/gnocchi/indexer/alembic/versions/18fff4509e3e_create_column_for_truncate_inactive_metrics_process.py
+++ b/gnocchi/indexer/alembic/versions/18fff4509e3e_create_column_for_truncate_inactive_metrics_process.py
@@ -1,0 +1,42 @@
+# Copyright 2015 OpenStack Foundation
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+"""create metric truncation status column
+
+Revision ID: 18fff4509e3e
+Revises: 04eba72e4f90
+Create Date: 2024-04-24 09:16:00
+
+"""
+import datetime
+
+from alembic import op
+from sqlalchemy.sql import func
+
+import sqlalchemy
+
+# revision identifiers, used by Alembic.
+revision = '18fff4509e3e'
+down_revision = '04eba72e4f90'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "metric", sqlalchemy.Column(
+            "needs_raw_data_truncation", sqlalchemy.Boolean,
+            nullable=False, default=True,
+            server_default=sqlalchemy.sql.true()))

--- a/gnocchi/indexer/sqlalchemy_base.py
+++ b/gnocchi/indexer/sqlalchemy_base.py
@@ -19,6 +19,7 @@ from oslo_db.sqlalchemy import models
 import sqlalchemy
 from sqlalchemy.ext import declarative
 from sqlalchemy.orm import declarative_base
+
 import sqlalchemy_utils
 
 from gnocchi import archive_policy
@@ -99,12 +100,18 @@ class Metric(Base, GnocchiBase, indexer.Metric):
         sqlalchemy.ForeignKey('resource.id',
                               ondelete="SET NULL",
                               name="fk_metric_resource_id_resource_id"))
+
     name = sqlalchemy.Column(sqlalchemy.String(255))
     unit = sqlalchemy.Column(sqlalchemy.String(31))
     status = sqlalchemy.Column(sqlalchemy.Enum('active', 'delete',
                                                name="metric_status_enum"),
                                nullable=False,
                                server_default='active')
+
+    needs_raw_data_truncation = sqlalchemy.Column(
+        "needs_raw_data_truncation", sqlalchemy.Boolean,
+        nullable=False, default=True,
+        server_default=sqlalchemy.sql.true())
 
     def jsonify(self):
         d = {

--- a/gnocchi/opts.py
+++ b/gnocchi/opts.py
@@ -172,7 +172,7 @@ def list_opts():
                        default=10000,
                        min=1,
                        help="Number of metrics that should be deleted "
-                       "simultaneously by one janitor."),
+                       "simultaneously by one janitor.")
         )),
         ("api", (
             cfg.StrOpt('paste_config',

--- a/gnocchi/rest/app.py
+++ b/gnocchi/rest/app.py
@@ -174,9 +174,13 @@ def load_app(conf, not_implemented_middleware=True):
     configkey = str(uuid.uuid4())
     APPCONFIGS[configkey] = config
 
-    LOG.info("WSGI config used: %s", cfg_path)
+    LOG.debug("WSGI config used: %s", cfg_path)
 
     appname = "gnocchi+" + conf.api.auth_mode
+
+    LOG.debug("Starting application [%s] with configuration [%s].",
+              appname, APPCONFIGS)
+
     app = deploy.loadapp("config:" + cfg_path, name=appname,
                          global_conf={'configkey': configkey})
     return http_proxy_to_wsgi.HTTPProxyToWSGI(
@@ -194,6 +198,9 @@ def _setup_app(root, conf, not_implemented_middleware):
     if not_implemented_middleware:
         app = webob.exc.HTTPExceptionMiddleware(NotImplementedMiddleware(app))
 
+    LOG.info("Application setup for context path [%s] and "
+             "configurations [%s].",
+             root, conf.__dict__ if conf else None)
     return app
 
 

--- a/gnocchi/rest/auth_helper.py
+++ b/gnocchi/rest/auth_helper.py
@@ -14,10 +14,15 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+import daiquiri
+
 import webob
 import werkzeug.http
 
 from gnocchi.rest import api
+
+
+LOG = daiquiri.getLogger(__name__)
 
 
 class KeystoneAuthHelper(object):
@@ -119,6 +124,8 @@ class BasicAuthHelper(object):
     @staticmethod
     def get_current_user(request):
         hdr = request.headers.get("Authorization")
+        LOG.debug("Processing basic auth request [%s]. Found "
+                  "Authorization header [%s].", request, hdr)
         auth_hdr = (hdr.decode('utf-8') if isinstance(hdr, bytes)
                     else hdr)
 
@@ -134,6 +141,7 @@ class BasicAuthHelper(object):
     def get_auth_info(self, request):
         user = self.get_current_user(request)
         roles = []
+
         if user == "admin":
             roles.append("admin")
         return {
@@ -154,6 +162,8 @@ class RemoteUserAuthHelper(object):
     @staticmethod
     def get_current_user(request):
         user = request.remote_user
+        LOG.debug("Processing remote user authentication for request [%s]. "
+                  "The remote user found is [%s].", request, user)
         if user is None:
             api.abort(401)
         return user.decode('iso-8859-1')
@@ -161,6 +171,7 @@ class RemoteUserAuthHelper(object):
     def get_auth_info(self, request):
         user = self.get_current_user(request)
         roles = []
+
         if user == "admin":
             roles.append("admin")
         return {

--- a/gnocchi/service.py
+++ b/gnocchi/service.py
@@ -78,6 +78,7 @@ def prepare_service(args=None, conf=None,
             logging_level = logging.WARNING
     logging.getLogger("gnocchi").setLevel(logging_level)
 
+    LOG.info("Preparing gnocchi service for configuration [%s].", conf.__dict__ if conf else None)
     # HACK(jd) I'm not happy about that, fix AP class to handle a conf object?
     archive_policy.ArchivePolicy.DEFAULT_AGGREGATION_METHODS = (
         conf.archive_policy.default_aggregation_methods

--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -579,7 +579,7 @@ class StorageDriver(object):
              in metrics_keys_aggregations.items()
              for key, aggregation in keys_and_aggregations))
 
-    def add_measures_to_metrics(self, metrics_and_measures):
+    def add_measures_to_metrics(self, metrics_and_measures, indexer_driver):
         """Update a metric with a new measures, computing new aggregations.
 
         :param metrics_and_measures: A dict there keys are `storage.Metric`
@@ -681,6 +681,12 @@ class StorageDriver(object):
                                         new_first_block_timestamp)
 
             new_boundts.append((metric, ts.serialize()))
+
+            # If the archive policy backwindow is changed, the data is going to
+            # be truncated in the processing of new datapoints. Therefore, we
+            # can mark the metric as not needing raw data truncation anymore
+            if metric.needs_raw_data_truncation:
+                indexer_driver.update_needs_raw_data_truncation(metric.id)
 
         with self.statistics.time("splits delete"):
             self._delete_metric_splits(splits_to_delete)


### PR DESCRIPTION
The truncating of the raw metrics data is only done when new measures are pushed. Therefore, if no new measures are pushed, and the archive policy is updated to reduce the back window, the raw data points for metrics that are not receiving new data points are never truncated.

The goal of this PR is to propose a method to identify metrics that are in "inactive state", meaning, not receiving new data points, and execute their raw data points truncation when the archive policy backwindow is changed.