### PR TITLE
Automatically detect deleted resources

### DIFF
--- a/gnocchi/chef.py
+++ b/gnocchi/chef.py
@@ -17,8 +17,8 @@
 import hashlib
 
 import daiquiri
-import random
 import datetime
+import random
 
 from gnocchi import carbonara
 from gnocchi import indexer

--- a/gnocchi/chef.py
+++ b/gnocchi/chef.py
@@ -82,26 +82,26 @@ class Chef(object):
         LOG.debug("Inactive metrics found for processing: [%s].",
                   inactive_metrics)
 
-        metrics_by_resource_id = {}
+        inactive_metrics_by_resource_id = {}
         for metric in inactive_metrics:
             resource_id = metric.resource_id
-            if metrics_by_resource_id.get(resource_id) is None:
-                metrics_by_resource_id[resource_id] = []
+            if inactive_metrics_by_resource_id.get(resource_id) is None:
+                inactive_metrics_by_resource_id[resource_id] = []
 
-            metrics_by_resource_id[resource_id].append(metric)
+            inactive_metrics_by_resource_id[resource_id].append(metric)
 
-        for resource_id in metrics_by_resource_id.keys():
+        for resource_id in inactive_metrics_by_resource_id.keys():
             if resource_id is None:
                 LOG.debug("We do not need to process inactive metrics that do "
                           "not have resource. Therefore, these metrics [%s] "
                           "will be considered inactive, but there is nothing "
                           "else we can do in this process.",
-                          metrics_by_resource_id[resource_id])
+                          inactive_metrics_by_resource_id[resource_id])
                 continue
             resource = self.index.get_resource(
                 "generic", resource_id, with_metrics=True)
             resource_metrics = resource.metrics
-            resource_inactive_metrics = metrics_by_resource_id.get(resource_id)
+            resource_inactive_metrics = inactive_metrics_by_resource_id.get(resource_id)
 
             all_metrics_are_inactive = True
             for m in resource_metrics:

--- a/gnocchi/chef.py
+++ b/gnocchi/chef.py
@@ -14,8 +14,8 @@
 # implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import hashlib
 import datetime
+import hashlib
 
 import daiquiri
 import random

--- a/gnocchi/chef.py
+++ b/gnocchi/chef.py
@@ -82,12 +82,9 @@ class Chef(object):
         LOG.debug("Inactive metrics found for processing: [%s].",
                   inactive_metrics)
 
-        inactive_metrics_by_resource_id = {}
+        inactive_metrics_by_resource_id = collections.defaultdict(list)
         for metric in inactive_metrics:
             resource_id = metric.resource_id
-            if inactive_metrics_by_resource_id.get(resource_id) is None:
-                inactive_metrics_by_resource_id[resource_id] = []
-
             inactive_metrics_by_resource_id[resource_id].append(metric)
 
         for resource_id in inactive_metrics_by_resource_id.keys():

--- a/gnocchi/chef.py
+++ b/gnocchi/chef.py
@@ -66,6 +66,7 @@ class Chef(object):
         inactive, according to `metric_inactive_after` parameter. Therefore,
         we do not need to lock these metrics while processing, as they are
         inactive, and chances are that they will not receive measures anymore.
+        Moreover, we are only touching metadata, and not the actual data.
         """
 
         momment_now = utils.utcnow()

--- a/gnocchi/chef.py
+++ b/gnocchi/chef.py
@@ -15,11 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import hashlib
+import datetime
 
 import daiquiri
-import datetime
 import random
 
+from collections import defaultdict
 from gnocchi import carbonara
 from gnocchi import indexer
 from gnocchi import utils
@@ -69,20 +70,20 @@ class Chef(object):
         Moreover, we are only touching metadata, and not the actual data.
         """
 
-        momment_now = utils.utcnow()
-        momment = momment_now - datetime.timedelta(
+        moment_now = utils.utcnow()
+        moment = moment_now - datetime.timedelta(
             seconds=metric_inactive_after)
 
         inactive_metrics = self.index.list_metrics(
             attribute_filter={"<": {
-                "last_measure_timestamp": momment}},
+                "last_measure_timestamp": moment}},
             resource_policy_filter={"==": {"ended_at": None}}
         )
 
         LOG.debug("Inactive metrics found for processing: [%s].",
                   inactive_metrics)
 
-        inactive_metrics_by_resource_id = collections.defaultdict(list)
+        inactive_metrics_by_resource_id = defaultdict(list)
         for metric in inactive_metrics:
             resource_id = metric.resource_id
             inactive_metrics_by_resource_id[resource_id].append(metric)
