### PR TITLE
Remove default override for policy_file option

### DIFF
--- a/gnocchi/cli/api.py
+++ b/gnocchi/cli/api.py
@@ -21,7 +21,6 @@ import sys
 
 import daiquiri
 from oslo_config import cfg
-from oslo_policy import opts as policy_opts
 
 from gnocchi import opts
 from gnocchi.rest import app
@@ -37,7 +36,6 @@ def prepare_service(conf=None):
         conf = cfg.ConfigOpts()
 
     opts.set_defaults()
-    policy_opts.set_defaults(conf, 'policy.yaml')
 
     conf = service.prepare_service(conf=conf)
     return conf

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     numpy>=1.14.0
     iso8601
     oslo.config>=3.22.0
-    oslo.policy>=3.5.0
+    oslo.policy>=4.5.0
     oslo.middleware>=3.22.0
     oslo.utils>=1.1.1
     pytimeparse


### PR DESCRIPTION
oslo.policy 4.5.0[1] changed the default value of `[oslo_policy] policy_file` to use yaml file by default.

[1] https://opendev.org/openstack/oslo.policy/commit/26b04a4a803b21f8dc5ea7e3bc6ca76bf3144cfc