### PR TITLE
Swift: Add a config option for prefixing all containers

### DIFF
--- a/gnocchi/storage/swift.py
+++ b/gnocchi/storage/swift.py
@@ -67,6 +67,16 @@ OPTS = [
     cfg.StrOpt('swift_container_prefix',
                default='gnocchi',
                help='Prefix to namespace metric containers.'),
+    cfg.BoolOpt('swift_container_prefix_all',
+                default=False,
+                help='Prefix not just metric containers, but all '
+                     'Swift containers created by Gnocchi for the '
+                     'namespace defined in swift_container_prefix. '
+                     'This allows multiple Gnocchi deployments using '
+                     'the Swift storage driver to share the same project. '
+                     'NOTE: This should be either enabled or disabled ONCE '
+                     'for NEW Gnocchi deployments. This cannot be changed '
+                     'for existing deployments.'),
     cfg.StrOpt('swift_storage_policy',
                default=None,
                help='Storage policy to use when creating containers. '


### PR DESCRIPTION
The `swift_container_prefix` option by itself only prefixes the containers created for metric storage.

This is not enough to allow multiple Gnocchi deployments to share the same OpenStack project, as additional containers are created for Gnocchi configuration as well as for incoming metric storage, if Swift is also used as the incoming storage driver.

This adds a new `swift_container_prefix_all` flag for enabling prepending `swift_container_prefix` to **all** Swift containers that can be made by Gnocchi.

This allows new deployments of Gnocchi to be configured in a way that multiple deployments can share the project (e.g. a service project in a multi-region cloud). Unfortunately, existing Gnocchi deployments cannot easily be reconfigured to enable prefixes, nor can the prefix easily be changed.

Fixes #1067.