@@ -122,7 +123,7 @@ class Chef(object):
                              "[%s] because all of its metrics are inactive.",
                              resource)
                     self.index.update_resource(
-                        "generic", resource_id, ended_at=momment_now)
+                        "generic", resource_id, ended_at=moment_now)
 
     def clean_raw_data_inactive_metrics(self):
         """Cleans metrics raw data if they are inactive.

--- a/gnocchi/cli/metricd.py
+++ b/gnocchi/cli/metricd.py
@@ -278,6 +278,17 @@ class MetricJanitor(MetricProcessBase):
         LOG.debug("Finished the cleaning of raw data points for metrics that "
                   "are no longer receiving measures.")
 
+        if (self.conf.metricd.metric_inactive_after and
+                self.conf.metricd.metric_inactive_after > 0):
+            LOG.debug("Starting resource ended at field normalization.")
+            self.chef.resource_ended_at_normalization(
+                self.conf.metricd.metric_inactive_after)
+            LOG.debug("Finished resource ended at field normalization.")
+        else:
+            LOG.debug("Resource ended at field normalization is not "
+                      "activated. See 'metric_inactive_after' parameter if "
+                      "you wish to activate it.")
+
 
 class MetricdServiceManager(cotyledon.ServiceManager):
     def __init__(self, conf):

--- a/gnocchi/indexer/__init__.py
+++ b/gnocchi/indexer/__init__.py
@@ -450,7 +450,7 @@ class IndexerDriver(object):
         raise exceptions.NotImplementedError
 
     @staticmethod
-    def update_last_measure_timestmap(metric_id):
+    def update_last_measure_timestamp(metric_id):
         raise exceptions.NotImplementedError
 
     @staticmethod

--- a/gnocchi/indexer/__init__.py
+++ b/gnocchi/indexer/__init__.py
@@ -446,7 +446,11 @@ class IndexerDriver(object):
         raise exceptions.NotImplementedError
 
     @staticmethod
-    def update_needs_raw_data_truncation(metric_id):
+    def update_needs_raw_data_truncation(metric_id, value):
+        raise exceptions.NotImplementedError
+
+    @staticmethod
+    def update_last_measure_timestmap(metric_id):
         raise exceptions.NotImplementedError
 
     @staticmethod

--- a/gnocchi/indexer/alembic/versions/f89ed2e3c2ec_create_last_measure_timestamp_column.py
+++ b/gnocchi/indexer/alembic/versions/f89ed2e3c2ec_create_last_measure_timestamp_column.py
@@ -19,11 +19,10 @@ Revises: 18fff4509e3e
 Create Date: 2024-04-24 09:16:00
 """
 
+import datetime
 from alembic import op
 
 import sqlalchemy
-
-from sqlalchemy.sql import func
 
 # revision identifiers, used by Alembic.
 revision = 'f89ed2e3c2ec'
@@ -33,7 +32,9 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column(
-        "metric", sqlalchemy.Column(
+    sql_column = sqlalchemy.Column(
             "last_measure_timestamp", sqlalchemy.DateTime,
-            nullable=False, server_default=func.current_timestamp()))
+            nullable=False, default=datetime.datetime.now(datetime.UTC),
+            server_default=sqlalchemy.sql.func.current_timestamp())
+    op.add_column(
+        "metric", sql_column)

--- a/gnocchi/indexer/alembic/versions/f89ed2e3c2ec_create_last_measure_timestamp_column.py
+++ b/gnocchi/indexer/alembic/versions/f89ed2e3c2ec_create_last_measure_timestamp_column.py
@@ -13,21 +13,21 @@
 #    under the License.
 #
 
-"""Create metric truncation status column
-
-Revision ID: 18fff4509e3e
-Revises: 04eba72e4f90
+"""Create last measure push timestamp column
+Revision ID: f89ed2e3c2ec
+Revises: 18fff4509e3e
 Create Date: 2024-04-24 09:16:00
-
 """
 
 from alembic import op
 
 import sqlalchemy
 
+from sqlalchemy.sql import func
+
 # revision identifiers, used by Alembic.
-revision = '18fff4509e3e'
-down_revision = '04eba72e4f90'
+revision = 'f89ed2e3c2ec'
+down_revision = '18fff4509e3e'
 branch_labels = None
 depends_on = None
 
@@ -35,6 +35,5 @@ depends_on = None
 def upgrade():
     op.add_column(
         "metric", sqlalchemy.Column(
-            "needs_raw_data_truncation", sqlalchemy.Boolean,
-            nullable=False, default=True,
-            server_default=sqlalchemy.sql.true()))
+            "last_measure_timestamp", sqlalchemy.DateTime,
+            nullable=False, server_default=func.current_timestamp()))

--- a/gnocchi/indexer/alembic/versions/f89ed2e3c2ec_create_last_measure_timestamp_column.py
+++ b/gnocchi/indexer/alembic/versions/f89ed2e3c2ec_create_last_measure_timestamp_column.py
@@ -15,7 +15,7 @@
 
 """Create last measure push timestamp column
 Revision ID: f89ed2e3c2ec
