### PR TITLE
Fix running functional tests with NumPy 2.2

### DIFF
--- a/gnocchi/tests/test_carbonara.py
+++ b/gnocchi/tests/test_carbonara.py
@@ -316,7 +316,7 @@ class TestAggregatedTimeSerie(base.BaseTestCase):
         ts = carbonara.TimeSerie.from_data(
             [datetime64(2014, 1, 1, 12, 0, 0)], [3])
         ts = self._resample(ts, numpy.timedelta64(60, 's'), 'std')
-        self.assertEqual(0, len(ts), ts.values)
+        self.assertEqual(0, len(ts), str(ts.values))
 
         ts = carbonara.TimeSerie.from_data(
             [datetime64(2014, 1, 1, 12, 0, 0),


### PR DESCRIPTION
`testcase` performs an `if not` check on annotations passed in asserts.

From NumPy 2.2 this raises an exception about ambiguous falseyness [1], so convert the array to a string when passing it as an annotation to get around this.

[1]: https://numpy.org/devdocs/release/2.2.0-notes.html#expired-deprecations