### PR TITLE
Remove wheel in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm", "wheel"]
+requires = ["setuptools", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
This is installed automatically by setuptools and
should not be specified, see [1].

[1] https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a