### PR TITLE
Switch Metric-Resource relationship to back_populates

### DIFF
--- a/gnocchi/indexer/sqlalchemy_base.py
+++ b/gnocchi/indexer/sqlalchemy_base.py
@@ -100,7 +100,8 @@ class Metric(Base, GnocchiBase, indexer.Metric):
         sqlalchemy.ForeignKey('resource.id',
                               ondelete="SET NULL",
                               name="fk_metric_resource_id_resource_id"))
-
+    resource = sqlalchemy.orm.relationship("Resource",
+                                           back_populates="metrics")
     name = sqlalchemy.Column(sqlalchemy.String(255))
     unit = sqlalchemy.Column(sqlalchemy.String(31))
     status = sqlalchemy.Column(sqlalchemy.Enum('active', 'delete',
@@ -273,7 +274,7 @@ class Resource(ResourceMixin, Base, GnocchiBase):
                            primary_key=True)
     revision_end = None
     metrics = sqlalchemy.orm.relationship(
-        Metric, backref="resource",
+        Metric, back_populates="resource",
         primaryjoin="and_(Resource.id == Metric.resource_id, "
         "Metric.status == 'active')")
 


### PR DESCRIPTION
Replace usage of the deprecated backref option [1] and implicit relationship population, with the new back_populates [2] option and explicit relationship definitions on both the Metric and Resource classes.

This eliminates "AttributeError: type object 'Metric' has no attribute 'resource'" exceptions that can occur when Metric.resource is referenced using sqlalchemy.orm.joinedload in queries.

This change is backwards compatible with SQLAlchemy 1.4.

1: https://docs.sqlalchemy.org/en/20/orm/backref.html
2: https://docs.sqlalchemy.org/en/20/orm/basic_relationships.html