### PR TITLE
Test Python 3.12 on Ubuntu 24.04 LTS

### DIFF
--- a/.github/workflows/gnocchi.yml
+++ b/.github/workflows/gnocchi.yml
@@ -110,6 +110,7 @@ jobs:
         python:
           - py39
           - py311
+          - py312
         env:
           - mysql-ceph-upgrade-from-4.5
           - postgresql-file-upgrade-from-4.5

--- a/.github/workflows/gnocchi.yml
+++ b/.github/workflows/gnocchi.yml
@@ -137,6 +137,11 @@ jobs:
             python: py311
           - env: postgresql-ceph
             python: py311
+          # TODO(tobias-urdin): We need to fix below Ceph jobs
+          - env: mysql-ceph
+            python: py312
+          - env: postgresql-ceph
+            python: py312
     steps:
       - uses: actions/checkout@v4
       - run: sudo chown -R 1001:1001 $GITHUB_WORKSPACE

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -26,6 +26,18 @@ queue_rules:
     - check-success=test (py311, postgresql-file-sqlalchemy14)
     - check-success=test (py311, postgresql-swift)
     - check-success=test (py311, postgresql-s3)
+    - check-success=test (py312, mysql-ceph-upgrade-from-4.5)
+    - check-success=test (py312, postgresql-file-upgrade-from-4.5)
+    - check-success=test (py312, mysql-file)
+    - check-success=test (py312, mysql-file-sqlalchemy14)
+    - check-success=test (py312, mysql-swift)
+    - check-success=test (py312, mysql-s3)
+    - check-success=test (py312, mysql-ceph)
+    - check-success=test (py312, postgresql-file)
+    - check-success=test (py312, postgresql-file-sqlalchemy14)
+    - check-success=test (py312, postgresql-swift)
+    - check-success=test (py312, postgresql-s3)
+    - check-success=test (py312, postgresql-ceph)
 
 pull_request_rules:
   - name: automatic merge
@@ -61,6 +73,18 @@ pull_request_rules:
     - check-success=test (py311, postgresql-file-sqlalchemy14)
     - check-success=test (py311, postgresql-swift)
     - check-success=test (py311, postgresql-s3)
+    - check-success=test (py312, mysql-ceph-upgrade-from-4.5)
+    - check-success=test (py312, postgresql-file-upgrade-from-4.5)
+    - check-success=test (py312, mysql-file)
+    - check-success=test (py312, mysql-file-sqlalchemy14)
+    - check-success=test (py312, mysql-swift)
+    - check-success=test (py312, mysql-s3)
+    - check-success=test (py312, mysql-ceph)
+    - check-success=test (py312, postgresql-file)
+    - check-success=test (py312, postgresql-file-sqlalchemy14)
+    - check-success=test (py312, postgresql-swift)
+    - check-success=test (py312, postgresql-s3)
+    - check-success=test (py312, postgresql-ceph)
 
   - name: automatic merge backports from Mergify
     actions:

--- a/images/Dockerfile.ci
+++ b/images/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 ENV GNOCCHI_WORKSPACE /github/workspace
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -15,6 +15,7 @@ RUN apt-get update -y && apt-get install -qy \
         python3 \
         python3-dev \
         python3-pip \
+        python3-virtualenv \
         python3.9 \
         python3.9-dev \
         python3.9-distutils \
@@ -54,9 +55,6 @@ RUN sed -i '1s/^/from __future__ import annotations\n/' /usr/lib/python3/dist-pa
 ENV LANG en_US.UTF-8
 RUN update-locale
 RUN locale-gen $LANG
-
-#NOTE(sileht): Upgrade python dev tools
-RUN python3 -m pip install -U pip tox virtualenv
 
 RUN npm install s3rver@3.7.0 --global
 

--- a/images/entrypoint.sh.ci
+++ b/images/entrypoint.sh.ci
@@ -1,2 +1,7 @@
 #!/bin/sh
+
+python3 -m virtualenv /tmp/gnocchi-tox-env
+. /tmp/gnocchi-tox-env/bin/activate
+pip install tox
+
 $@

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,8 @@ setenv =
 deps =
     .[test,redis,prometheus,amqp1,{env:GNOCCHI_STORAGE_DEPS:},{env:GNOCCHI_INDEXER_DEPS:}]
     {env:GNOCCHI_TEST_TARBALLS:}
