### PR TITLE
Fix metric aggregates as non-admin

### DIFF
--- a/gnocchi/rest/aggregates/api.py
+++ b/gnocchi/rest/aggregates/api.py
@@ -612,7 +612,8 @@ class AggregatesController(rest.RestController):
                                 "detail": references})
 
             metrics = pecan.request.indexer.list_metrics(
-                attribute_filter={"in": {"id": metric_ids}})
+                attribute_filter={"in": {"id": metric_ids}},
+                details=True)
             missing_metric_ids = (set(metric_ids)
                                   - set(str(m.id) for m in metrics))
             if missing_metric_ids:


### PR DESCRIPTION
When using the aggregates API with a metric ID, the RBAC policy `project_id:%(resource.project_id)s"` fails to authenticate a non-admin user that is part of the project the metric is also part of via its resource relationship.

This patch fixes two issues preventing this from working:

* Set `details=True` when listing specified metrics to ensure the joined load with the `Metric` and `Resource` models is done.
* Add support for processing oslo.db SQLAlchemy models in `gnocchi.rest.api.flatten_dict_to_keypairs` to make sure nested attributes are added to the list of targets passed to the policy enforcer.