### PR TITLE
Install setuptools

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ passenv =
     GNOCCHI_TEST_*
     AWS_*
 setenv =
+    VIRTUALENV_SETUPTOOLS=bundle
     GNOCCHI_TEST_STORAGE_DRIVER=file
     GNOCCHI_TEST_INDEXER_DRIVER=postgresql
     GNOCCHI_TEST_STORAGE_DRIVERS=file swift ceph s3 redis
@@ -62,6 +63,7 @@ commands =
 # Gnocchi we can't reuse the virtualenv
 recreate = True
 setenv =
+  VIRTUALENV_SETUPTOOLS=bundle
   GNOCCHI_VERSION_FROM=stable/4.4
   GNOCCHI_VARIANT=test,postgresql,file
 deps =
@@ -78,6 +80,7 @@ commands = {toxinidir}/run-upgrade-tests.sh postgresql-file
 # Gnocchi we can't reuse the virtualenv
 recreate = True
 setenv =
+  VIRTUALENV_SETUPTOOLS=bundle
   GNOCCHI_VERSION_FROM=stable/4.4
   GNOCCHI_VARIANT=test,mysql,ceph,ceph_recommended_lib
 deps =
@@ -131,7 +134,9 @@ basepython = python3.9
 deps =
     .[test,file,postgresql,doc]
     doc8
-setenv = GNOCCHI_TEST_DEBUG=1
+setenv =
+    VIRTUALENV_SETUPTOOLS=bundle
+    GNOCCHI_TEST_DEBUG=1
 commands = doc8 --ignore-path doc/source/rest.rst,doc/source/comparison-table.rst doc/source
            pifpaf -g GNOCCHI_INDEXER_URL run postgresql -- sphinx-build -W --keep-going -b html -j auto doc/source doc/build/html
 
@@ -140,11 +145,12 @@ basepython = python3.9
 whitelist_externals =
     /bin/bash
     /bin/rm
-setenv = GNOCCHI_STORAGE_DEPS=file
-         GNOCCHI_TEST_DEBUG=1
+setenv =
+    VIRTUALENV_SETUPTOOLS=bundle
+    GNOCCHI_STORAGE_DEPS=file
+    GNOCCHI_TEST_DEBUG=1
 install_command = pip install -U {opts} {packages}
 deps = {[testenv:docs]deps}
-       setuptools
 commands =
     /bin/rm -rf doc/build/html
     pifpaf -g GNOCCHI_INDEXER_URL run postgresql -- sphinx-build -W --keep-going -b html -j auto doc/source doc/build/html


### PR DESCRIPTION
It seems the setuptools library is no longer installed by default.

Co-Authored-By: @kajinamit
(cherry picked from commit 74c81c79c57fbccdea55b056e3edb6a5e425e0d9)