### PR TITLE
Add more indexes to the resource_history table

### DIFF
--- a/gnocchi/indexer/alembic/versions/6291a0f71cf6_add_new_indexes.py
+++ b/gnocchi/indexer/alembic/versions/6291a0f71cf6_add_new_indexes.py
@@ -1,0 +1,38 @@
+# Copyright 2025 The Gnocchi Developers
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+
+"""empty message
+
+Revision ID: 6291a0f71cf6
+Revises: 04eba72e4f90
+Create Date: 2025-06-03 11:37:12.161253
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '6291a0f71cf6'
+down_revision = '04eba72e4f90'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index('fk_resource_history_resource_project_id', 'resource_history', ['project_id'], unique=False)
+    op.create_index('fk_resource_history_resource_revision_start', 'resource_history', ['revision_start'], unique=False)
+    op.create_index('fk_resource_history_resource_revision_end', 'resource_history', ['revision_end'], unique=False)


### PR DESCRIPTION
With many resources, Gnocchi cannot handle its own queries, and one may experience very slow queries.

Adding these 3 indexes fixes everything.

Example of problematic requests:

SELECT
    result.creator AS result_creator,
    result.started_at AS result_started_at,
    result.revision_start AS result_revision_start,
    result.ended_at AS result_ended_at,
    result.user_id AS result_user_id,
    result.project_id AS result_project_id,
    result.original_resource_id AS result_original_resource_id,
    result.revision AS result_revision,
    result.id AS result_id,
    result.revision_end AS result_revision_end,
    result.type AS result_type,
    result.flavor_id AS result_flavor_id,
    result.image_ref AS result_image_ref,
    result.host AS result_host,
    result.display_name AS result_display_name,
    result.server_group AS result_server_group,
    result.flavor_name AS result_flavor_name,
    result.launched_at AS result_launched_at,
    result.created_at AS result_created_at,
    result.deleted_at AS result_deleted_at,
    result.availability_zone AS result_availability_zone,
    result.os_family AS result_os_family,
    result.os_distro AS result_os_distro,
    result.os_info AS result_os_info,
    archive_policy_1.name AS archive_policy_1_name,
    archive_policy_1.back_window AS archive_policy_1_back_window,
    archive_policy_1.definition AS archive_policy_1_definition,
    archive_policy_1.aggregation_methods AS archive_policy_1_aggregation_methods,
    metric_1.id AS metric_1_id,
    metric_1.archive_policy_name AS metric_1_archive_policy_name,
    metric_1.creator AS metric_1_creator,
    metric_1.resource_id AS metric_1_resource_id,
    metric_1.name AS metric_1_name,
    metric_1.unit AS metric_1_unit,
    metric_1.status AS metric_1_status
FROM (
    SELECT
        resource_history.creator,
        resource_history.started_at,
        resource_history.revision_start,
        resource_history.ended_at,
        resource_history.user_id,
        resource_history.project_id,
        resource_history.original_resource_id,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746_history.revision,
        resource_history.id,
        resource_history.revision_end,
        resource_history.type,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746_history.flavor_id,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746_history.image_ref,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746_history.host,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746_history.display_name,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746_history.server_group,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746_history.flavor_name,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746_history.launched_at,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746_history.created_at,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746_history.deleted_at,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746_history.availability_zone,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746_history.os_family,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746_history.os_distro,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746_history.os_info
    FROM
        resource_history,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746_history
    WHERE
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746_history.revision = resource_history.revision

    UNION

    SELECT
        resource.creator,
        resource.started_at,
        resource.revision_start,
        resource.ended_at,
        resource.user_id,
        resource.project_id,
        resource.original_resource_id,
        -1 AS revision,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746.id,
        NULL AS revision_end,
        resource.type,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746.flavor_id,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746.image_ref,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746.host,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746.display_name,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746.server_group,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746.flavor_name,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746.launched_at,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746.created_at,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746.deleted_at,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746.availability_zone,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746.os_family,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746.os_distro,
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746.os_info
    FROM
        resource
    INNER JOIN
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746
        ON resource.id = rt_cb477cc7ea324ea18b0dd4fbb6bdb746.id
    WHERE
        rt_cb477cc7ea324ea18b0dd4fbb6bdb746.id = resource.id
) AS result
LEFT OUTER JOIN metric AS metric_1
    ON metric_1.resource_id = result.id
    AND metric_1.status = 'active'
LEFT OUTER JOIN archive_policy AS archive_policy_1
    ON archive_policy_1.name = metric_1.archive_policy_name
WHERE
    result.revision_start < '2025-06-01 03:00:00'
    AND (
        result.revision_end >= '2025-06-01 02:00:00'
        OR result.revision_end IS NULL
    )
    AND result.type = 'instance'
    AND result.project_id = '7e3975ba5a524a0685df8c9dfb0ffed2'
ORDER BY
    result.id ASC,
    result.project_id ASC,
    result.revision ASC;