-Revises: 18fff4509e3e
+Revises: 94544ca86c7e
 Create Date: 2024-04-24 09:16:00
 """
 
@@ -26,7 +26,7 @@ import sqlalchemy
 
 # revision identifiers, used by Alembic.
 revision = 'f89ed2e3c2ec'
-down_revision = '18fff4509e3e'
+down_revision = '94544ca86c7e'
 branch_labels = None
 depends_on = None
 
@@ -34,7 +34,7 @@ depends_on = None
 def upgrade():
     sql_column = sqlalchemy.Column(
             "last_measure_timestamp", sqlalchemy.DateTime,
-            nullable=False, default=datetime.datetime.now(datetime.UTC),
+            nullable=False, default=datetime.datetime.utcnow(),
             server_default=sqlalchemy.sql.func.current_timestamp())
     op.add_column(
         "metric", sql_column)

--- a/gnocchi/indexer/sqlalchemy.py
+++ b/gnocchi/indexer/sqlalchemy.py
@@ -1403,6 +1403,13 @@ class SQLAlchemyIndexer(indexer.IndexerDriver):
             if session.execute(stmt).rowcount == 0:
                 raise indexer.NoSuchMetric(metrid_id)
 
+    def update_last_measure_timestmap(self, metrid_id):
+        with self.facade.writer() as session:
+            stmt = update(Metric).filter(Metric.id == metrid_id).values(
+                last_measure_timestamp=datetime.datetime.utcnow())
+            if session.execute(stmt).rowcount == 0:
+                raise indexer.NoSuchMetric(metrid_id)
+
     def update_backwindow_changed_for_metrics_archive_policy(
             self, archive_policy_name):
         with self.facade.writer() as session:

--- a/gnocchi/indexer/sqlalchemy.py
+++ b/gnocchi/indexer/sqlalchemy.py
@@ -1403,7 +1403,7 @@ class SQLAlchemyIndexer(indexer.IndexerDriver):
             if session.execute(stmt).rowcount == 0:
                 raise indexer.NoSuchMetric(metrid_id)
 
-    def update_last_measure_timestmap(self, metrid_id):
+    def update_last_measure_timestamp(self, metrid_id):
         with self.facade.writer() as session:
             stmt = update(Metric).filter(Metric.id == metrid_id).values(
                 last_measure_timestamp=datetime.datetime.utcnow())

--- a/gnocchi/indexer/sqlalchemy_base.py
+++ b/gnocchi/indexer/sqlalchemy_base.py
@@ -15,11 +15,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import datetime
 from oslo_db.sqlalchemy import models
 import sqlalchemy
 from sqlalchemy.ext import declarative
 from sqlalchemy.orm import declarative_base
-from sqlalchemy.sql import func
 
 import sqlalchemy_utils
 
@@ -120,8 +120,8 @@ class Metric(Base, GnocchiBase, indexer.Metric):
     # measurements; thus, if all metric for a resource are in this situation,
     # chances are that the resource ceased existing in the backend.
     last_measure_timestamp = sqlalchemy.Column(
-        "last_measure_timestamp", sqlalchemy.DateTime,
-        nullable=False, server_default=func.current_timestamp())
+        "last_measure_timestamp", sqlalchemy.DateTime, default=datetime.datetime.now(datetime.UTC), nullable=False,
+        server_default=sqlalchemy.sql.func.current_timestamp())
 
     def jsonify(self):
         d = {

--- a/gnocchi/indexer/sqlalchemy_base.py
+++ b/gnocchi/indexer/sqlalchemy_base.py
@@ -120,7 +120,7 @@ class Metric(Base, GnocchiBase, indexer.Metric):
     # measurements; thus, if all metric for a resource are in this situation,
     # chances are that the resource ceased existing in the backend.
     last_measure_timestamp = sqlalchemy.Column(
-        "last_measure_timestamp", sqlalchemy.DateTime, default=datetime.datetime.now(datetime.UTC), nullable=False,
+        "last_measure_timestamp", sqlalchemy.DateTime, default=datetime.datetime.utcnow(), nullable=False,
         server_default=sqlalchemy.sql.func.current_timestamp())
 
     def jsonify(self):

--- a/gnocchi/opts.py
+++ b/gnocchi/opts.py
@@ -77,7 +77,7 @@ API_OPTS = (
   but not chunked encoding (InfluxDB)
 * http-socket/socket: support chunked encoding, but require a upstream HTTP
   Server for HTTP/1.1, keepalive and HTTP protocol correctness.
-"""),
+""")
 )
 
 

--- a/gnocchi/opts.py
+++ b/gnocchi/opts.py
@@ -62,7 +62,6 @@ _INCOMING_OPTS = copy.deepcopy(_STORAGE_OPTS)
 for opt in _INCOMING_OPTS:
     opt.default = '${storage.%s}' % opt.name
 
-
 API_OPTS = (
     cfg.HostAddressOpt('host',
                        default="0.0.0.0",
@@ -78,7 +77,7 @@ API_OPTS = (
   but not chunked encoding (InfluxDB)
 * http-socket/socket: support chunked encoding, but require a upstream HTTP
   Server for HTTP/1.1, keepalive and HTTP protocol correctness.
-""")
+"""),
 )
 
 
@@ -177,7 +176,16 @@ def list_opts():
                        default=10000,
                        min=1,
                        help="Number of metrics that should be deleted "
-                       "simultaneously by one janitor.")
+                            "simultaneously by one janitor."),
+            cfg.IntOpt('metric_inactive_after',
+                       default=0,
+                       help="Number of seconds to wait before we consider a "
+                            "metric inactive. An inactive metric is a metric "
+                            "that has not received new measurements for a "
+                            "given period. If all metrics of a resource are "
+                            "inactive, we mark the resource with the "
+                            "'ended_at' timestamp. The default is 0 (zero), "
+                            "which means that we never execute process.")
         )),
         ("api", (
             cfg.StrOpt('paste_config',

--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -700,7 +700,7 @@ class StorageDriver(object):
                 if resource.ended_at is not None:
                     LOG.info("Resource [%s] was marked with a timestamp for the "
                              "'ended_at' field. However, it received a "
-                             "measurement for metric [%s]. Therefore, we undelete "
+                             "measurement for metric [%s]. Therefore, restoring "
                              "it.", resource, metric)
                     indexer_driver.update_resource(
                         "generic", resource_id, ended_at=None)

--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -689,7 +689,7 @@ class StorageDriver(object):
                 indexer_driver.update_needs_raw_data_truncation(metric.id)
 
             # Mark when the metric receives its latest measures
-            indexer_driver.update_last_measure_timestmap(metric.id)
+            indexer_driver.update_last_measure_timestamp(metric.id)
 
             resource_id = metric.resource_id
             if resource_id:

--- a/gnocchi/storage/__init__.py
+++ b/gnocchi/storage/__init__.py
@@ -695,7 +695,7 @@ class StorageDriver(object):
             if resource_id:
                 resource = indexer_driver.get_resource('generic', resource_id)
                 LOG.debug("Checking if resource [%s] of metric [%s] with "
-                          "resource ID [%s] needs to be 'undeleted.'",
+                          "resource ID [%s] needs to be restored.",
                           resource, metric.id, resource_id)
                 if resource.ended_at is not None:
                     LOG.info("Resource [%s] was marked with a timestamp for the "

--- a/gnocchi/tests/functional/gabbits/aggregates-with-resources.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregates-with-resources.yaml
@@ -6,6 +6,9 @@ defaults:
     # User foobar
     authorization: "basic Zm9vYmFyOg=="
     content-type: application/json
+  poll:
+    count: 3
+    delay: 1
 
 tests:
     - name: create archive policy

--- a/run-upgrade-tests.sh
+++ b/run-upgrade-tests.sh
@@ -107,7 +107,7 @@ export GNOCCHI_USER=$GNOCCHI_USER_ID
 # needs to be released. Otherwise, the logs stop to be writen, and the
 # execution of the code is "frozen", due to the lack of buffer in the
 # process output. To work around that, we can read the buffer, and dump it
-# into a lof file. Then, we can cat the log file content at the end of the
+# into a log file. Then, we can cat the log file content at the end of the
 # process.
 UWSGI_LOG_FILE=/tmp/uwsgi-new-version.log
 METRICD_LOG_FILE=/tmp/gnocchi-metricd-new-version.log


### PR DESCRIPTION
This patch is created on top of https://github.com/gnocchixyz/gnocchi/pull/1385, https://github.com/gnocchixyz/gnocchi/pull/1381,  https://github.com/gnocchixyz/gnocchi/pull/1387, and https://github.com/gnocchixyz/gnocchi/pull/1388. Therefore, we need to merge them first. Then, the extra commits here will disappear.

While executing some Gnocchi optimizations (https://github.com/gnocchixyz/gnocchi/pull/1307), we noticed that some deleted/removed resources do not have the "ended_at" field with a datetime. This can cause slowness with time, as more and more "zombie" resources are left there, and this has a direct impact in the MySQL queries executed with the aggregates API.

This patch introduces a new parameter called `metric_inactive_after`, which defines for how long a metric can go without receiving new data points until we consider it as inactive. Then, when all metrics of a resource are in inactive state, we can mark/consider the resource as removed.