### PR TITLE
Revert "Use custom pifpaf"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -50,8 +50,6 @@ setenv =
 deps =
     .[test,redis,prometheus,amqp1,{env:GNOCCHI_STORAGE_DEPS:},{env:GNOCCHI_INDEXER_DEPS:}]
     {env:GNOCCHI_TEST_TARBALLS:}
-    # TODO(tobias-urdin): Remove when Ubuntu doesn't have a mangled Ceph version.
-    git+https://github.com/tobias-urdin/pifpaf@2d0890b7efb7af50172a95e5065a51d7871e8a76
     cliff!=2.9.0
     gnocchiclient>=2.8.0,!=7.0.7
 commands =
@@ -75,9 +73,8 @@ setenv =
     GNOCCHI_VERSION_FROM=stable/4.5
     GNOCCHI_VARIANT=test,postgresql,file
 deps =
-    # TODO(tobias-urdin): Remove when Ubuntu doesn't have a mangled Ceph version.
-    git+https://github.com/tobias-urdin/pifpaf@2d0890b7efb7af50172a95e5065a51d7871e8a76
     gnocchiclient>=2.8.0,!=7.0.7
+    pifpaf
     xattr!=0.9.4
 commands = {toxinidir}/run-upgrade-tests.sh postgresql-file
 allowlist_externals = {toxinidir}/run-upgrade-tests.sh
@@ -91,9 +88,8 @@ setenv =
     GNOCCHI_VERSION_FROM=stable/4.5
     GNOCCHI_VARIANT=test,mysql,ceph,ceph_recommended_lib
 deps =
-    # TODO(tobias-urdin): Remove when Ubuntu doesn't have a mangled Ceph version.
-    git+https://github.com/tobias-urdin/pifpaf@2d0890b7efb7af50172a95e5065a51d7871e8a76
     gnocchiclient>=2.8.0,!=7.0.7
+    pifpaf[ceph]
     xattr!=0.9.4
 commands = {toxinidir}/run-upgrade-tests.sh mysql-ceph
 allowlist_externals = {toxinidir}/run-upgrade-tests.sh


### PR DESCRIPTION
The 3.2.2 release of pifpaf includes the
Ceph fix that we need.

This reverts commit a537a58ad8d735ada17bd7c96a6cf3f2b0a24ec2.