### PR TITLE
Enable custom uWSGI path

### DIFF
--- a/gnocchi/cli/api.py
+++ b/gnocchi/cli/api.py
@@ -71,7 +71,9 @@ def api():
             "No need to pass `--' in gnocchi-api command line anymore, "
             "please remove")
 
-    uwsgi = spawn.find_executable("uwsgi")
+    uwsgi = conf.api.uwsgi_path
+    if not uwsgi:
+        uwsgi = spawn.find_executable("uwsgi")
     if not uwsgi:
         LOG.error("Unable to find `uwsgi'.\n"
                   "Be sure it is installed and in $PATH.")
@@ -113,4 +115,6 @@ def api():
     if virtual_env is not None:
         args.extend(["-H", os.getenv("VIRTUAL_ENV", ".")])
 
+    LOG.debug("Starting gnocchi api server with [%s] and arguments [%s]",
+              uwsgi, args)
     return os.execl(uwsgi, uwsgi, *args)

--- a/gnocchi/cli/api.py
+++ b/gnocchi/cli/api.py
@@ -71,9 +71,7 @@ def api():
             "No need to pass `--' in gnocchi-api command line anymore, "
             "please remove")
 
-    uwsgi = conf.api.uwsgi_path
-    if not uwsgi:
-        uwsgi = spawn.find_executable("uwsgi")
+    uwsgi = conf.api.uwsgi_path or spawn.find_executable("uwsgi")
     if not uwsgi:
         LOG.error("Unable to find `uwsgi'.\n"
                   "Be sure it is installed and in $PATH.")

--- a/gnocchi/opts.py
+++ b/gnocchi/opts.py
@@ -193,7 +193,7 @@ def list_opts():
                        default=10, min=0,
                        help='Number of seconds before timeout when attempting '
                             'to do some operations.'),
-            cfg.StrOpt('uwsgi-path',
+            cfg.StrOpt('uwsgi_path',
                        default=None,
                        help="Custom UWSGI path to avoid auto discovery of packages.")
         ) + API_OPTS + gnocchi.rest.http_proxy_to_wsgi.OPTS,

--- a/gnocchi/opts.py
+++ b/gnocchi/opts.py
@@ -193,6 +193,9 @@ def list_opts():
                        default=10, min=0,
                        help='Number of seconds before timeout when attempting '
                             'to do some operations.'),
+            cfg.StrOpt('uwsgi-path',
+                       default=None,
+                       help="Custom UWSGI path to avoid auto discovery of packages.")
         ) + API_OPTS + gnocchi.rest.http_proxy_to_wsgi.OPTS,
         ),
         ("storage", _STORAGE_OPTS),


### PR DESCRIPTION
In some cases, we might need to override the uWSGI path. Therefore, a configuration for the operator to execute such configuration is interesting to have in hand.