### PR TITLE
Change upgrade test validation in Main

### DIFF
--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -195,8 +195,8 @@ class GroupedTimeSeries(object):
         ordered = numpy.lexsort((self._ts['values'], self.indexes))
         min_pos = numpy.cumsum(self.counts) - self.counts
         real_pos = min_pos + (self.counts - 1) * (q / 100)
-        floor_pos = numpy.floor(real_pos).astype(numpy.integer, copy=False)
-        ceil_pos = numpy.ceil(real_pos).astype(numpy.integer, copy=False)
+        floor_pos = numpy.floor(real_pos).astype(numpy.int64, copy=False)
+        ceil_pos = numpy.ceil(real_pos).astype(numpy.int64, copy=False)
         values = (
             self._ts['values'][ordered][floor_pos] * (ceil_pos - real_pos) +
             self._ts['values'][ordered][ceil_pos] * (real_pos - floor_pos))
@@ -774,7 +774,7 @@ class AggregatedTimeSerie(TimeSerie):
         first = self.first  # NOTE(jd) needed because faster
         e_offset = int((self.last - first) / offset_div) + 1
 
-        locs = numpy.zeros(self.timestamps.size, dtype=numpy.integer)
+        locs = numpy.zeros(self.timestamps.size, dtype=numpy.int64)
         locs[1:] = numpy.cumsum(numpy.diff(self.timestamps)) / offset_div
 
         # Fill everything with zero and set

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,7 +96,7 @@ doc =
     reno>=1.6.2
 test =
     pifpaf[ceph,gnocchi]
-    gabbi>=1.37.0
+    gabbi>=1.37.0,<4
     coverage>=3.6
     fixtures
     python-subunit>=0.0.18

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     iso8601
     oslo.config>=3.22.0
     oslo.policy>=4.5.0
-    oslo.middleware>=3.22.0,<6.4.0
+    oslo.middleware>=3.22.0
     oslo.utils>=1.1.1
     pytimeparse
     pecan>=0.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     iso8601
     oslo.config>=3.22.0
     oslo.policy>=4.5.0
-    oslo.middleware>=3.22.0
+    oslo.middleware>=3.22.0,<6.4.0
     oslo.utils>=1.1.1
     pytimeparse
     pecan>=0.9

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,7 @@ deps =
 recreate = True
 setenv =
     SETUPTOOLS_USE_DISTUTILS={env:SETUPTOOLS_USE_DISTUTILS:local}
-    GNOCCHI_VERSION_FROM=stable/4.5
+    GNOCCHI_VERSION_FROM=stable/4.6
     GNOCCHI_VARIANT=test,postgresql,file
 deps =
     gnocchiclient>=2.8.0,!=7.0.7
@@ -85,7 +85,7 @@ allowlist_externals = {toxinidir}/run-upgrade-tests.sh
 recreate = True
 setenv =
     SETUPTOOLS_USE_DISTUTILS={env:SETUPTOOLS_USE_DISTUTILS:local}
-    GNOCCHI_VERSION_FROM=stable/4.5
+    GNOCCHI_VERSION_FROM=stable/4.6
     GNOCCHI_VARIANT=test,mysql,ceph,ceph_recommended_lib
 deps =
     gnocchiclient>=2.8.0,!=7.0.7

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ deps =
    {[testenv]deps}
    sqlalchemy<2
 
-[testenv:{py39,py311,py312}-postgresql-file-upgrade-from-4.5]
+[testenv:{py39,py311,py312}-postgresql-file-upgrade-from-4.6]
 # We should always recreate since the script upgrade
 # Gnocchi we can't reuse the virtualenv
 recreate = True
@@ -79,7 +79,7 @@ deps =
 commands = {toxinidir}/run-upgrade-tests.sh postgresql-file
 allowlist_externals = {toxinidir}/run-upgrade-tests.sh
 
-[testenv:{py39,py311,py312}-mysql-ceph-upgrade-from-4.5]
+[testenv:{py39,py311,py312}-mysql-ceph-upgrade-from-4.6]
 # We should always recreate since the script upgrade
 # Gnocchi we can't reuse the virtualenv
 recreate = True


### PR DESCRIPTION
As discussed in https://github.com/gnocchixyz/gnocchi/pull/1450#issuecomment-2876210849, we will change the upgrade tests to check against stable/4.6. The idea is to remove/deprecate stable/4.5 branch.