### PR TITLE
Increase string attribute max length to 256 chars

### DIFF
--- a/gnocchi/resource_type.py
+++ b/gnocchi/resource_type.py
@@ -141,9 +141,9 @@ class StringSchema(CommonAttributeSchema):
 
     meta_schema_ext = {
         voluptuous.Required('min_length', default=0):
-        voluptuous.All(int, voluptuous.Range(min=0, max=255)),
-        voluptuous.Required('max_length', default=255):
-        voluptuous.All(int, voluptuous.Range(min=1, max=255))
+        voluptuous.All(int, voluptuous.Range(min=0, max=256)),
+        voluptuous.Required('max_length', default=256):
+        voluptuous.All(int, voluptuous.Range(min=1, max=256))
     }
 
     @property

--- a/gnocchi/tests/functional/gabbits/resource-type.yaml
+++ b/gnocchi/tests/functional/gabbits/resource-type.yaml
@@ -146,7 +146,7 @@ tests:
               foobar:
                   type: string
                   required: False
-                  max_length: 255
+                  max_length: 256
                   min_length: 0
               uuid:
                   type: uuid
@@ -200,7 +200,7 @@ tests:
                   type: string
                   required: False
                   min_length: 0
-                  max_length: 255
+                  max_length: 256
               uuid:
                   type: uuid
                   required: True

--- a/releasenotes/notes/string-attribute-max-length-33e037494a0e318c.yaml
+++ b/releasenotes/notes/string-attribute-max-length-33e037494a0e318c.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    The maximum allowed length for string-type resource attributes has been
+    increased from 255 to 256 characters. This allows creating attributes
+    that accept values up to 256 characters long e.g. Swift container names.


### PR DESCRIPTION
Increase the maximum supported length for string type resource attributes from 255 to 256 characters, to allow creating string attributes on resources that accept values of such length (e.g. Swift container names).