### PR TITLE
Fix listing metrics as non-admin without creator policy defined

### DIFF
--- a/gnocchi/rest/api.py
+++ b/gnocchi/rest/api.py
@@ -698,7 +698,7 @@ class MetricsController(rest.RestController):
             attr_filters.append({"=": {k: v}})
 
         policy_filter = pecan.request.auth_helper.get_metric_policy_filter(
-            pecan.request, "list metric")
+            pecan.request, "list metric", allow_resource_project_id=True)
         resource_policy_filter = (
             pecan.request.auth_helper.get_resource_policy_filter(
                 pecan.request, "list metric", resource_type=None,


### PR DESCRIPTION
When using a minimal RBAC policy that only allows either access either to a cloud admin or a user that is part of the project a metric's resource is owned by, e.g.

```yaml
"list metric": "role:admin or project_id:%(resource.project_id)s"
```

There is an issue where `KeystoneAuthHelper.get_metric_policy_filter` will reject access to the metrics because from its perspective there are no applicable policies that the user has permission under.

This patch fixes that by adding an option to `get_metric_policy_filter` that allows an empty policy filter to be returned if an enforcement check for `resource.project_id` passes. This option is set to `False` by default, and only enabled where necessary.

This allows the caller to use `KeystoneAuthHelper.get_resource_policy_filter` to add project filters to the metric query based on the resource the metric is associated with.