### PR TITLE
Get rid of distutils

### DIFF
--- a/gnocchi/cli/api.py
+++ b/gnocchi/cli/api.py
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
-from distutils import spawn
 import math
 import os
+import shutil
 import sys
 
 import daiquiri
@@ -72,7 +72,7 @@ def api():
             "No need to pass `--' in gnocchi-api command line anymore, "
             "please remove")
 
-    uwsgi = conf.api.uwsgi_path or spawn.find_executable("uwsgi")
+    uwsgi = conf.api.uwsgi_path or shutil.which("uwsgi")
     if not uwsgi:
         LOG.error("Unable to find `uwsgi'.\n"
                   "Be sure it is installed and in $PATH.")

--- a/gnocchi/common/redis.py
+++ b/gnocchi/common/redis.py
@@ -17,6 +17,7 @@
 import re
 
 from oslo_config import cfg
+from oslo_utils import strutils
 from urllib import parse
 
 try:
@@ -25,8 +26,6 @@ try:
 except ImportError:
     redis = None
     sentinel = None
-
-from gnocchi import utils
 
 
 SEP_S = ':'
@@ -155,7 +154,7 @@ def get_client(conf, scripts=None):
         if a not in options:
             continue
         if a in CLIENT_BOOL_ARGS:
-            v = utils.strtobool(options[a][-1])
+            v = strutils.bool_from_string(options[a][-1])
         elif a in CLIENT_LIST_ARGS:
             v = options[a]
         elif a in CLIENT_INT_ARGS:

--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -22,6 +22,7 @@ import operator
 import uuid
 
 import jsonpatch
+from oslo_utils import strutils
 import pecan
 from pecan import rest
 import pyparsing
@@ -189,7 +190,7 @@ def get_bool_param(name, params, default='false'):
 def strtobool(varname, v):
     """Convert a string to a boolean."""
     try:
-        return utils.strtobool(v)
+        return strutils.bool_from_string(v, strict=True)
     except ValueError as e:
         abort(400, "Unable to parse `%s': %s" % (varname, str(e)))
 

--- a/gnocchi/tests/test_rest.py
+++ b/gnocchi/tests/test_rest.py
@@ -1500,7 +1500,7 @@ class ResourceTest(RestTest):
         result = self.app.get("/v1/resource/generic?details=awesome",
                               status=400)
         self.assertIn(
-            b"Unable to parse `details': invalid truth value",
+            b"Unable to parse `details':",
             result.body)
 
     def _do_test_list_resources_with_detail(self, request):

--- a/gnocchi/utils.py
+++ b/gnocchi/utils.py
@@ -15,7 +15,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 import datetime
-import distutils.util
 import errno
 import functools
 import itertools
@@ -196,12 +195,6 @@ def ensure_paths(paths):
         except OSError as e:
             if e.errno != errno.EEXIST:
                 raise
-
-
-def strtobool(v):
-    if isinstance(v, bool):
-        return v
-    return bool(distutils.util.strtobool(v))
 
 
 class StopWatch(object):


### PR DESCRIPTION
The distutils module was removed from Python 3.12 .