### PR TITLE
Install setuptools

### DIFF
--- a/.github/workflows/gnocchi.yml
+++ b/.github/workflows/gnocchi.yml
@@ -106,6 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         python:
           - py39

--- a/.github/workflows/gnocchi.yml
+++ b/.github/workflows/gnocchi.yml
@@ -112,8 +112,8 @@ jobs:
           - py39
           - py311
         env:
-          - mysql-ceph-upgrade-from-4.4
-          - postgresql-file-upgrade-from-4.4
+          - mysql-ceph-upgrade-from-4.5
+          - postgresql-file-upgrade-from-4.5
           - mysql-file
           - mysql-file-sqlalchemy14
           - mysql-swift
@@ -125,13 +125,13 @@ jobs:
           - postgresql-s3
           - postgresql-ceph
         exclude:
-          - env: mysql-ceph-upgrade-from-4.4
+          - env: mysql-ceph-upgrade-from-4.5
             python: py39
           - env: mysql-ceph
             python: py39
           - env: postgresql-ceph
             python: py39
-          - env: mysql-ceph-upgrade-from-4.4
+          - env: mysql-ceph-upgrade-from-4.5
             python: py311
           - env: mysql-ceph
             python: py311

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,8 +5,8 @@ queue_rules:
     - check-success=doc (docs-gnocchi-web)
     - check-success=check (build)
     - check-success=check (pep8)
-    - check-success=test (py39, mysql-ceph-upgrade-from-4.4)
-    - check-success=test (py39, postgresql-file-upgrade-from-4.4)
+    - check-success=test (py39, mysql-ceph-upgrade-from-4.5)
+    - check-success=test (py39, postgresql-file-upgrade-from-4.5)
     - check-success=test (py39, mysql-file)
     - check-success=test (py39, mysql-file-sqlalchemy14)
     - check-success=test (py39, mysql-swift)
@@ -17,7 +17,7 @@ queue_rules:
     - check-success=test (py39, postgresql-swift)
     - check-success=test (py39, postgresql-s3)
     - check-success=test (py39, postgresql-ceph)
-    - check-success=test (py311, postgresql-file-upgrade-from-4.4)
+    - check-success=test (py311, postgresql-file-upgrade-from-4.5)
     - check-success=test (py311, mysql-file)
     - check-success=test (py311, mysql-file-sqlalchemy14)
     - check-success=test (py311, mysql-swift)
@@ -40,8 +40,8 @@ pull_request_rules:
     - check-success=doc (docs-gnocchi-web)
     - check-success=check (build)
     - check-success=check (pep8)
-    - check-success=test (py39, mysql-ceph-upgrade-from-4.4)
-    - check-success=test (py39, postgresql-file-upgrade-from-4.4)
+    - check-success=test (py39, mysql-ceph-upgrade-from-4.5)
+    - check-success=test (py39, postgresql-file-upgrade-from-4.5)
     - check-success=test (py39, mysql-file)
     - check-success=test (py39, mysql-file-sqlalchemy14)
     - check-success=test (py39, mysql-swift)
@@ -52,7 +52,7 @@ pull_request_rules:
     - check-success=test (py39, postgresql-swift)
     - check-success=test (py39, postgresql-s3)
     - check-success=test (py39, postgresql-ceph)
-    - check-success=test (py311, postgresql-file-upgrade-from-4.4)
+    - check-success=test (py311, postgresql-file-upgrade-from-4.5)
     - check-success=test (py311, mysql-file)
     - check-success=test (py311, mysql-file-sqlalchemy14)
     - check-success=test (py311, mysql-swift)
@@ -81,10 +81,10 @@ pull_request_rules:
   - actions:
       backport:
         branches:
-        - stable/4.4
+        - stable/4.5
     conditions:
-    - label=backport-to-4.4
-    name: backport stable/4.4
+    - label=backport-to-4.5
+    name: backport stable/4.5
 
   - actions:
       backport:

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ passenv =
     GNOCCHI_TEST_*
     AWS_*
 setenv =
