### PR TITLE
Use oslo.utils method to parse server format

### DIFF
--- a/gnocchi/common/redis.py
+++ b/gnocchi/common/redis.py
@@ -14,9 +14,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import re
-
 from oslo_config import cfg
+from oslo_utils import netutils
 from oslo_utils import strutils
 from urllib import parse
 
@@ -119,15 +118,10 @@ OPTS = [
 
 
 def _parse_sentinel(sentinel):
-    # IPv6 (eg. [::1]:6379 )
-    match = re.search(r'^\[(\S+)\]:(\d+)$', sentinel)
-    if match:
-        return (match[1], int(match[2]))
-    # IPv4 or hostname (eg. 127.0.0.1:6379 or localhost:6379)
-    match = re.search(r'^(\S+):(\d+)$', sentinel)
-    if match:
-        return (match[1], int(match[2]))
-    raise ValueError('Malformed sentinel server format')
+    host, port = netutils.parse_host_port(sentinel)
+    if host is None or port is None:
+        raise ValueError('Malformed sentinel server format')
+    return (host, port)
 
 
 def get_client(conf, scripts=None):

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
     oslo.config>=3.22.0
     oslo.policy>=3.5.0
     oslo.middleware>=3.22.0
+    oslo.utils>=1.1.1
     pytimeparse
     pecan>=0.9
     jsonpatch


### PR DESCRIPTION
The oslo.utils library is already required via some of the current dependencies (eg. tooz). Use the utility method from it to parse host:port format instead of carrying our own method.