+    # TODO(tobias-urdin): Remove when Ubuntu doesn't have a mangled Ceph version.
+    git+https://github.com/tobias-urdin/pifpaf@2d0890b7efb7af50172a95e5065a51d7871e8a76
     cliff!=2.9.0
     gnocchiclient>=2.8.0,!=7.0.7
 commands =
@@ -73,8 +75,9 @@ setenv =
     GNOCCHI_VERSION_FROM=stable/4.5
     GNOCCHI_VARIANT=test,postgresql,file
 deps =
+    # TODO(tobias-urdin): Remove when Ubuntu doesn't have a mangled Ceph version.
+    git+https://github.com/tobias-urdin/pifpaf@2d0890b7efb7af50172a95e5065a51d7871e8a76
     gnocchiclient>=2.8.0,!=7.0.7
-    pifpaf
     xattr!=0.9.4
 commands = {toxinidir}/run-upgrade-tests.sh postgresql-file
 allowlist_externals = {toxinidir}/run-upgrade-tests.sh
@@ -88,8 +91,9 @@ setenv =
     GNOCCHI_VERSION_FROM=stable/4.5
     GNOCCHI_VARIANT=test,mysql,ceph,ceph_recommended_lib
 deps =
+    # TODO(tobias-urdin): Remove when Ubuntu doesn't have a mangled Ceph version.
+    git+https://github.com/tobias-urdin/pifpaf@2d0890b7efb7af50172a95e5065a51d7871e8a76
     gnocchiclient>=2.8.0,!=7.0.7
-    pifpaf[ceph]
     xattr!=0.9.4
 commands = {toxinidir}/run-upgrade-tests.sh mysql-ceph
 allowlist_externals = {toxinidir}/run-upgrade-tests.sh

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.1
-envlist = {py39,py311}-{postgresql,mysql}{,-file,-file-sqlalchemy14,-swift,-ceph,-s3},pep8
+envlist = {py39,py311,py312}-{postgresql,mysql}{,-file,-file-sqlalchemy14,-swift,-ceph,-s3},pep8
 skipsdist = True
 
 [testenv]
@@ -59,12 +59,12 @@ allowlist_externals =
     {toxinidir}/run-tests.sh
     {toxinidir}/run-func-tests.sh
 
-[testenv:{py38,py39,py311}-{postgresql,mysql}-file-sqlalchemy14]
+[testenv:{py38,py39,py311,py312}-{postgresql,mysql}-file-sqlalchemy14]
 deps =
    {[testenv]deps}
    sqlalchemy<2
 
-[testenv:{py39,py311}-postgresql-file-upgrade-from-4.5]
+[testenv:{py39,py311,py312}-postgresql-file-upgrade-from-4.5]
 # We should always recreate since the script upgrade
 # Gnocchi we can't reuse the virtualenv
 recreate = True
@@ -79,7 +79,7 @@ deps =
 commands = {toxinidir}/run-upgrade-tests.sh postgresql-file
 allowlist_externals = {toxinidir}/run-upgrade-tests.sh
 
-[testenv:{py39,py311}-mysql-ceph-upgrade-from-4.5]
+[testenv:{py39,py311,py312}-mysql-ceph-upgrade-from-4.5]
 # We should always recreate since the script upgrade
 # Gnocchi we can't reuse the virtualenv
 recreate = True
@@ -99,12 +99,12 @@ deps = build
 commands = python -m build
 
 [testenv:pep8]
-deps = hacking>=3.2.0,<4.0.0
+deps = hacking>=3.2.0,<8.0.0
 commands = flake8 {posargs}
 allowlist_externals =
     /usr/bin/flake8
 
-[testenv:{py39,py311}-cover]
+[testenv:{py39,py311,py312}-cover]
 setenv =
     {[testenv]setenv}
     PYTHON=coverage run --source gnocchi --parallel-mode


### PR DESCRIPTION
* Use Ubuntu 24.04 LTS for Docker image
* Add testing for Python 3.12 (we now test 3.9, 3.11 and 3.12)
* We still don't test Ceph jobs (they have been disabled for a while due to rados timeouts) – this needs to be fixed in the future
* Install virtualenv from disto package
* Use a virtualenv for tox to not interfere with distro
* Use my Pifpaf fork that includes commit https://github.com/tobias-urdin/pifpaf@2d0890b7efb7af50172a95e5065a51d7871e8a76 because Ubuntu 24.04 LTS packages Ceph 19.2.0 with a version containing a `~<git commit>` suffix that packaging doesn't like, this is because Ubuntu packaged Ceph 19.2.0 before it was released officially
* Pin hacking to a newer version so that we get atleast 7.0.0 that has Python 3.12 support