### PR TITLE
Support returning boolean aggregates

### DIFF
--- a/gnocchi/json.py
+++ b/gnocchi/json.py
@@ -29,6 +29,8 @@ def to_primitive(obj):
         return str(obj)
     if isinstance(obj, datetime.datetime):
         return obj.isoformat()
+    if isinstance(obj, numpy.bool):
+        return float(obj)
     if isinstance(obj, numpy.datetime64):
         return numpy.datetime_as_string(obj, unit='s') + "+00:00"
     if isinstance(obj, numpy.timedelta64):

--- a/gnocchi/tests/functional/gabbits/aggregates-with-resources.yaml
+++ b/gnocchi/tests/functional/gabbits/aggregates-with-resources.yaml
@@ -328,6 +328,33 @@ tests:
           - ['2015-03-06T14:33:57+00:00', 1.0, 43.1]
           - ['2015-03-06T14:34:12+00:00', 1.0, 12.0]
 
+    - name: aggregate metric to boolean value
+      POST: /v1/aggregates?details=true
+      data:
+        resource_type: generic
+        search: "user_id = 'A50F549C-1F1C-4888-A71A-2C5473CCCEC1'"
+        operations: "(> (metric cpu.util mean) 20)"
+      poll:
+        count: 10
+        delay: 1
+      response_json_paths:
+        $.references.`len`: 3
+        $.references[/id].[0]: $HISTORY['list resources'].$RESPONSE['$[0]']
+        $.references[/id].[1]: $HISTORY['list resources'].$RESPONSE['$[1]']
+        $.references[/id].[2]: $HISTORY['list resources'].$RESPONSE['$[2]']
+        $.measures."$HISTORY['list resources'].$RESPONSE['$[0].id']"."cpu.util".mean:
+          - ['2015-03-06T14:30:00+00:00', 300.0, 1.0]
+          - ['2015-03-06T14:33:57+00:00', 1.0, 1.0]
+          - ['2015-03-06T14:34:12+00:00', 1.0, 0.0]
+        $.measures."$HISTORY['list resources'].$RESPONSE['$[1].id']"."cpu.util".mean:
+          - ['2015-03-06T14:30:00+00:00', 300.0, 0.0]
+          - ['2015-03-06T14:33:57+00:00', 1.0, 1.0]
+          - ['2015-03-06T14:34:12+00:00', 1.0, 0.0]
+        $.measures."$HISTORY['list resources'].$RESPONSE['$[2].id']"."cpu.util".mean:
+          - ['2015-03-06T14:30:00+00:00', 300.0, 1.0]
+          - ['2015-03-06T14:33:57+00:00', 1.0, 1.0]
+          - ['2015-03-06T14:34:12+00:00', 1.0, 1.0]
+
     - name: aggregate metric with groupby on project_id and user_id with aggregates API
       POST: /v1/aggregates?groupby=project_id&groupby=user_id&details=true
       data:


### PR DESCRIPTION
Some aggregates operations (e.g. `=`) return a `numpy.bool` object, and it is possible to get Gnocchi to return these, but the JSON encoder fails to encode them correctly.

This could be useful for some aggregations (e.g. checking status of OpenStack resources is a specific value), so add support to `gnocchi.json.to_primitive` for encoding `numpy.bool` to a floating-point number so it can be returned in aggregates queries as a `numbool`-style value.

Fixes #1473.