### PR TITLE
Add main to CLI classes

### DIFF
--- a/gnocchi/cli/api.py
+++ b/gnocchi/cli/api.py
@@ -114,3 +114,7 @@ def api():
         args.extend(["-H", os.getenv("VIRTUAL_ENV", ".")])
 
     return os.execl(uwsgi, uwsgi, *args)
+
+
+if __name__ == '__main__':
+    api()

--- a/gnocchi/cli/manage.py
+++ b/gnocchi/cli/manage.py
@@ -105,3 +105,7 @@ def change_sack_size():
     s.remove_sacks()
     LOG.info("Creating new %d sacks", conf.sacks_number)
     s.upgrade(conf.sacks_number)
+
+
+if __name__ == '__main__':
+    upgrade()

--- a/gnocchi/cli/metricd.py
+++ b/gnocchi/cli/metricd.py
@@ -329,3 +329,7 @@ def metricd():
         metricd_tester(conf)
     else:
         MetricdServiceManager(conf).run()
+
+
+if __name__ == '__main__':
+    metricd()

--- a/gnocchi/cli/statsd.py
+++ b/gnocchi/cli/statsd.py
@@ -18,3 +18,7 @@ from gnocchi import statsd as statsd_service
 
 def statsd():
     statsd_service.start()
+
+
+if __name__ == '__main__':
+    statsd()


### PR DESCRIPTION
When developing to Gnocchi, it is handy to run Gnocchi from Pycharm. To achieve that, if we have the main methods already in the CLI modules, one can easily start Gnocchi directly from Pycharm in Debug mode. Therefore, this patch introduces such option