### PR TITLE
Only load the metrics used in the aggregates API

### DIFF
--- a/gnocchi/indexer/sqlalchemy.py
+++ b/gnocchi/indexer/sqlalchemy.py
@@ -1165,7 +1165,7 @@ class SQLAlchemyIndexer(indexer.IndexerDriver):
         return attribute_filters_to_use
 
     def _get_history_result_mapper(self, session, resource_type,
-                                   attribute_filter=None):
+                                   attribute_filter=None, metrics_to_load=None):
 
         mappers = self._resource_type_to_mappers(session, resource_type)
         resource_cls = mappers['resource']
@@ -1245,15 +1245,25 @@ class SQLAlchemyIndexer(indexer.IndexerDriver):
         # To avoid such issues, and also a memory leak, we can clean
         # the previously registered ones.
         mapper_reg.dispose()
+
+        if metrics_to_load:
+            inner_condition_for_metrics_join = sqlalchemy.and_(
+                Metric.status == 'active', Metric.name.in_(metrics_to_load))
+        else:
+            inner_condition_for_metrics_join = Metric.status == 'active'
+
+        primary_join = sqlalchemy.and_(
+            Metric.resource_id == stmt.c.id,
+            inner_condition_for_metrics_join
+        )
+
         mapper_reg.map_imperatively(
             Result, stmt, primary_key=[stmt.c.id, stmt.c.revision],
             properties={
                 'metrics': sqlalchemy.orm.relationship(
                     Metric,
                     overlaps="metrics,resource",
-                    primaryjoin=sqlalchemy.and_(
-                        Metric.resource_id == stmt.c.id,
-                        Metric.status == 'active'),
+                    primaryjoin=primary_join,
                     foreign_keys=Metric.resource_id)
             })
 
@@ -1266,13 +1276,14 @@ class SQLAlchemyIndexer(indexer.IndexerDriver):
                        history=False,
                        limit=None,
                        marker=None,
-                       sorts=None):
+                       sorts=None,
+                       metrics_to_load=None):
         sorts = sorts or []
 
         with self.facade.independent_reader() as session:
             if history:
                 target_cls = self._get_history_result_mapper(
-                    session, resource_type, attribute_filter)
+                    session, resource_type, attribute_filter, metrics_to_load)
                 unique_keys = ["id", "revision"]
             else:
                 target_cls = self._resource_type_to_mappers(

--- a/gnocchi/rest/aggregates/api.py
+++ b/gnocchi/rest/aggregates/api.py
@@ -299,11 +299,14 @@ class Grouper(object):
         return {"and": [period_filter, self.attr_filter]}
 
     def retrieve_resources_history(self):
+        set_of_metrics = set()
+        for ops in self.references:
+            set_of_metrics.add(ops[0])
+
         return pecan.request.indexer.list_resources(
             self.body["resource_type"],
             attribute_filter=self.create_history_period_filter(),
-            history=True,
-            sorts=self.sorts)
+            history=True, sorts=self.sorts, metrics_to_load=set_of_metrics)
 
     def get_grouped_measures(self):
         resources = self.retrieve_resources_history()


### PR DESCRIPTION
Gnocchi aggregates API can struggle to process the requests when someone is, for instance, searching for all resources in a project, and if this project has thousands of resources.

The highest cost is at the execution of "all_resources = session.scalars(q).unique().all()" in the "list_resources" method. Because of the data structure used and the SQLAlchemy joins, a single resource entry, when joined with the metrics table, can multiply the output by a factor that represents the number of metrics the resource has. Thus, we have seen a 10k resource output (of the final response in the API) become more than 100k entries in the output, which will then be instantiated as a Python object, and afterwards filtered by the "unique" operation. The problem is that this process is costly.

The proposal here is to only load the metrics used in the aggregates API request operation. By doing this, we can reduce the pressure on both the DB and Gnocchi API itself.