### PR TITLE
Function call issue for parsing sentinel_fallback

### DIFF
--- a/gnocchi/common/redis.py
+++ b/gnocchi/common/redis.py
@@ -119,7 +119,7 @@ OPTS = [
 ]
 
 
-def _parse_sentinel(cls, sentinel):
+def _parse_sentinel(sentinel):
     # IPv6 (eg. [::1]:6379 )
     match = re.search(r'^\[(\S+)\]:(\d+)$', sentinel)
     if match:


### PR DESCRIPTION
Hi,
The `_parse_sentinel` was a class function and when it get called by
```
sentinel_hosts = [
            _parse_sentinel(fallback)
            for fallback in kwargs.pop('sentinel_fallback', [])
        ]
```
It made errors because it doesn't pass cls to it and it can't receive the sentinel.
So I made it static and tested it and its OK now.