### PR TITLE
Unpin pifpaf

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -92,7 +92,7 @@ doc =
     Jinja2
     reno>=1.6.2
 test =
-    pifpaf[ceph,gnocchi]>=1.0.1
+    pifpaf[ceph,gnocchi]
     gabbi>=1.37.0
     coverage>=3.6
     fixtures

--- a/tox.ini
+++ b/tox.ini
@@ -49,9 +49,6 @@ setenv =
 deps =
     .[test,redis,prometheus,amqp1,{env:GNOCCHI_STORAGE_DEPS:},{env:GNOCCHI_INDEXER_DEPS:}]
     {env:GNOCCHI_TEST_TARBALLS:}
-    # TODO(tobias-urdin): Remove this pin and use pifpaf directly instead when this is
-    # merged and released
-    git+https://github.com/jd/pifpaf@d5103d4bcf80aa6f74e31e92e4a7eb92997d4c73
     cliff!=2.9.0
     gnocchiclient>=2.8.0,!=7.0.7
 commands =
@@ -74,10 +71,8 @@ setenv =
     GNOCCHI_VERSION_FROM=stable/4.4
     GNOCCHI_VARIANT=test,postgresql,file
 deps =
-    # TODO(tobias-urdin): Remove this pin and use pifpaf directly instead when this is
-    # merged and released
-    git+https://github.com/jd/pifpaf@d5103d4bcf80aa6f74e31e92e4a7eb92997d4c73
     gnocchiclient>=2.8.0,!=7.0.7
+    pifpaf
     xattr!=0.9.4
 commands = {toxinidir}/run-upgrade-tests.sh postgresql-file
 allowlist_externals = {toxinidir}/run-upgrade-tests.sh
@@ -90,10 +85,8 @@ setenv =
     GNOCCHI_VERSION_FROM=stable/4.4
     GNOCCHI_VARIANT=test,mysql,ceph,ceph_recommended_lib
 deps =
-    # TODO(tobias-urdin): Remove this pin and use pifpaf directly instead when this is
-    # merged and released
-    git+https://github.com/jd/pifpaf@d5103d4bcf80aa6f74e31e92e4a7eb92997d4c73
     gnocchiclient>=2.8.0,!=7.0.7
+    pifpaf[ceph]
     xattr!=0.9.4
 commands = {toxinidir}/run-upgrade-tests.sh mysql-ceph
 allowlist_externals = {toxinidir}/run-upgrade-tests.sh


### PR DESCRIPTION
Now that pifpaf 3.2.0 is released we can
stop pinning it and unpin it completely.