### PR TITLE
image: hack jaraco.text and werkzeug to fix CI

### DIFF
--- a/images/Dockerfile.ci
+++ b/images/Dockerfile.ci
@@ -44,6 +44,9 @@ RUN rm -rf /var/lib/apt/lists/*
 # NOTE(tobias.urdin): hack since pyparsing in site-packages collides with our requirements
 RUN rm -rf /usr/lib/python3/dist-packages/pyparsing*
 
+# NOTE(tobias.urdin): hack since jaraco.text in site-packages collides with our requirements
+RUN rm -rf /usr/lib/python3/dist-packages/jaraco/text*
+
 #NOTE(sileht): really no utf-8 in 2017 !?
 ENV LANG en_US.UTF-8
 RUN update-locale

--- a/images/Dockerfile.ci
+++ b/images/Dockerfile.ci
@@ -47,6 +47,9 @@ RUN rm -rf /usr/lib/python3/dist-packages/pyparsing*
 # NOTE(tobias.urdin): hack since jaraco.text in site-packages collides with our requirements
 RUN rm -rf /usr/lib/python3/dist-packages/jaraco/text*
 
+# TODO(tobias.urdin): hack remove this when we drop python 3.9
+RUN sed -i '1s/^/from __future__ import annotations\n/' /usr/lib/python3/dist-packages/werkzeug/sansio/utils.py
+
 #NOTE(sileht): really no utf-8 in 2017 !?
 ENV LANG en_US.UTF-8
 RUN update-locale


### PR DESCRIPTION
we get a collision because jaraco.text is installed in site-packages but we want a newer version when
testing.

werkzeug dist package in ubuntu works with python 3.10 but not 3.9, this fixes that, the hack can be removed when we drop 3.9 support