### PR TITLE
dnm: Upgrade test from stable/4.6

### DIFF
--- a/.github/workflows/gnocchi.yml
+++ b/.github/workflows/gnocchi.yml
@@ -112,8 +112,8 @@ jobs:
           - py311
           - py312
         env:
-          - mysql-ceph-upgrade-from-4.5
-          - postgresql-file-upgrade-from-4.5
+          - mysql-ceph-upgrade-from-4.6
+          - postgresql-file-upgrade-from-4.6
           - mysql-file
           - mysql-file-sqlalchemy14
           - mysql-swift
@@ -125,13 +125,13 @@ jobs:
           - postgresql-s3
           - postgresql-ceph
         exclude:
-          - env: mysql-ceph-upgrade-from-4.5
+          - env: mysql-ceph-upgrade-from-4.6
             python: py39
           - env: mysql-ceph
             python: py39
           - env: postgresql-ceph
             python: py39
-          - env: mysql-ceph-upgrade-from-4.5
+          - env: mysql-ceph-upgrade-from-4.6
             python: py311
           - env: mysql-ceph
             python: py311

--- a/gnocchi/tests/functional/fixtures.py
+++ b/gnocchi/tests/functional/fixtures.py
@@ -53,7 +53,7 @@ LOAD_APP_KWARGS = None
 
 def setup_app():
     global LOAD_APP_KWARGS
-    return app.load_app(**LOAD_APP_KWARGS)
+    return app.load_app(**(LOAD_APP_KWARGS or {}))
 
 
 class AssertNAN(yaml.YAMLObject):

--- a/tox.ini
+++ b/tox.ini
@@ -64,13 +64,13 @@ deps =
    {[testenv]deps}
    sqlalchemy<2
 
-[testenv:{py39,py311,py312}-postgresql-file-upgrade-from-4.5]
+[testenv:{py39,py311,py312}-postgresql-file-upgrade-from-4.6]
 # We should always recreate since the script upgrade
 # Gnocchi we can't reuse the virtualenv
 recreate = True
 setenv =
     SETUPTOOLS_USE_DISTUTILS={env:SETUPTOOLS_USE_DISTUTILS:local}
-    GNOCCHI_VERSION_FROM=stable/4.5
+    GNOCCHI_VERSION_FROM=stable/4.6
     GNOCCHI_VARIANT=test,postgresql,file
 deps =
     gnocchiclient>=2.8.0,!=7.0.7
@@ -79,13 +79,13 @@ deps =
 commands = {toxinidir}/run-upgrade-tests.sh postgresql-file
 allowlist_externals = {toxinidir}/run-upgrade-tests.sh
 
-[testenv:{py39,py311,py312}-mysql-ceph-upgrade-from-4.5]
+[testenv:{py39,py311,py312}-mysql-ceph-upgrade-from-4.6]
 # We should always recreate since the script upgrade
 # Gnocchi we can't reuse the virtualenv
 recreate = True
 setenv =
     SETUPTOOLS_USE_DISTUTILS={env:SETUPTOOLS_USE_DISTUTILS:local}
-    GNOCCHI_VERSION_FROM=stable/4.5
+    GNOCCHI_VERSION_FROM=stable/4.6
     GNOCCHI_VARIANT=test,mysql,ceph,ceph_recommended_lib
 deps =
     gnocchiclient>=2.8.0,!=7.0.7


### PR DESCRIPTION
... instead of upgrading from 4.5 use 4.6 which
is the version that is most up-to-date.