### PR TITLE
flake8: excludes more directories

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -120,7 +120,7 @@ commands =
     coverage report
 
 [flake8]
-exclude = .tox,.local,.eggs,doc,gnocchi/rest/prometheus/remote_pb2.py,gnocchi/indexer/alembic/versions/
+exclude = .venv,.git,.tox,.local,*egg,dist,doc,build,gnocchi/rest/prometheus/remote_pb2.py,gnocchi/indexer/alembic/versions/
 show-source = true
 enable-extensions = H904
 ignore = E501,E731,W503,W504


### PR DESCRIPTION
A few directories (expecially build) may include files which cause undesired errors.