### PR TITLE
Define ResourceHistory.metrics relationship overlap

### DIFF
--- a/gnocchi/indexer/sqlalchemy_base.py
+++ b/gnocchi/indexer/sqlalchemy_base.py
@@ -313,7 +313,8 @@ class ResourceHistory(ResourceMixin, Base, GnocchiBase):
                                      nullable=False,
                                      default=lambda: utils.utcnow())
     metrics = sqlalchemy.orm.relationship(
-        Metric, primaryjoin="Metric.resource_id == ResourceHistory.id",
+        Metric, overlaps="metrics,resource",
+        primaryjoin="Metric.resource_id == ResourceHistory.id",
         foreign_keys='Metric.resource_id')
 
 


### PR DESCRIPTION
Set `overlaps="metrics,resource"` on the `ResourceHistory.metrics` relationship defining a one-to-many relationship between resource history columns and metrics mapped to the resource.

This lets SQLAlchemy know to expect an overlap for the relationships between `Metric`, `Resource` and `ResourceHistory`, suppressing a warning output when the table schema is loaded. Because `back_populates` is configured to go between `Metric` and `Resource`, `ResourceHistory` rows should not be returned when `Metric.resource` is used.

Fixes #1406.