### PR TITLE
Get rid of pkg_resources

### DIFF
--- a/gnocchi/__init__.py
+++ b/gnocchi/__init__.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pkg_resources
+import importlib.metadata
 
 try:
-    __version__ = pkg_resources.get_distribution(__name__).version
-except pkg_resources.DistributionNotFound:
+    __version__ = importlib.metadata.version('gnocchi')
+except importlib.metadata.PackageNotFoundError:
     # package is not installed
     pass

--- a/gnocchi/opts.py
+++ b/gnocchi/opts.py
@@ -14,7 +14,7 @@
 import copy
 import itertools
 import operator
-import pkg_resources
+import sys
 import uuid
 
 from oslo_config import cfg
@@ -28,6 +28,11 @@ import gnocchi.storage.ceph
 import gnocchi.storage.file
 import gnocchi.storage.s3
 import gnocchi.storage.swift
+
+if sys.version_info < (3, 10, 0):
+    import importlib_metadata
+else:
+    from importlib import metadata as importlib_metadata
 
 
 # NOTE(sileht): The oslo.config interpolation is buggy when the value
@@ -178,12 +183,14 @@ def list_opts():
             cfg.StrOpt('paste_config',
                        default="api-paste.ini",
                        help='Path to API Paste configuration.'),
-            cfg.StrOpt('auth_mode',
-                       default="basic",
-                       choices=list(map(operator.attrgetter("name"),
-                                    pkg_resources.iter_entry_points(
-                                        "gnocchi.rest.auth_helper"))),
-                       help='Authentication mode to use.'),
+            cfg.StrOpt(
+                'auth_mode',
+                default="basic",
+                choices=list(map(
+                    operator.attrgetter("name"),
+                    importlib_metadata.entry_points(
+                        group='gnocchi.rest.auth_helper'))),
+                help='Authentication mode to use.'),
             cfg.IntOpt('max_limit',
                        default=1000,
                        help=('The maximum number of items returned in a '

--- a/gnocchi/rest/app.py
+++ b/gnocchi/rest/app.py
@@ -15,7 +15,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 import os
-import pkg_resources
 import threading
 import uuid
 
@@ -166,8 +165,8 @@ def load_app(conf, not_implemented_middleware=True):
 
     if cfg_path is None or not os.path.exists(cfg_path):
         LOG.debug("No api-paste configuration file found! Using default.")
-        cfg_path = os.path.abspath(pkg_resources.resource_filename(
-            __name__, "api-paste.ini"))
+        cfg_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                'api-paste.ini')
 
     config = dict(conf=conf,
                   not_implemented_middleware=not_implemented_middleware)

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ install_requires =
     lz4>=0.9.0
     tooz>=1.38
     cachetools
+    importlib_metadata>=3.6; python_version<"3.10"
 
 [options.extras_require]
 keystone =


### PR DESCRIPTION
... because it was removed in Python 3.12 [1].

[1] https://docs.python.org/3/whatsnew/3.12.html#ensurepip