+    VIRTUALENV_SETUPTOOLS=bundle
     GNOCCHI_TEST_STORAGE_DRIVER=file
     GNOCCHI_TEST_INDEXER_DRIVER=postgresql
     GNOCCHI_TEST_STORAGE_DRIVERS=file swift ceph s3 redis
@@ -69,6 +70,7 @@ deps =
 recreate = True
 setenv =
     GNOCCHI_VERSION_FROM=stable/4.5
+    VIRTUALENV_SETUPTOOLS=bundle
     GNOCCHI_VARIANT=test,postgresql,file
 deps =
     gnocchiclient>=2.8.0,!=7.0.7
@@ -82,6 +84,7 @@ allowlist_externals = {toxinidir}/run-upgrade-tests.sh
 # Gnocchi we can't reuse the virtualenv
 recreate = True
 setenv =
+    VIRTUALENV_SETUPTOOLS=bundle
     GNOCCHI_VERSION_FROM=stable/4.5
     GNOCCHI_VARIANT=test,mysql,ceph,ceph_recommended_lib
 deps =
@@ -103,6 +106,7 @@ allowlist_externals =
 
 [testenv:{py39,py311}-cover]
 setenv =
+    VIRTUALENV_SETUPTOOLS=bundle
     {[testenv]setenv}
     PYTHON=coverage run --source gnocchi --parallel-mode
 commands =
@@ -131,6 +135,7 @@ deps =
     .[test,file,postgresql,doc]
     doc8
 setenv =
+    VIRTUALENV_SETUPTOOLS=bundle
     GNOCCHI_TEST_DEBUG=1
 commands =
     doc8 --ignore-path doc/source/rest.rst,doc/source/comparison-table.rst doc/source
@@ -141,11 +146,11 @@ allowlist_externals =
     /bin/bash
     /bin/rm
 setenv =
+    VIRTUALENV_SETUPTOOLS=bundle
     GNOCCHI_STORAGE_DEPS=file
     GNOCCHI_TEST_DEBUG=1
 deps =
     {[testenv:docs]deps}
-    setuptools
 commands =
     /bin/rm -rf doc/build/html
     pifpaf -g GNOCCHI_INDEXER_URL run postgresql -- sphinx-build -W --keep-going -b html -j auto doc/source doc/build/html

--- a/tox.ini
+++ b/tox.ini
@@ -63,12 +63,12 @@ deps =
    {[testenv]deps}
    sqlalchemy<2
 
-[testenv:{py39,py311}-postgresql-file-upgrade-from-4.4]
+[testenv:{py39,py311}-postgresql-file-upgrade-from-4.5]
 # We should always recreate since the script upgrade
 # Gnocchi we can't reuse the virtualenv
 recreate = True
 setenv =
-    GNOCCHI_VERSION_FROM=stable/4.4
+    GNOCCHI_VERSION_FROM=stable/4.5
     GNOCCHI_VARIANT=test,postgresql,file
 deps =
     gnocchiclient>=2.8.0,!=7.0.7
@@ -77,12 +77,12 @@ deps =
 commands = {toxinidir}/run-upgrade-tests.sh postgresql-file
 allowlist_externals = {toxinidir}/run-upgrade-tests.sh
 
-[testenv:{py39,py311}-mysql-ceph-upgrade-from-4.4]
+[testenv:{py39,py311}-mysql-ceph-upgrade-from-4.5]
 # We should always recreate since the script upgrade
 # Gnocchi we can't reuse the virtualenv
 recreate = True
 setenv =
-    GNOCCHI_VERSION_FROM=stable/4.4
+    GNOCCHI_VERSION_FROM=stable/4.5
     GNOCCHI_VARIANT=test,mysql,ceph,ceph_recommended_lib
 deps =
     gnocchiclient>=2.8.0,!=7.0.7


### PR DESCRIPTION
It seems the setuptools library is no longer available in the base Ubuntu 22.04 image (or its python packages).