### PR TITLE
[stable/4.6] Fix NumPy 2.3 support and test runs

### DIFF
--- a/gnocchi/carbonara.py
+++ b/gnocchi/carbonara.py
@@ -195,8 +195,8 @@ class GroupedTimeSeries(object):
         ordered = numpy.lexsort((self._ts['values'], self.indexes))
         min_pos = numpy.cumsum(self.counts) - self.counts
         real_pos = min_pos + (self.counts - 1) * (q / 100)
-        floor_pos = numpy.floor(real_pos).astype(numpy.integer, copy=False)
-        ceil_pos = numpy.ceil(real_pos).astype(numpy.integer, copy=False)
+        floor_pos = numpy.floor(real_pos).astype(numpy.int64, copy=False)
+        ceil_pos = numpy.ceil(real_pos).astype(numpy.int64, copy=False)
         values = (
             self._ts['values'][ordered][floor_pos] * (ceil_pos - real_pos) +
             self._ts['values'][ordered][ceil_pos] * (real_pos - floor_pos))
@@ -774,7 +774,7 @@ class AggregatedTimeSerie(TimeSerie):
         first = self.first  # NOTE(jd) needed because faster
         e_offset = int((self.last - first) / offset_div) + 1
 
-        locs = numpy.zeros(self.timestamps.size, dtype=numpy.integer)
+        locs = numpy.zeros(self.timestamps.size, dtype=numpy.int64)
         locs[1:] = numpy.cumsum(numpy.diff(self.timestamps)) / offset_div
 
         # Fill everything with zero and set

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,8 +93,8 @@ doc =
     Jinja2
     reno>=1.6.2
 test =
-    pifpaf[ceph,gnocchi]>=1.0.1
-    gabbi>=1.37.0
+    pifpaf[gnocchi]
+    gabbi>=1.37.0,<4
     coverage>=3.6
     fixtures
     python-subunit>=0.0.18

--- a/tox.ini
+++ b/tox.ini
@@ -38,9 +38,9 @@ setenv =
     postgresql: GNOCCHI_INDEXER_DEPS=postgresql
 
     # FIXME(sileht): pbr doesn't support url in setup.cfg extras, so we do this crap
-    GNOCCHI_TEST_TARBALLS=http://tarballs.openstack.org/swift/swift-master.tar.gz#egg=swift
+    GNOCCHI_TEST_TARBALLS=swift@http://tarballs.openstack.org/swift/swift-master.tar.gz
     ceph: GNOCCHI_TEST_TARBALLS=
-    swift: GNOCCHI_TEST_TARBALLS=http://tarballs.openstack.org/swift/swift-master.tar.gz#egg=swift
+    swift: GNOCCHI_TEST_TARBALLS=swift@http://tarballs.openstack.org/swift/swift-master.tar.gz
     s3: GNOCCHI_TEST_TARBALLS=
     redis: GNOCCHI_TEST_TARBALLS=
     file: GNOCCHI_TEST_TARBALLS=
@@ -90,7 +90,7 @@ setenv =
   GNOCCHI_VARIANT=test,mysql,ceph,ceph_recommended_lib
 deps =
   gnocchiclient>=2.8.0,!=7.0.7
-  pifpaf[ceph]
+  pifpaf
   xattr!=0.9.4
 commands = {toxinidir}/run-upgrade-tests.sh mysql-ceph
 allowlist_externals = {toxinidir}/run-upgrade-tests.sh


### PR DESCRIPTION
* Change a number of dtype conversions from`np.integer` to the specific type `np.int64`. This fixes NumPy 2.3 compatibility.
* Pin Gabbi to an older version, as the Gnocchi test suite is currently incompatible with Gabbi 4.0.
* Disable broken tests that cannot easily be fixed at the moment.
* Fix warnings due to use of deprecated `pip` URL package references and extra requires that do not exist.

(cherry picked from commit 8c6ccbacee654df75eb43089a8998f7616538641)

Backport-Note: Partial backport of 8c6ccbacee654