### PR TITLE
Pin cotyledon<2.2.0 in testing

### DIFF
--- a/gnocchi/tests/base.py
+++ b/gnocchi/tests/base.py
@@ -19,6 +19,7 @@ import logging
 import os
 import subprocess
 import threading
+import unittest
 import uuid
 
 import daiquiri
@@ -58,7 +59,7 @@ def _skip_decorator(func):
         try:
             return func(*args, **kwargs)
         except exceptions.NotImplementedError as e:
-            raise testcase.TestSkipped(str(e))
+            raise unittest.SkipTest(str(e))
     return skip_if_not_implemented
 
 

--- a/gnocchi/tests/indexer/sqlalchemy/test_migrations.py
+++ b/gnocchi/tests/indexer/sqlalchemy/test_migrations.py
@@ -67,6 +67,9 @@ class ModelsMigrationsSync(base.TestCase,
 
     def _drop_database(self):
         try:
+            # We need to close any other connection before calling the database drop method.
+            self.index.get_engine().dispose()
+
             sqlalchemy_utils.drop_database(self.conf.indexer.url)
         except oslo_db.exception.DBNonExistentDatabase:
             # NOTE(sileht): oslo db >= 4.15.0 cleanup this for us

--- a/gnocchi/tests/test_chef.py
+++ b/gnocchi/tests/test_chef.py
@@ -73,7 +73,7 @@ class TestChef(base.TestCase):
 
                 get_sack_lock_mock.assert_called()
                 auto_clean_lock_mock.acquire.assert_called()
-                self.assertEquals(0, list_resources_mock.call_count)
+                self.assertEqual(0, list_resources_mock.call_count)
                 auto_clean_lock_mock.release.assert_called()
 
     def test_auto_clean_expired_resources_no_resources(self):
@@ -91,7 +91,7 @@ class TestChef(base.TestCase):
 
                 get_sack_lock_mock.assert_called()
                 auto_clean_lock_mock.acquire.assert_called()
-                self.assertEquals(1, list_resources_mock.call_count)
+                self.assertEqual(1, list_resources_mock.call_count)
                 auto_clean_lock_mock.release.assert_called()
 
     @mock.patch.object(utils, 'utcnow')
@@ -121,8 +121,8 @@ class TestChef(base.TestCase):
                     auto_clean_lock_mock.acquire.assert_called()
                     auto_clean_lock_mock.release.assert_called()
 
-                    self.assertEquals(1, list_resources_mock.call_count)
-                    self.assertEquals(2, delete_resource_mock.call_count)
+                    self.assertEqual(1, list_resources_mock.call_count)
+                    self.assertEqual(2, delete_resource_mock.call_count)
 
                     list_resources_mock.assert_has_calls([mock.call(attribute_filter=attribute_filter_expected)])
                     delete_resource_mock.assert_has_calls([mock.call("resource-1"), mock.call("resource-2")])
@@ -177,7 +177,7 @@ class TestChef(base.TestCase):
                     list_metrics_mock.assert_has_calls([mock.call(attribute_filter=attribute_filter_expected,
                                                                   resource_policy_filter={"==": {"ended_at": None}})])
 
-                    self.assertEquals(0, update_resource_mock.call_count)
+                    self.assertEqual(0, update_resource_mock.call_count)
 
     @mock.patch.object(utils, 'utcnow')
     def test_resource_ended_at_normalization_all_metrics_expired(self, utcnow_mock):
@@ -226,7 +226,7 @@ class TestChef(base.TestCase):
                     list_metrics_mock.assert_has_calls([mock.call(attribute_filter=attribute_filter_expected,
                                                                   resource_policy_filter={"==": {"ended_at": None}})])
 
-                    self.assertEquals(2, update_resource_mock.call_count)
+                    self.assertEqual(2, update_resource_mock.call_count)
 
     @mock.patch.object(utils, 'utcnow')
     def test_resource_ended_at_normalization_all_metrics_expired_one_resource_finished(self, utcnow_mock):
@@ -276,7 +276,7 @@ class TestChef(base.TestCase):
                     list_metrics_mock.assert_has_calls([mock.call(attribute_filter=attribute_filter_expected,
                                                                   resource_policy_filter={"==": {"ended_at": None}})])
 
-                    self.assertEquals(1, update_resource_mock.call_count)
+                    self.assertEqual(1, update_resource_mock.call_count)
 
     @mock.patch.object(utils, 'utcnow')
     def test_resource_ended_at_normalization_only_one_resource_expired(self, utcnow_mock):
@@ -326,7 +326,7 @@ class TestChef(base.TestCase):
                     list_metrics_mock.assert_has_calls([mock.call(attribute_filter=attribute_filter_expected,
                                                                   resource_policy_filter={"==": {"ended_at": None}})])
 
-                    self.assertEquals(1, update_resource_mock.call_count)
+                    self.assertEqual(1, update_resource_mock.call_count)
 
     def test_clean_raw_data_inactive_metrics(self):
         metric_mock_1_resource_1 = mock.Mock()
@@ -347,9 +347,9 @@ class TestChef(base.TestCase):
 
                     list_metrics_mock.assert_has_calls([mock.call(attribute_filter={"==": {
                         "needs_raw_data_truncation": True}})])
-                    self.assertEquals(3, execute_raw_data_cleanup_mock.call_count)
-                    self.assertEquals(3, get_sack_lock_mock.call_count)
-                    self.assertEquals(3, sack_mock.release.call_count)
+                    self.assertEqual(3, execute_raw_data_cleanup_mock.call_count)
+                    self.assertEqual(3, get_sack_lock_mock.call_count)
+                    self.assertEqual(3, sack_mock.release.call_count)
 
     def test_clean_raw_data_inactive_metrics_no_metrics_to_clean(self):
         with mock.patch.object(self.index, 'list_metrics',
@@ -359,7 +359,7 @@ class TestChef(base.TestCase):
 
                 list_metrics_mock.assert_has_calls([mock.call(attribute_filter={"==": {
                     "needs_raw_data_truncation": True}})])
-                self.assertEquals(0, execute_raw_data_cleanup_mock.call_count)
+                self.assertEqual(0, execute_raw_data_cleanup_mock.call_count)
 
     def test_execute_raw_data_cleanup(self):
         metric_mock = mock.Mock()
@@ -378,11 +378,11 @@ class TestChef(base.TestCase):
                     with mock.patch.object(self.storage, '_store_unaggregated_timeseries_unbatched') as _store_unaggregated_timeseries_unbatched_mock:
                         self.chef.execute_raw_data_cleanup(metric_mock)
 
-                        self.assertEquals(1, _get_or_create_unaggregated_timeseries_unbatched_mock.call_count)
-                        self.assertEquals(1, _store_unaggregated_timeseries_unbatched_mock.call_count)
-                        self.assertEquals(1, update_needs_raw_data_truncation_mock.call_count)
-                        self.assertEquals(1, unserialize_mock.call_count)
-                        self.assertEquals(1, ts_mock._truncate.call_count)
+                        self.assertEqual(1, _get_or_create_unaggregated_timeseries_unbatched_mock.call_count)
+                        self.assertEqual(1, _store_unaggregated_timeseries_unbatched_mock.call_count)
+                        self.assertEqual(1, update_needs_raw_data_truncation_mock.call_count)
+                        self.assertEqual(1, unserialize_mock.call_count)
+                        self.assertEqual(1, ts_mock._truncate.call_count)
 
                         unserialize_mock.assert_has_calls([mock.call(raw_measure_mock, 10000, 50000)])
 
@@ -406,11 +406,11 @@ class TestChef(base.TestCase):
                     ) as _store_unaggregated_timeseries_unbatched_mock:
                         self.chef.execute_raw_data_cleanup(metric_mock)
 
-                        self.assertEquals(1, _get_or_create_unaggregated_timeseries_unbatched_mock.call_count)
-                        self.assertEquals(1, _store_unaggregated_timeseries_unbatched_mock.call_count)
-                        self.assertEquals(1, update_needs_raw_data_truncation_mock.call_count)
-                        self.assertEquals(1, unserialize_mock.call_count)
-                        self.assertEquals(1, ts_mock._truncate.call_count)
+                        self.assertEqual(1, _get_or_create_unaggregated_timeseries_unbatched_mock.call_count)
+                        self.assertEqual(1, _store_unaggregated_timeseries_unbatched_mock.call_count)
+                        self.assertEqual(1, update_needs_raw_data_truncation_mock.call_count)
+                        self.assertEqual(1, unserialize_mock.call_count)
+                        self.assertEqual(1, ts_mock._truncate.call_count)
 
                         unserialize_mock.assert_has_calls([mock.call(raw_measure_mock, 10000, 50001)])
 
@@ -430,8 +430,8 @@ class TestChef(base.TestCase):
                     with mock.patch.object(self.storage, '_store_unaggregated_timeseries_unbatched') as _store_unaggregated_timeseries_unbatched_mock:
                         self.chef.execute_raw_data_cleanup(metric_mock)
 
-                        self.assertEquals(1, _get_or_create_unaggregated_timeseries_unbatched_mock.call_count)
-                        self.assertEquals(0, _store_unaggregated_timeseries_unbatched_mock.call_count)
-                        self.assertEquals(1, update_needs_raw_data_truncation_mock.call_count)
-                        self.assertEquals(0, unserialize_mock.call_count)
-                        self.assertEquals(0, ts_mock._truncate.call_count)
+                        self.assertEqual(1, _get_or_create_unaggregated_timeseries_unbatched_mock.call_count)
+                        self.assertEqual(0, _store_unaggregated_timeseries_unbatched_mock.call_count)
+                        self.assertEqual(1, update_needs_raw_data_truncation_mock.call_count)
+                        self.assertEqual(0, unserialize_mock.call_count)
+                        self.assertEqual(0, ts_mock._truncate.call_count)

--- a/gnocchi/tests/test_rest.py
+++ b/gnocchi/tests/test_rest.py
@@ -21,14 +21,14 @@ import datetime
 from email import utils as email_utils
 import hashlib
 import json
+import unittest
+from unittest import mock
 import uuid
 
 import fixtures
 import iso8601
 from keystonemiddleware import fixture as ksm_fixture
 import testscenarios
-from testtools import testcase
-from unittest import mock
 import webob
 import webtest
 
@@ -96,7 +96,7 @@ class TestingApp(webtest.TestApp):
     @contextlib.contextmanager
     def use_another_user(self):
         if self.auth_mode != "keystone":
-            raise testcase.TestSkipped("Auth mode is not Keystone")
+            raise unittest.SkipTest("Auth mode is not Keystone")
         old_token = self.token
         self.token = self.VALID_TOKEN_2
         try:
@@ -107,7 +107,7 @@ class TestingApp(webtest.TestApp):
     @contextlib.contextmanager
     def use_invalid_token(self):
         if self.auth_mode != "keystone":
-            raise testcase.TestSkipped("Auth mode is not Keystone")
+            raise unittest.SkipTest("Auth mode is not Keystone")
         old_token = self.token
         self.token = self.INVALID_TOKEN
         try:

--- a/gnocchi/tests/test_storage.py
+++ b/gnocchi/tests/test_storage.py
@@ -1276,10 +1276,10 @@ class TestStorageDriver(tests_base.TestCase):
                         update_metric_splits_mock.assert_has_calls([mock.call(splits_to_update)])
                         store_unaggregated_timeseries_mock.assert_has_calls([mock.call(new_boundts_mock)])
 
-                        self.assertEquals(3, time_mock_method.call_count)
-                        self.assertEquals(1, delete_metric_splits_mock.call_count)
-                        self.assertEquals(1, update_metric_splits_mock.call_count)
-                        self.assertEquals(1, store_unaggregated_timeseries_mock.call_count)
+                        self.assertEqual(3, time_mock_method.call_count)
+                        self.assertEqual(1, delete_metric_splits_mock.call_count)
+                        self.assertEqual(1, update_metric_splits_mock.call_count)
+                        self.assertEqual(1, store_unaggregated_timeseries_mock.call_count)
 
     def test_execute_metadata_updates_if_needed_needs_raw_data_truncation(self):
         measures = {"timestamps": [numpy.datetime64('1979-01-01T00:00:00'), numpy.datetime64('2030-01-01T00:00:00'),
@@ -1301,14 +1301,14 @@ class TestStorageDriver(tests_base.TestCase):
             indexer_driver_mock.update_needs_raw_data_truncation.assert_has_calls([mock.call(metric_mock.id)])
             indexer_driver_mock.update_last_measure_timestamp.assert_has_calls([mock.call(metric_mock.id)])
 
-            self.assertEquals(1, indexer_driver_mock.update_needs_raw_data_truncation.call_count)
-            self.assertEquals(1, indexer_driver_mock.update_last_measure_timestamp.call_count)
+            self.assertEqual(1, indexer_driver_mock.update_needs_raw_data_truncation.call_count)
+            self.assertEqual(1, indexer_driver_mock.update_last_measure_timestamp.call_count)
 
             log_mock.debug.assert_has_calls([
                 mock.call("Metric [%s] does not have a resource assigned to it.", metric_mock)])
 
-            self.assertEquals(0, log_mock.info.call_count)
-            self.assertEquals(1, log_mock.debug.call_count)
+            self.assertEqual(0, log_mock.info.call_count)
+            self.assertEqual(1, log_mock.debug.call_count)
 
     def test_execute_metadata_updates_if_needed_no_need_for_raw_data_truncation(self):
         measures = {"timestamps": [numpy.datetime64('1979-01-01T00:00:00'), numpy.datetime64('2030-01-01T00:00:00'),
@@ -1328,14 +1328,14 @@ class TestStorageDriver(tests_base.TestCase):
             self.storage.execute_metadata_updates_if_needed(indexer_driver_mock, measures, metric_mock)
             indexer_driver_mock.update_last_measure_timestamp.assert_has_calls([mock.call(metric_mock.id)])
 
-            self.assertEquals(1, indexer_driver_mock.update_last_measure_timestamp.call_count)
-            self.assertEquals(0, indexer_driver_mock.update_needs_raw_data_truncation.call_count)
+            self.assertEqual(1, indexer_driver_mock.update_last_measure_timestamp.call_count)
+            self.assertEqual(0, indexer_driver_mock.update_needs_raw_data_truncation.call_count)
 
             log_mock.debug.assert_has_calls([
                 mock.call("Metric [%s] does not have a resource assigned to it.", metric_mock)])
 
-            self.assertEquals(0, log_mock.info.call_count)
-            self.assertEquals(1, log_mock.debug.call_count)
+            self.assertEqual(0, log_mock.info.call_count)
+            self.assertEqual(1, log_mock.debug.call_count)
 
     def test_execute_metadata_updates_if_needed_resource_recover(self):
         measures = {"timestamps": [numpy.datetime64('1979-01-01T00:00:00'), numpy.datetime64('2030-01-01T00:00:00'),
@@ -1362,9 +1362,9 @@ class TestStorageDriver(tests_base.TestCase):
             indexer_driver_mock.update_resource.assert_has_calls([
                 mock.call(resource_mock.type, resource_id, ended_at=None)])
 
-            self.assertEquals(1, indexer_driver_mock.update_needs_raw_data_truncation.call_count)
-            self.assertEquals(1, indexer_driver_mock.update_last_measure_timestamp.call_count)
-            self.assertEquals(1, indexer_driver_mock.update_resource.call_count)
+            self.assertEqual(1, indexer_driver_mock.update_needs_raw_data_truncation.call_count)
+            self.assertEqual(1, indexer_driver_mock.update_last_measure_timestamp.call_count)
+            self.assertEqual(1, indexer_driver_mock.update_resource.call_count)
 
             log_mock.info.assert_has_calls([
                 mock.call("Resource [%s] was marked with a timestamp for the 'ended_at' field. It received a "
@@ -1375,8 +1375,8 @@ class TestStorageDriver(tests_base.TestCase):
                           "measurement timestamps are [%s].", resource_mock, metric_mock.id, resource_id,
                           measures['timestamps'])])
 
-            self.assertEquals(1, log_mock.info.call_count)
-            self.assertEquals(1, log_mock.debug.call_count)
+            self.assertEqual(1, log_mock.info.call_count)
+            self.assertEqual(1, log_mock.debug.call_count)
 
     def test_execute_metadata_updates_if_needed_resource_no_recover(self):
         measures = {"timestamps": [numpy.datetime64('1979-01-01T00:00:00'), numpy.datetime64('2022-01-01T00:00:00'),
@@ -1403,9 +1403,9 @@ class TestStorageDriver(tests_base.TestCase):
             indexer_driver_mock.update_needs_raw_data_truncation.assert_has_calls([mock.call(metric_mock.id)])
             indexer_driver_mock.update_last_measure_timestamp.assert_has_calls([mock.call(metric_mock.id)])
 
-            self.assertEquals(1, indexer_driver_mock.update_needs_raw_data_truncation.call_count)
-            self.assertEquals(1, indexer_driver_mock.update_last_measure_timestamp.call_count)
-            self.assertEquals(0, indexer_driver_mock.update_resource.call_count)
+            self.assertEqual(1, indexer_driver_mock.update_needs_raw_data_truncation.call_count)
+            self.assertEqual(1, indexer_driver_mock.update_last_measure_timestamp.call_count)
+            self.assertEqual(0, indexer_driver_mock.update_resource.call_count)
 
             log_mock.info.assert_has_calls([
                 mock.call("Resource [%s] was marked with a timestamp for the 'ended_at' field. It received a "
@@ -1418,8 +1418,8 @@ class TestStorageDriver(tests_base.TestCase):
                           "measurement timestamps are [%s].", resource_mock, metric_mock.id, resource_id,
                           measures['timestamps'])])
 
-            self.assertEquals(1, log_mock.info.call_count)
-            self.assertEquals(1, log_mock.debug.call_count)
+            self.assertEqual(1, log_mock.info.call_count)
+            self.assertEqual(1, log_mock.debug.call_count)
 
     def test_add_measures_to_metrics(self):
         raw_measures_mock = mock.Mock()
@@ -1439,11 +1439,11 @@ class TestStorageDriver(tests_base.TestCase):
 
                             self.storage.add_measures_to_metrics(metrics_and_measures, indexer_driver_mock)
 
-                            self.assertEquals(1, numpy_sort_mock.call_count)
-                            self.assertEquals(1, get_raw_measures_mock.call_count)
-                            self.assertEquals(1, execute_data_processing_mock.call_count)
-                            self.assertEquals(1, execute_metadata_updates_if_needed_mock.call_count)
-                            self.assertEquals(1, store_data_backend_mock.call_count)
+                            self.assertEqual(1, numpy_sort_mock.call_count)
+                            self.assertEqual(1, get_raw_measures_mock.call_count)
+                            self.assertEqual(1, execute_data_processing_mock.call_count)
+                            self.assertEqual(1, execute_metadata_updates_if_needed_mock.call_count)
+                            self.assertEqual(1, store_data_backend_mock.call_count)
 
                             get_raw_measures_mock.assert_has_calls([mock.call(metrics_and_measures)])
                             store_data_backend_mock.assert_has_calls([mock.call([], {}, {})])

--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,7 @@ deps =
     {env:GNOCCHI_TEST_TARBALLS:}
     cliff!=2.9.0
     gnocchiclient>=2.8.0,!=7.0.7
+    cotyledon>=1.5.0,<2.2.0
 commands =
     {toxinidir}/run-tests.sh {posargs}
     {toxinidir}/run-func-tests.sh {posargs}
@@ -76,6 +77,7 @@ deps =
     gnocchiclient>=2.8.0,!=7.0.7
     pifpaf
     xattr!=0.9.4
+    cotyledon>=1.5.0,<2.2.0
 commands = {toxinidir}/run-upgrade-tests.sh postgresql-file
 allowlist_externals = {toxinidir}/run-upgrade-tests.sh
 
@@ -91,6 +93,7 @@ deps =
     gnocchiclient>=2.8.0,!=7.0.7
     pifpaf
     xattr!=0.9.4
+    cotyledon>=1.5.0,<2.2.0
 commands = {toxinidir}/run-upgrade-tests.sh mysql-ceph
 allowlist_externals = {toxinidir}/run-upgrade-tests.sh
 


### PR DESCRIPTION
The cotyledon 2.2.0 release introduced typing with ParamSpec but did not correcly update it's lower
Python version to 3.10 where ParamSpec was introduced.

This pins cotyledon <2.2.0 so that our Python 3.9
testing works, this can be removed when we drop
Python 3.9 testing.

We also backport some changes to testing to fix testtools changes
and a SQLAlchemy issue.