### PR TITLE
Swift: Allow configuring container storage policies

### DIFF
--- a/releasenotes/notes/swift-storage-policy-fa2d73d8714e3a03.yaml
+++ b/releasenotes/notes/swift-storage-policy-fa2d73d8714e3a03.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    The Swift storage driver can now be configured to create containers
+    with a custom storage policy using the ``swift_storage_policy``
+    option. This allows for overriding the storage policy when using
+    the default policy is not desirable, e.g. to limit object replication
+    to a single region when multi-region replication is the default.


### PR DESCRIPTION
This adds the `swift_storage_policy` configuration option for setting the storage policy Gnocchi will use when creating new Swift containers.

When unset the storage policy will not be configured when creating containers, in which case Swift will use the default storage policy.