### PR TITLE
Run metricd more frequently in functional tests

### DIFF
--- a/gnocchi/tests/functional/fixtures.py
+++ b/gnocchi/tests/functional/fixtures.py
@@ -273,7 +273,7 @@ class MetricdThread(threading.Thread):
         while self.flag:
             for sack in self.chef.incoming.iter_sacks():
                 self.chef.process_new_measures_for_sack(sack, blocking=True)
-            time.sleep(0.1)
+            time.sleep(0.01)
 
     def stop(self):
         self.flag = False


### PR DESCRIPTION
The metricd thread in the functional tests waits for 100ms between runs.

This is actually quite a long time to wait, as the functional tests can run much faster than that. This results in a race condition where earlier tests submit measures, and they are not actually processed by the time the test that needs them is run, and fails because they are not done (and there's no waits or retries or anything).

Tighten up the metricd thread loop so that it waits only 10ms between runs. This will increase load but the more frequent runs should be good enough for the tests to pass.