### PR TITLE
Get rid of pkg_resources

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -10,7 +10,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import pkg_resources
+import importlib.metadata
 
 # -- General configuration -----------------------------------------------------
 
@@ -38,7 +38,7 @@ copyright = 'The Gnocchi Developers'
 # built documents.
 #
 # The short X.Y version.
-release = pkg_resources.get_distribution('gnocchi').version
+release = importlib.metadata.version('gnocchi')
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/gnocchi/__init__.py
+++ b/gnocchi/__init__.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pkg_resources
+import importlib.metadata
 
 try:
-    __version__ = pkg_resources.get_distribution(__name__).version
-except pkg_resources.DistributionNotFound:
+    __version__ = importlib.metadata.version('gnocchi')
+except importlib.metadata.PackageNotFoundError:
     # package is not installed
     pass

--- a/gnocchi/opts.py
+++ b/gnocchi/opts.py
@@ -14,7 +14,7 @@
 import copy
 import itertools
 import operator
-import pkg_resources
+import sys
 import uuid
 
 from oslo_config import cfg
@@ -28,6 +28,11 @@ import gnocchi.storage.ceph
 import gnocchi.storage.file
 import gnocchi.storage.s3
 import gnocchi.storage.swift
+
+if sys.version_info < (3, 10, 0):
+    import importlib_metadata
+else:
+    from importlib import metadata as importlib_metadata
 
 
 # NOTE(sileht): The oslo.config interpolation is buggy when the value
@@ -182,12 +187,14 @@ def list_opts():
             cfg.StrOpt('paste_config',
                        default="api-paste.ini",
                        help='Path to API Paste configuration.'),
-            cfg.StrOpt('auth_mode',
-                       default="basic",
-                       choices=list(map(operator.attrgetter("name"),
-                                    pkg_resources.iter_entry_points(
-                                        "gnocchi.rest.auth_helper"))),
-                       help='Authentication mode to use.'),
+            cfg.StrOpt(
+                'auth_mode',
+                default="basic",
+                choices=list(map(
+                    operator.attrgetter("name"),
+                    importlib_metadata.entry_points(
+                        group='gnocchi.rest.auth_helper'))),
+                help='Authentication mode to use.'),
             cfg.IntOpt('max_limit',
                        default=1000,
                        required=True,

--- a/gnocchi/rest/app.py
+++ b/gnocchi/rest/app.py
@@ -15,7 +15,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 import os
-import pkg_resources
 import threading
 import uuid
 
@@ -166,8 +165,8 @@ def load_app(conf, not_implemented_middleware=True):
 
     if cfg_path is None or not os.path.exists(cfg_path):
         LOG.debug("No api-paste configuration file found! Using default.")
-        cfg_path = os.path.abspath(pkg_resources.resource_filename(
-            __name__, "api-paste.ini"))
+        cfg_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                'api-paste.ini')
 
     config = dict(conf=conf,
                   not_implemented_middleware=not_implemented_middleware)

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ install_requires =
     lz4>=0.9.0
     tooz>=1.38
     cachetools
+    importlib_metadata>=3.6; python_version<"3.10"
 
 [options.extras_require]
 keystone =

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     pytimeparse
     pecan>=0.9
     jsonpatch
-    cotyledon>=1.5.0
+    cotyledon>=1.5.0,<2.2.0
     stevedore
     ujson
     voluptuous>=0.8.10


### PR DESCRIPTION
... because it was removed in Python 3.12 [1].

[1] https://docs.python.org/3/whatsnew/3.12.html#ensurepip

(cherry picked from commit 7c90f348d7aba9155e50da4886f93c45c8d9f381)