### PR TITLE
Bump minimum python version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ description = Metric as a Service
 long_description = file: README.rst
 long_description_content_type = text/x-rst
 author = Gnocchi developers
-python_requires = >=3.8
+python_requires = >=3.9
 classifier =
     Intended Audience :: Information Technology
     Intended Audience :: System Administrators
@@ -14,9 +14,10 @@ classifier =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: System :: Monitoring
 
 [options]


### PR DESCRIPTION
Python 3.8 already reached its EOL and was removed from test coverage.